### PR TITLE
Check if the given class could be a valid resque job.

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -253,6 +253,15 @@ module Resque
     Job.reserve(queue)
   end
 
+  # Validates if the given klass could be a valid Resque job
+  #
+  # If no queue can be inferred this method will raise a `Resque::NoQueueError` 
+  # 
+  # If given klass is nil this method will raise a `Resque::NoClassError`
+  def validate!(klass)
+    Job.validate!(klass)
+  end
+
 
   #
   # worker shortcuts

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -40,13 +40,7 @@ module Resque
     #
     # Raises an exception if no queue or class is given.
     def self.create(queue, klass, *args)
-      if !queue
-        raise NoQueueError.new("Jobs must be placed onto a queue.")
-      end
-
-      if klass.to_s.empty?
-        raise NoClassError.new("Jobs must be given a class.")
-      end
+      validate!(klass, queue)
 
       ret = Resque.push(queue, :class => klass.to_s, :args => args)
       Plugin.after_enqueue_hooks(klass).each do |hook|
@@ -102,6 +96,18 @@ module Resque
     def self.reserve(queue)
       return unless payload = Resque.pop(queue)
       new(queue, payload)
+    end
+
+
+    # Validates if the given klass could be a valid Resque job
+    def self.validate!(klass, queue = Resque.queue_from_class(klass))
+      if !queue
+        raise NoQueueError.new("Jobs must be placed onto a queue.")
+      end
+
+      if klass.to_s.empty?
+        raise NoClassError.new("Jobs must be given a class.")
+      end
     end
 
     # Attempts to perform the work represented by this job instance.

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -128,6 +128,12 @@ context "Resque" do
     end
   end
 
+  test "validates job for queue presence" do
+    assert_raises Resque::NoQueueError do
+      Resque.validate!(SomeJob)
+    end
+  end
+
   test "can put items on a queue" do
     assert Resque.push(:people, { 'name' => 'jon' })
   end


### PR DESCRIPTION
In case of some plugins you need to be able to validate that a given class could be a valid resque job.

For example resque-scheduler don't enqueue the job immediately and you see the issue only after the enqueue.

So I think it's a good idea to make the code that raises NoQueueError and NoClassError reusable.
