### PR TITLE
Either depend on Sinatra 1.2, or use a different method :) (updated)

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -110,7 +110,7 @@ module Resque
         if @polling
           text = "Last Updated: #{Time.now.strftime("%H:%M:%S")}"
         else
-          text = "<a href='#{url(request.path_info)}.poll' rel='poll'>Live Poll</a>"
+          text = "<a href='#{u(request.path_info)}.poll' rel='poll'>Live Poll</a>"
         end
         "<p class='poll'>#{text}</p>"
       end


### PR DESCRIPTION
(as per https://github.com/defunkt/resque/commit/65f7bb0c5ccd159e5059954cfdea292d6ff94cf0#commitcomment-306585)

I just checked the Gemfile.lock, and it seems that while the Gemfile.lock is requesting Sinatra 1.2.1, the gemspec itself only requests >= 0.9.2; This is probably too lenient if you really do want to require Sinatra 1.2 in any application.

Given the nature of https://github.com/defunkt/resque/commit/65f7bb0c5ccd159e5059954cfdea292d6ff94cf0 I would probably go with my patch - introducing a required large jump in Sinatra versions seems like a larger decision.

Cheers!
