### PR TITLE
Multiple failure backend remove

### DIFF
--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -45,6 +45,10 @@ module Resque
       def self.requeue(*args)
         classes.first.requeue(*args)
       end
+
+      def self.remove(index)
+        classes.each { |klass| klass.remove(index) }
+      end
     end
   end
 end


### PR DESCRIPTION
I was excited to see an interface for individual failure removal, only to see it didn't work with the multiple backend handler. This simple fix calls remove on each of the backends, since it is presumable that each backend uses a different store mechanism if any.
