### PR TITLE
Display Environment in process string

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -461,7 +461,7 @@ module Resque
     # Procline is always in the format of:
     #   resque-VERSION: STRING
     def procline(string)
-      $0 = "resque-#{Resque::Version}: #{string}"
+      $0 = "resque-#{Resque::Version} [#{Resque.info[:environment]}]: #{string}"
       log! $0
     end
 

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -216,7 +216,8 @@ context "Resque::Worker" do
   test "sets $0 while working" do
     @worker.work(0) do
       ver = Resque::Version
-      assert_equal "resque-#{ver}: Processing jobs since #{Time.now.to_i}", $0
+      env = Resque.info[:environment]
+      assert_equal "resque-#{ver} [#{env}]: Processing jobs since #{Time.now.to_i}", $0
     end
   end
 


### PR DESCRIPTION
The process name should include the env, so that we can send signals to selected processes.
