### PR TITLE
Add test for Resque.redis=(<a Redis::Namespace>).

### DIFF
--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -16,6 +16,15 @@ context "Resque" do
     assert_equal 'namespace', Resque.redis.namespace
   end
 
+  test "redis= works correctly with a Redis::Namespace param" do
+    new_redis = Redis.new(:host => "localhost", :port => 9736)
+    new_namespace = Redis::Namespace.new("namespace", :redis => new_redis)
+    Resque.redis = new_namespace
+    assert_equal new_namespace, Resque.redis
+
+    Resque.redis = 'localhost:9736/namespace'
+  end
+
   test "can put jobs on a queue" do
     assert Resque::Job.create(:jobs, 'SomeJob', 20, '/tmp')
     assert Resque::Job.create(:jobs, 'SomeJob', 20, '/tmp')


### PR DESCRIPTION
I added a unit test to ensure  `Resque.redis=` works correctly when passed a `Redis::Namespace` object. With the current versions of resque and redis-namespace, the test fails. See my pull request for redis-namespace for a proposed fix.
