### PR TITLE
Broken rake tasks (introduced in commit c7a524467b72188ec1c5)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@
 # Setup
 #
 
-load 'tasks/redis.rake'
+load 'lib/tasks/redis.rake'
 
 $LOAD_PATH.unshift 'lib'
 require 'resque/tasks'


### PR DESCRIPTION
Solved bug introduced in commit c7a524467b72188ec1c5 that broke the rake tasks ('lib/' missing inside the load 'tasks/redis.rake')
