### PR TITLE
supply a quick fix for issue #304.

### DIFF
--- a/lib/resque/failure/hoptoad.rb
+++ b/lib/resque/failure/hoptoad.rb
@@ -25,7 +25,7 @@ module Resque
     class Hoptoad < Base
       def self.configure
         Resque::Failure.backend = self
-        HoptoadNotifier.configure
+        HoptoadNotifier.configure {}
       end
 
       def self.count


### PR DESCRIPTION
Quick fix for issue #304 that just passes an empty block to HoptoadNotifier.configure. 
This prevents it from raising an exception and allows apps to run again. 
