### PR TITLE
killing resque workers using grep needs to be more precise

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -452,7 +452,7 @@ module Resque
     # Returns an array of string pids of all the other workers on this
     # machine. Useful when pruning dead workers on startup.
     def worker_pids
-      `ps -A -o pid,command | grep [r]esque`.split("\n").map do |line|
+      `ps -A -o pid,command | grep [r]esque | grep --invert-match "resque-web"`.split("\n").map do |line|
         line.split(' ')[0]
       end
     end


### PR DESCRIPTION
The grep syntax for killing resque workers using grep needs to be more precise.
It was killing resque-web on my system, as the grep you used to determine the pid's did match the following process (which it should not kill!):

7014 ruby /var/simfy/rubygems/1.8/bin/resque-web

Thanks a lot for your work,
Björn
