### PR TITLE
Show correct relative times to viewers in different timezone

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -2,6 +2,7 @@ require 'sinatra/base'
 require 'erb'
 require 'resque'
 require 'resque/version'
+require 'time'
 
 module Resque
   class Server < Sinatra::Base

--- a/lib/resque/server/views/failed.erb
+++ b/lib/resque/server/views/failed.erb
@@ -22,10 +22,10 @@
         <% else %>
         <dt>Worker</dt>
         <dd>
-          <a href="<%= u(:workers, job['worker']) %>"><%= job['worker'].split(':')[0...2].join(':') %></a> on <b class='queue-tag'><%= job['queue'] %></b > at <b><span class="time"><%= job['failed_at'] %></span></b>
+          <a href="<%= u(:workers, job['worker']) %>"><%= job['worker'].split(':')[0...2].join(':') %></a> on <b class='queue-tag'><%= job['queue'] %></b > at <b><span class="time"><%= Time.parse(job['failed_at']).strftime("%F %T %z") %></span></b>
           <% if job['retried_at'] %>
             <div class='retried'>
-              Retried <b><span class="time"><%= job['retried_at'] %></span></b>
+              Retried <b><span class="time"><%= Time.parse(job['retried_at']).strftime("%F %T %z") %></span></b>
               <a href="<%= u "failed/remove/#{start + index - 1}" %>" class="remove" rel="remove">Remove</a>
             </div>
           <% else %>


### PR DESCRIPTION
resque-web shows incorrect relative time on Failed Job tab if the viewer is in a different timezone from the server one. For example, the server's local time is California (GMT -7 hour) and an engineer lives in London (GMT +1 hour). Even if a job was just failed a second ago, the resque-web shows `8 hours ago` to the engineer. If they are opposite (the server is located in London time and the engineer lives in California), it is even worse since the web resque-web shows `just now` to the engineer for all failed jobs which failed in last 8 hours.

This commit fixes the issue. Since the relatizeDate jquery plugin handles timezone nicely, what the fix had to do is to add timezone information on erb.
