### PR TITLE
Reverse jobs on the failed list on resque web UI

### DIFF
--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -22,7 +22,17 @@ module Resque
       end
 
       def self.all(start = 0, count = 1)
-        Resque.list_range(:failed, start, count)
+        # failed jobs from Redis are displayed in reverse order, because we want recent ones at the beginning
+        start = self.count - count - start
+        if start < 0
+          count += start
+          start = 0
+        end
+        if count > 0
+          Resque.list_range(:failed, start, count).reverse
+        else
+          []
+        end
       end
 
       def self.clear


### PR DESCRIPTION
I think it would be better to display the failed jobs in reversed order - right now the first page you get are jobs that failed long ago (unless you clear the list regularly), and you're usually most interested about those that failed today. The attached pull request is my lame attempt at that, though you'll probably be able to implement that better...
