### PR TITLE
Remove failed jobs

### DIFF
--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -62,5 +62,9 @@ module Resque
     def self.requeue(index)
       backend.requeue(index)
     end
+
+    def self.remove(index)
+      backend.remove(index)
+    end
   end
 end

--- a/lib/resque/failure/base.rb
+++ b/lib/resque/failure/base.rb
@@ -52,6 +52,9 @@ module Resque
       def self.requeue(index)
       end
 
+      def self.remove(index)
+      end
+
       # Logging!
       def log(message)
         @worker.log(message)

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -35,6 +35,12 @@ module Resque
         Resque.redis.lset(:failed, index, Resque.encode(item))
         Job.create(item['queue'], item['payload']['class'], *item['payload']['args'])
       end
+
+      def self.remove(index)
+        id = rand(0xffffff)
+        Resque.redis.lset(:failed, index, id)
+        Resque.redis.lrem(:failed, 1, id)
+      end
     end
   end
 end

--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -175,6 +175,11 @@ module Resque
       end
     end
 
+    get "/failed/remove/:index" do
+      Resque::Failure.remove(params[:index])
+      redirect u('failed')
+    end
+
     get "/stats" do
       redirect url("/stats/resque")
     end

--- a/lib/resque/server/public/ranger.js
+++ b/lib/resque/server/public/ranger.js
@@ -50,6 +50,12 @@ $(function() {
     return false
   })
 
+  $('ul.failed li').hover(function() {
+    $(this).addClass('hover');
+  }, function() {
+    $(this).removeClass('hover');
+  })
+
   $('ul.failed a[rel=retry]').click(function() {
     var href = $(this).attr('href');
     $(this).text('Retrying...');

--- a/lib/resque/server/public/style.css
+++ b/lib/resque/server/public/style.css
@@ -67,7 +67,11 @@ body { padding:0; margin:0; }
 #main ul.failed li {background:-webkit-gradient(linear, left top, left bottom, from(#efefef), to(#fff)) #efefef; margin-top:10px; padding:10px; overflow:hidden; -webkit-border-radius:5px; border:1px solid #ccc; }
 #main ul.failed li dl dt {font-size:80%; color:#999; width:60px; float:left; padding-top:1px; text-align:right;}
 #main ul.failed li dl dd {margin-bottom:10px; margin-left:70px;}
-#main ul.failed li dl dd .retry { float: right; }
+#main ul.failed li dl dd .retried { float:right; text-align: right; }
+#main ul.failed li dl dd .retried .remove { display:none; margin-top: 8px; }
+#main ul.failed li.hover dl dd .retried .remove { display:block; }
+#main ul.failed li dl dd .controls { display:none; float:right; }
+#main ul.failed li.hover dl dd .controls { display:block; }
 #main ul.failed li dl dd code, #main ul.failed li dl dd pre { font-family:Monaco, "Courier New", monospace; font-size:90%;}
 #main ul.failed li dl dd.error a {font-family:Monaco, "Courier New", monospace; font-size:90%; }
 #main ul.failed li dl dd.error pre { margin-top:3px; line-height:1.3;}

--- a/lib/resque/server/views/failed.erb
+++ b/lib/resque/server/views/failed.erb
@@ -19,19 +19,24 @@
         <dt>Worker</dt>
         <dd>
           <a href="<%= url(:workers, job['worker']) %>"><%= job['worker'].split(':')[0...2].join(':') %></a> on <b class='queue-tag'><%= job['queue'] %></b > at <b><span class="time"><%= job['failed_at'] %></span></b>
-          <div class='retry'>
-            <% if job['retried_at'] %>
+          <% if job['retried_at'] %>
+            <div class='retried'>
               Retried <b><span class="time"><%= job['retried_at'] %></span></b>
-            <% else %>
+              <a href="<%= u "failed/remove/#{start + index - 1}" %>" class="remove" rel="remove">Remove</a>
+            </div>
+          <% else %>
+            <div class='controls'>
               <a href="<%= u "failed/requeue/#{start + index - 1}" %>" rel="retry">Retry</a>
-            <% end %>
-          </div>
+              or
+              <a href="<%= u "failed/remove/#{start + index - 1}" %>" rel="remove">Remove</a>
+            </div>
+          <% end %>
         </dd>
         <dt>Class</dt>
         <dd><code><%= job['payload'] ? job['payload']['class'] : 'nil' %></code></dd>
         <dt>Arguments</dt>
         <dd><pre><%=h job['payload'] ? show_args(job['payload']['args']) : 'nil' %></pre></dd>
-        <dt>Exception</td>
+        <dt>Exception</dt>
         <dd><code><%= job['exception'] %></code></dd>
         <dt>Error</dt>
         <dd class='error'>


### PR DESCRIPTION
Adds a link to remove individual failed jobs.
- Add `remove(index)` to Failure backends
- Add "or Remove" after "Retry" link
- Hides retry and remove controls until you hover over them
- Fixes a unclosed `dt`

I had to do this ghetto lset/lrem dance because you can't remove an item by index (maybe theres a better way).
