### PR TITLE
Fix relative time display for failed jobs in Safari

### DIFF
--- a/lib/resque/server/views/failed.erb
+++ b/lib/resque/server/views/failed.erb
@@ -22,10 +22,10 @@
         <% else %>
         <dt>Worker</dt>
         <dd>
-          <a href="<%= u(:workers, job['worker']) %>"><%= job['worker'].split(':')[0...2].join(':') %></a> on <b class='queue-tag'><%= job['queue'] %></b > at <b><span class="time"><%= Time.parse(job['failed_at']).strftime("%F %T %z") %></span></b>
+          <a href="<%= u(:workers, job['worker']) %>"><%= job['worker'].split(':')[0...2].join(':') %></a> on <b class='queue-tag'><%= job['queue'] %></b > at <b><span class="time"><%= Time.parse(job['failed_at']).strftime("%D %T %z") %></span></b>
           <% if job['retried_at'] %>
             <div class='retried'>
-              Retried <b><span class="time"><%= Time.parse(job['retried_at']).strftime("%F %T %z") %></span></b>
+              Retried <b><span class="time"><%= Time.parse(job['retried_at']).strftime("%D %T %z") %></span></b>
               <a href="<%= u "failed/remove/#{start + index - 1}" %>" class="remove" rel="remove">Remove</a>
             </div>
           <% else %>


### PR DESCRIPTION
Was displaying "NaN days ago" for relative time in Safari.

Safari cannot parse a date in the format '2010-05-10 16:24 -400',
but can parse '05/10/2010 16:24 -400'
