### PR TITLE
Remove trailing whitespace in readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,8 @@
 Resque
 ======
 
-Resque (pronounced like "rescue") is a Redis-backed library for creating 
-background jobs, placing those jobs on multiple queues, and processing 
+Resque (pronounced like "rescue") is a Redis-backed library for creating
+background jobs, placing those jobs on multiple queues, and processing
 them later.
 
 Background jobs can be any Ruby class or module that responds to


### PR DESCRIPTION
This simply removes two instances of trailing whitespace in the `README.markdown` file.
