### PR TITLE
Log errors during reservation

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -178,6 +178,10 @@ module Resque
       end
 
       nil
+    rescue Exception => e
+      log "Error reserving job: #{e.inspect}"
+      log e.backtrace.join("\n")
+      raise e
     end
 
     # Returns a list of queues to use when searching for a job.


### PR DESCRIPTION
If there's an error while trying to reserve something from the queue, currently the worker dies; at the very least it's useful to see what the exception was.
