### PR TITLE
Make Hoptoad failure backend compatible with Redmine

### DIFF
--- a/lib/resque/failure/hoptoad.rb
+++ b/lib/resque/failure/hoptoad.rb
@@ -109,6 +109,7 @@ module Resque
           end
           x.tag!("server-environment") do
             x.tag!("environment-name",server_environment)
+            x.tag!("project-root", "RAILS_ROOT")
           end
 
         end


### PR DESCRIPTION
The Redmine plugin for Hoptoad notifications requires the /notice/server-environment/project-root element.
I will submit patches for that plugin too, but this is harmless enough and provides top compatibility.
