### PR TITLE
Order matters for Hoptoad API

### DIFF
--- a/lib/resque/failure/hoptoad.rb
+++ b/lib/resque/failure/hoptoad.rb
@@ -108,8 +108,8 @@ module Resque
             end
           end
           x.tag!("server-environment") do
-            x.tag!("environment-name",server_environment)
             x.tag!("project-root", "RAILS_ROOT")
+            x.tag!("environment-name",server_environment)
           end
 
         end


### PR DESCRIPTION
Previously I'd get this error message from hoptoad

```
*** Starting worker imac.local:83285:*
*** got: (Job{high} | FailingJob | [])
*** Running after_fork hook with [(Job{high} | FailingJob | [])]
*** (Job{high} | FailingJob | []) failed: #<RuntimeError: this should fail!>
*** Hoptoad Failure: Net::HTTPClientError
<?xml version="1.0" encoding="UTF-8"?>
<errors>
  <error>Element 'project-root': This element is not expected.</error>
</errors>
```

I switched the order and everything is ok. Apparently the xml is order sensitive.
