### PR TITLE
Don't try to perform placeholder jobs inline 

### DIFF
--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -43,7 +43,8 @@ module Resque
       Resque.validate(klass, queue)
 
       if Resque.inline?
-        constantize(klass).perform(*decode(encode(args)))
+        klass_const = constantize(klass)
+        klass_const.perform(*decode(encode(args))) if klass_const.respond_to?(:perform)
       else
         Resque.push(queue, :class => klass.to_s, :args => args)
       end

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -251,6 +251,7 @@ context "Resque" do
     begin
       Resque.inline = true
       Resque.enqueue(SomeIvarJob, 20, '/tmp')
+      Resque.enqueue(PlaceholderIvarJob, 20, '/tmp')
       assert_equal 0, Resque.size(:ivar)
     ensure
       Resque.inline = false

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -120,6 +120,10 @@ class BadJobWithSyntaxError
   end
 end
 
+class PlaceholderIvarJob
+  @queue = :ivar
+end
+
 class BadFailureBackend < Resque::Failure::Base
   def save
     raise Exception.new("Failure backend error")


### PR DESCRIPTION
If Resque.inline has been set to true, but the requested job does
not have a perform method, ignore it. These jobs are intended
to be processed by a non-Ruby client, so there's not really anything good
we can do inline.

There's an argument to be made that the right thing to do here is
ignore the "inline" config value in this case (ie, enqueue as usual)
but not queueing the job is actually more convenient in test environments,
which is, I think, where this feature is most often used.
