### PR TITLE
Bugfix on multiple workers running on dev (rake resque:workers)

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -33,7 +33,7 @@ namespace :resque do
 
     ENV['COUNT'].to_i.times do
       threads << Thread.new do
-        system "rake resque:work"
+        system "rake environment resque:work"
       end
     end
 


### PR DESCRIPTION
Hi, I wasn't able to run multiple workers on my dev machine. Jobs were added to the queue but when the workers tried to process them, they complained of not recognizing them.

I think it was caused by not including the environment on the internal rake resque:work calls.

Now with this fix, it works for me.

Thanks! :)
