### PR TITLE
Use Multi Json instead of depending on the json gem

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -1,11 +1,5 @@
 require 'redis/namespace'
 
-begin
-  require 'yajl'
-rescue LoadError
-  require 'json'
-end
-
 require 'resque/version'
 
 require 'resque/errors'

--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -1,3 +1,5 @@
+require 'multi_json'
+
 module Resque
   # Methods used by various classes in Resque.
   module Helpers
@@ -11,29 +13,17 @@ module Resque
     # Given a Ruby object, returns a string suitable for storage in a
     # queue.
     def encode(object)
-      if defined? Yajl
-        Yajl::Encoder.encode(object)
-      else
-        object.to_json
-      end
+      ::MultiJson.encode(object)
     end
 
     # Given a string, returns a Ruby object.
     def decode(object)
       return unless object
 
-      if defined? Yajl
-        begin
-          Yajl::Parser.parse(object, :check_utf8 => false)
-        rescue Yajl::ParseError => e
-          raise DecodeException, e
-        end
-      else
-        begin
-          JSON.parse(object)
-        rescue JSON::ParserError => e
-          raise DecodeException, e
-        end
+      begin
+        ::MultiJson.decode(object)
+      rescue ::MultiJson::DecodeError => e
+        raise DecodeException, e
       end
     end
 

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "redis-namespace", "~> 1.0.2"
   s.add_dependency "vegas",           "~> 0.1.2"
   s.add_dependency "sinatra",         ">= 0.9.2"
-  s.add_dependency "json",            ">= 1.4.6", "< 1.6"
+  s.add_dependency "multi_json",      "~> 1.0"
 
   s.description = <<description
     Resque is a Redis-backed Ruby library for creating background jobs,


### PR DESCRIPTION
Hey Chris,

Instead of using the json gem, or trying to require yajl, this patch uses Multi Json which takes care of deciding which json engine to use, and includes a vendored json implementation if one is not available (okjson).

Multi Json is smart enough that it will use either Yajl, the built in 1.9 json, json gem, json pure, or okjson, in that order.

Let me know what you think.

Thanks,

Josh
