### PR TITLE
Currently the long log format uses AM/PM style logs without adding AM/PM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source :gemcutter
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,33 @@
+PATH
+  remote: .
+  specs:
+    resque (1.13.0)
+      json (~> 1.4.6)
+      redis-namespace (>= 0.10.0)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    json (1.4.6)
+    rack (1.2.1)
+    redis (2.1.1)
+    redis-namespace (0.10.0)
+      redis (< 3.0.0)
+    sinatra (1.1.3)
+      rack (~> 1.1)
+      tilt (>= 1.2.2, < 2.0)
+    tilt (1.2.2)
+    vegas (0.1.8)
+      rack (>= 1.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json (~> 1.4.6)
+  redis-namespace (>= 0.10.0)
+  resque!
+  sinatra (>= 0.9.2)
+  vegas (~> 0.1.2)

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -488,7 +488,7 @@ module Resque
       if verbose
         puts "*** #{message}"
       elsif very_verbose
-        time = Time.now.strftime('%I:%M:%S %Y-%m-%d')
+        time = Time.now.strftime('%H:%M:%S %Y-%m-%d')
         puts "** [#{time}] #$$: #{message}"
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -128,3 +128,16 @@ def with_failure_backend(failure_backend, &block)
 ensure
   Resque::Failure.backend = previous_backend
 end
+
+class Time
+  # Thanks, Timecop
+  class << self
+    alias_method :now_without_mock_time, :now
+
+    def now_with_mock_time
+      $fake_time || now_without_mock_time
+    end
+
+    alias_method :now, :now_with_mock_time
+  end
+end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -300,6 +300,19 @@ context "Resque::Worker" do
     workerA.work(0)
     assert $BEFORE_FORK_CALLED
   end
+  
+  test "very verbose works in the afternoon" do
+    require 'time'
+    $last_puts = ""
+    $fake_time = Time.parse("15:44:33 2011-03-02")
+    singleton = class << @worker; self end
+    singleton.send :define_method, :puts, lambda { |thing| $last_puts = thing }
+
+    @worker.very_verbose = true
+    @worker.log("some log text")
+    
+    assert_match /\*\* \[15:44:33 2011-03-02\] \d+: some log text/, $last_puts
+  end
 
   test "Will call an after_fork hook after forking" do
     Resque.redis.flushall


### PR DESCRIPTION
We added some mocking for Time.now to write a failing test for this.

We also added a simple Gemfile for developing on it.
