### PR TITLE
Allow errors to be posted to hoptoad

### DIFF
--- a/lib/resque/failure/hoptoad.rb
+++ b/lib/resque/failure/hoptoad.rb
@@ -108,8 +108,8 @@ module Resque
             end
           end
           x.tag!("server-environment") do
-            x.tag!("environment-name",server_environment)
             x.tag!("project-root", "RAILS_ROOT")
+            x.tag!("environment-name",server_environment)
           end
 
         end


### PR DESCRIPTION
http://hoptoadapp.com/hoptoad_2_0.xsd enforces this order,
so errors coming from this notifier are being
dropped for being invalid
