### PR TITLE
Use pid from worker when writing pid file

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -19,7 +19,7 @@ namespace :resque do
     end
 
     if ENV['PIDFILE']
-      File.open(ENV['PIDFILE'], 'w') { |f| f << Process.pid.to_s }
+      File.open(ENV['PIDFILE'], 'w') { |f| f << worker.pid }
     end
 
     worker.log "Starting worker #{worker}"


### PR DESCRIPTION
This simplifies writing the pid of the worker to a file.  Now that workers have a `pid` it's a little cleaner to write that out.
