### PR TITLE
Protect the 'Remove Queue' button from accidental clicking

### DIFF
--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -4,7 +4,7 @@
 
   <h1>Pending jobs on <span class='hl'><%= queue %></span></h1>
   <form method="POST" action="<%=u "/queues/#{queue}/remove" %>" class='remove-queue'>
-    <input type='submit' name='' value='Remove Queue' />
+    <input type='submit' name='' value='Remove Queue' onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
   </form>
   <p class='sub'>Showing <%= start = params[:start].to_i %> to <%= start + 20 %> of <b><%=size = resque.size(queue)%></b> jobs</p>
   <table class='jobs'>


### PR DESCRIPTION
Resubmitting this pull request on a branch as [original pull request](https://github.com/defunkt/resque/pull/263)  was on master. Original pull request description:

As it stands, a single accidental click on this button can wipe queue data irrevocably; with a little bit of (sadly obtrusive) javascript, we can make that a bit harder to accidentally do.

Ideally there'd be some way to turn the button off completely, but this is a decent first step.
