### PR TITLE
url method defined in resque/server conflicts with Sinatra 1.2 url helper

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -16,17 +16,17 @@ module Resque
       alias_method :h, :escape_html
 
       def current_section
-        url request.path_info.sub('/','').split('/')[0].downcase
+        url_path request.path_info.sub('/','').split('/')[0].downcase
       end
 
       def current_page
-        url request.path_info.sub('/','')
+        url_path request.path_info.sub('/','')
       end
 
-      def url(*path_parts)
+      def url_path(*path_parts)
         [ path_prefix, path_parts ].join("/").squeeze('/')
       end
-      alias_method :u, :url
+      alias_method :u, :url_path
 
       def path_prefix
         request.env['SCRIPT_NAME']
@@ -38,7 +38,7 @@ module Resque
 
       def tab(name)
         dname = name.to_s.downcase
-        path = url(dname)
+        path = url_path(dname)
         "<li #{class_if_current(path)}><a href='#{path}'>#{name}</a></li>"
       end
 
@@ -127,7 +127,7 @@ module Resque
 
     # to make things easier on ourselves
     get "/?" do
-      redirect url(:overview)
+      redirect url_path(:overview)
     end
 
     %w( overview queues working workers key ).each do |page|
@@ -176,7 +176,7 @@ module Resque
     end
 
     get "/stats" do
-      redirect url("/stats/resque")
+      redirect url_path("/stats/resque")
     end
 
     get "/stats/:id" do

--- a/lib/resque/server/views/failed.erb
+++ b/lib/resque/server/views/failed.erb
@@ -18,7 +18,7 @@
       <dl>
         <dt>Worker</dt>
         <dd>
-          <a href="<%= url(:workers, job['worker']) %>"><%= job['worker'].split(':')[0...2].join(':') %></a> on <b class='queue-tag'><%= job['queue'] %></b > at <b><span class="time"><%= job['failed_at'] %></span></b>
+          <a href="<%= u(:workers, job['worker']) %>"><%= job['worker'].split(':')[0...2].join(':') %></a> on <b class='queue-tag'><%= job['queue'] %></b > at <b><span class="time"><%= job['failed_at'] %></span></b>
           <div class='retry'>
             <% if job['retried_at'] %>
               Retried <b><span class="time"><%= job['retried_at'] %></span></b>

--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -36,12 +36,12 @@
     </tr>
     <% for queue in resque.queues.sort_by { |q| q.to_s } %>
     <tr>
-      <td class='queue'><a class="queue" href="<%= url "queues/#{queue}" %>"><%= queue %></a></td>
+      <td class='queue'><a class="queue" href="<%= u "queues/#{queue}" %>"><%= queue %></a></td>
       <td class='size'><%= resque.size queue %></td>
     </tr>
     <% end %>
     <tr class="<%= Resque::Failure.count.zero? ? "failed" : "failure" %>">
-      <td class='queue failed'><a class="queue" href="<%= url :failed %>">failed</a></td>
+      <td class='queue failed'><a class="queue" href="<%= u :failed %>">failed</a></td>
       <td class='size'><%= Resque::Failure.count %></td>
     </tr>
   </table>

--- a/lib/resque/server/views/workers.erb
+++ b/lib/resque/server/views/workers.erb
@@ -95,12 +95,12 @@
     </tr>
     <% for hostname, workers in worker_hosts.sort_by { |h,w| h } %>
     <tr>
-      <td class='queue'><a class="queue" href="<%= url "workers/#{hostname}" %>"><%= hostname %></a></td>
+      <td class='queue'><a class="queue" href="<%= u "workers/#{hostname}" %>"><%= hostname %></a></td>
       <td class='size'><%= workers.size %></td>
     </tr>
     <% end %>
     <tr class="failed">
-      <td class='queue failed'><a class="queue" href="<%= url "workers/all" %>">all workers</a></td>
+      <td class='queue failed'><a class="queue" href="<%= u "workers/all" %>">all workers</a></td>
       <td class='size'><%= Resque.workers.size %></td>
     </tr>
   </table>


### PR DESCRIPTION
I renamed it to url_path and the problem is fixed. This solve #221
