### PR TITLE
Set the thread_safe option when specifying a Redis url

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -33,7 +33,7 @@ module Resque
   def redis=(server)
     if server.respond_to? :split
       if server =~ /redis\:\/\//
-        redis = Redis.connect(:url => server)
+        redis = Redis.connect(:url => server, :thread_safe => true)
       else
         server, namespace = server.split('/', 2)
         host, port, db = server.split(':')


### PR DESCRIPTION
If a Redis url is specified, this enables the thread_safe option.  This is consistent with the alternative way of specifying a Redis server (host:port:db).
