### PR TITLE
Always include queue names in procline

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -130,7 +130,7 @@ module Resque
         else
           break if interval.to_i == 0
           log! "Sleeping for #{interval.to_i}"
-          procline @paused ? "Paused" : "Waiting for #{@queues.join(',')}"
+          procline @paused ? "Paused" : "Waiting"
           sleep interval.to_i
         end
       end
@@ -461,7 +461,7 @@ module Resque
     # Procline is always in the format of:
     #   resque-VERSION: STRING
     def procline(string)
-      $0 = "resque-#{Resque::Version}: #{string}"
+      $0 = "resque-#{Resque::Version}: #{string} (queues: #{queues.join(', ')})"
       log! $0
     end
 

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -216,7 +216,7 @@ context "Resque::Worker" do
   test "sets $0 while working" do
     @worker.work(0) do
       ver = Resque::Version
-      assert_equal "resque-#{ver}: Processing jobs since #{Time.now.to_i}", $0
+      assert_equal "resque-#{ver}: Processing jobs since #{Time.now.to_i} (queues: #{@worker.queues})", $0
     end
   end
 


### PR DESCRIPTION
Makes debugging with 'ps' a lot easier when there's multiple workers processing different queues.
