### PR TITLE
Fix project-root for hoptoad notifier

### DIFF
--- a/lib/resque/failure/hoptoad.rb
+++ b/lib/resque/failure/hoptoad.rb
@@ -84,7 +84,7 @@ module Resque
         x.notice :version=>"2.0" do
           x.tag! "api-key", api_key
           x.notifier do
-            x.name "Resqueue"
+            x.name "Resque"
             x.version "0.1"
             x.url "http://github.com/defunkt/resque"
           end
@@ -108,8 +108,8 @@ module Resque
             end
           end
           x.tag!("server-environment") do
+            x.tag!("project-root", ENV['RAILS_ROOT'])
             x.tag!("environment-name",server_environment)
-            x.tag!("project-root", "RAILS_ROOT")
           end
 
         end


### PR DESCRIPTION
When submitting an error to hoptoad, I got this error:

```
*** Hoptoad Failure: Net::HTTPClientError 
<?xml version="1.0" encoding="UTF-8"?>
<errors>
    <error>Element 'project-root': This element is not expected.</error>
</errors>
```

According to the example [in the hoptoad docs](http://help.hoptoadapp.com/kb/api-2/notifier-api-version-2),  `project-root` is expected before `environment`. 
