### PR TITLE
Fix for mod_proxy_html

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -147,7 +147,7 @@ module Resque
 
     %w( overview workers ).each do |page|
       get "/#{page}.poll" do
-        content_type "text/plain"
+        content_type "text/html"
         @polling = true
         show(page.to_sym, false).gsub(/\s{1,}/, ' ')
       end
@@ -201,7 +201,7 @@ module Resque
         stats << "queues.#{queue}=#{Resque.size(queue)}"
       end
 
-      content_type 'text/plain'
+      content_type 'text/html'
       stats.join "\n"
     end
 


### PR DESCRIPTION
Simple fix to render as text/html instead of text/plain.  mod_proxy_html will only mangle text/html content.  Without this patch, the live reloading portion of resque-web really doesn't work in a proxied environment.
