### PR TITLE
Updated the rake install to accept alternate location for install directory 

### DIFF
--- a/tasks/redis.rake
+++ b/tasks/redis.rake
@@ -82,7 +82,12 @@ namespace :redis do
     RedisRunner.attach
   end
 
-  desc 'Install the latest verison of Redis from Github (requires git, duh)'
+  desc <<-DOC 
+  Install the latest verison of Redis from Github (requires git, duh).
+    Use INSTALL_DIR env var like "rake redis:install INSTALL_DIR=~/tmp"
+    in order to get an alternate location for your install files.
+  DOC
+  
   task :install => [:about, :download, :make] do
     bin_dir = '/usr/bin'
     conf_dir = '/etc'


### PR DESCRIPTION
Had some issues install redis/dtach via the default path, as there were mounting issues on the /tmp drive that prevented any writing to it.  This method allows a user to add an INSTALL_DIR to the command line in order to use an alternate path.

usage:

rake redis:install INSTALL_DIR=/home/username/tmp/redis

or 

rake dtach:install INSTALL_DIR=/home/username/tmp
