### PR TITLE
Strip whitespace from queue list

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -9,7 +9,7 @@ namespace :resque do
     require 'resque'
 
     worker = nil
-    queues = (ENV['QUEUES'] || ENV['QUEUE']).to_s.split(',')
+    queues = (ENV['QUEUES'] || ENV['QUEUE']).to_s.split(',').map(&:strip)
 
     begin
       worker = Resque::Worker.new(*queues)


### PR DESCRIPTION
This change will strip whitespace from queue names specified for the resque:work task.

This corrects the following situation and makes it work the expected queues.
    QUEUES="high, medium" rake resque:work

Previously, it would work the not so obvious "high" and " medium" (notice the space) queues.  With this change, it'll work the expected "high" and "medium" queues.
