### PR TITLE
Initialize default redis connection by redis gem

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -54,7 +54,7 @@ module Resque
   # create a new one.
   def redis
     return @redis if @redis
-    self.redis = 'localhost:6379'
+    self.redis = (Redis.respond_to?(:connect) ? Redis.connect : "localhost:6379")
     self.redis
   end
 


### PR DESCRIPTION
Default connection to redis should be initialized by redis gem.
There is support for REDIS_URL env variable, which is also useful in Resque.

This method (Redis.connect) was added in version 2.0, so patch supports also lower versions of redis gem.
 Exactly in this commit:
 https://github.com/ezmobius/redis-rb/commit/834e7cb26e900dce8e77d9d77b5e05cd50c66cbb

We can also remove this check and add requirement for redis gem version greater than 2.0.
If you prefer this option I can change this patch.
