### PR TITLE
move @paused into a #paused? method

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -116,7 +116,7 @@ module Resque
       loop do
         break if shutdown?
 
-        if not @paused and job = reserve
+        if not paused? and job = reserve
           log "got: #{job.inspect}"
           run_hook :before_fork, job
           working_on job
@@ -136,7 +136,7 @@ module Resque
         else
           break if interval.zero?
           log! "Sleeping for #{interval} seconds"
-          procline @paused ? "Paused" : "Waiting for #{@queues.join(',')}"
+          procline paused? ? "Paused" : "Waiting for #{@queues.join(',')}"
           sleep interval
         end
       end
@@ -298,6 +298,11 @@ module Resque
       end
     end
 
+    # are we paused?
+    def paused?
+      @paused
+    end
+    
     # Stop processing jobs after the current one has completed (if we're
     # currently running one).
     def pause_processing


### PR DESCRIPTION
This will make it easier to override or modify how a worker knows it's paused
