### PR TITLE
Typo in the Monit example

### DIFF
--- a/examples/monit/resque.monit
+++ b/examples/monit/resque.monit
@@ -1,6 +1,6 @@
 check process resque_worker_QUEUE
   with pidfile /data/APP_NAME/current/tmp/pids/resque_worker_QUEUE.pid
-  start program = "/bin/sh -c 'cd /data/APP_NAME/current; nohup rake environment resque:work RAILS_ENV=production QUEUE=queue_name VERBOSE=1 PIDFILE=tmp/pids/resque_worker_QUEUE.pid & > log/resque_worker_QUEUE.log" as uid deploy and gid deploy
+  start program = "/bin/sh -c 'cd /data/APP_NAME/current; nohup rake environment resque:work RAILS_ENV=production QUEUE=queue_name VERBOSE=1 PIDFILE=tmp/pids/resque_worker_QUEUE.pid &> log/resque_worker_QUEUE.log" as uid deploy and gid deploy
   stop program = "/bin/sh -c 'cd /data/APP_NAME/current && kill -s QUIT `cat tmp/pids/resque_worker_QUEUE.pid` && rm -f tmp/pids/resque_worker_QUEUE.pid; exit 0;'"
   if totalmem is greater than 300 MB for 10 cycles then restart  # eating up memory?
   group resque_workers


### PR DESCRIPTION
After some research (but I'm not a shell guru) I've come to the conclusion that there is a mistake.

It should be `nohup rake (...) &> log` instead of `nohup rake (...) & > log`.

From the Bash documentation I read that `&>` is redirecting the stderr AND stdout to the specified file. I guess that's what is intended here ; have everything in the log file.

In the current situation (with the space between & and >), we have a simple process detachment and a stdout redirection to the log file.
