### PR TITLE
QUIT signal is not available to the rake task in glassfish server

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -326,7 +326,7 @@ module Resque
       all_workers.each do |worker|
         host, pid, queues = worker.id.split(':')
         next unless host == hostname
-        next if known_workers.include?(pid)
+        next if known_workers.include?(pid) && !worker.shutdown?
         log! "Pruning dead worker: #{worker}"
         worker.unregister_worker
       end
@@ -361,6 +361,8 @@ module Resque
         job.fail(DirtyExit.new)
       end
 
+      system("kill -9 #{self.pid}")
+      
       redis.srem(:workers, self)
       redis.del("worker:#{self}")
       redis.del("worker:#{self}:started")


### PR DESCRIPTION
Hi defunkt,

When trying to kill the workers with the Cltr+C command on an application running in glassfish, the workers do not get killed. They remain in the background. So, when we start other workers, they add up to the list of previous workers.

When starting the rake resque:workers task in the shell, i get the following errors. Probably that could be the reason i have to use Cltr+C.
The signal QUIT is in use by the JVM and will not work correctly on this platform
The signal USR1 is in use by the JVM and will not work correctly on this platform

I have made changes to the worker.rb class, i am not a resque expert, but i guess the fix i have made is appropriate. Please check.

Thanks,
Pratik !
