### PR TITLE
Living workers erroneously pruned

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -470,7 +470,7 @@ module Resque
     # Returns an array of string pids of all the other workers on this
     # machine. Useful when pruning dead workers on startup.
     def worker_pids
-      `ps -A -o pid,command | grep [r]esque | grep -i "resque-web"`.split("\n").map do |line|
+      `ps -A -o pid,command | grep [r]esque | grep -v "resque-web"`.split("\n").map do |line|
         line.split(' ')[0]
       end
     end


### PR DESCRIPTION
12583b6edb413db269df5cab7f73ceb1244e2eac introduced a bug in the `ps | grep` that looks for running worker processes. As a result, no processes are detected, and all workers are pruned from redis even as they continue to run.
