### PR TITLE
Cache queues

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -1,3 +1,4 @@
+require 'set'
 require 'redis/namespace'
 
 begin
@@ -172,8 +173,14 @@ module Resque
     Array(redis.smembers(:queues))
   end
 
+  # Queues cached in memory to help prevent unnecessary sadd roundtrips.
+  def cached_queues
+    @cached_queues ||= Set.new
+  end
+
   # Given a queue name, completely deletes the queue.
   def remove_queue(queue)
+    cached_queues.delete(queue.to_s)
     redis.srem(:queues, queue.to_s)
     redis.del("queue:#{queue}")
   end
@@ -181,6 +188,8 @@ module Resque
   # Used internally to keep track of which queues we've created.
   # Don't call this directly.
   def watch_queue(queue)
+    return false if cached_queues.include?(queue.to_s)
+    cached_queues.add(queue.to_s)
     redis.sadd(:queues, queue.to_s)
   end
 

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -3,6 +3,7 @@ require File.dirname(__FILE__) + '/test_helper'
 context "Resque" do
   setup do
     Resque.redis.flushall
+    Resque.cached_queues.clear
 
     Resque.push(:people, { 'name' => 'chris' })
     Resque.push(:people, { 'name' => 'bob' })
@@ -180,9 +181,16 @@ context "Resque" do
   test "can delete a queue" do
     Resque.push(:cars, { 'make' => 'bmw' })
     assert_equal %w( cars people ), Resque.queues
+    assert_equal %w( cars people ).to_set, Resque.cached_queues
     Resque.remove_queue(:people)
     assert_equal %w( cars ), Resque.queues
+    assert_equal %w( cars ).to_set, Resque.cached_queues
     assert_equal nil, Resque.pop(:people)
+  end
+
+  test "can watch a queue" do
+    assert_equal true,  Resque.watch_queue(:cars)
+    assert_equal false, Resque.watch_queue(:cars)
   end
 
   test "keeps track of resque keys" do

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -3,6 +3,7 @@ require File.dirname(__FILE__) + '/test_helper'
 context "Resque::Worker" do
   setup do
     Resque.redis.flushall
+    Resque.cached_queues.clear
 
     Resque.before_first_fork = nil
     Resque.before_fork = nil


### PR DESCRIPTION
Not sure if this is anything you are interested in or not. Cached the known queues and checked that in memory to prevent network round trip of sadd.

Added tests for watch_queue which you mentioned is internal. Just wanted to make sure it maintained the same return value. I'd probably also through mocha or something in the mix and double check that sadd was not hit, but since it wasn't on the project I didn't.

I know this is minor but at the level we are doing with some things every bit counts.
