### PR TITLE
Update Resque.redis_id so resque-web can handle being used in a distributed ring

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -63,6 +63,8 @@ module Resque
     # support 1.x versions of redis-rb
     if redis.respond_to?(:server)
       redis.server
+    elsif redis.respond_to?(:nodes) # distributed
+      redis.nodes.map { |n| n.id }.join(', ')
     else
       redis.client.id
     end


### PR DESCRIPTION
This stops the 500 errors that are thrown otherwise.
