### PR TITLE
Use BLPOP when available to minimize lag in work-loop.

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -158,6 +158,13 @@ module Resque
     decode redis.lpop("queue:#{queue}")
   end
 
+  # Blocking pops a job off a list of queues. Queuelist should be an array.
+  #
+  # Returns a Ruby object.
+  def bpop(queuelist, timeout)
+    redis.blpop(*queuelist.map {|queue| "queue:#{queue}"}, timeout)
+  end
+
   # Returns an integer representing the size of a queue.
   # Queue name should be a string.
   def size(queue)

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -98,6 +98,15 @@ module Resque
       new(queue, payload)
     end
 
+    # Given a list of queue names, returns an instance or Resque::Job
+    # or blocks until a job becomes available on any of the queues, or
+    # timeout is reached.
+    def self.blocking_reserve(queues, timeout)
+      return unless payload = Resque.bpop(queues, timeout)  # payload = ["namespace:queue:job", payload]
+      queue = payload[0][16..-1]
+      new(queue, payload[1])
+    end
+
     # Attempts to perform the work represented by this job instance.
     # Calls #perform on the class given in the payload with the
     # arguments given in the payload.

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -329,4 +329,42 @@ context "Resque::Worker" do
   test "returns PID of running process" do
     assert_equal @worker.to_s.split(":")[1].to_i, @worker.pid
   end
+
+  test "can blocking grab a job from its queues" do
+    job = @worker.blocking_reserve(1)
+    assert_not_nil job
+    assert_equal 0, Resque.size(:jobs)
+  end
+
+  test "can blocking grab nothing from an empty queue" do
+    worker = Resque::Worker.new(:empty)
+    job = worker.blocking_reserve(1)
+    assert_nil job
+  end
+
+  test "can do blocking work" do
+    shutdown_thread = Thread.new do
+      sleep 2 
+      @worker.shutdown
+    end
+
+    @worker.work(1)
+
+    shutdown_thread.join
+  end
+
+  test "can blocking reserve from multiple queues" do
+    Resque::Job.create(:high, GoodJob)
+    Resque::Job.create(:critical, GoodJob)
+
+    worker = Resque::Worker.new(:critical, :high)
+
+    worker.blocking_reserve(5)
+    assert_equal 1, Resque.size(:high)
+    assert_equal 0, Resque.size(:critical)
+
+    worker.blocking_reserve(5)
+    assert_equal 0, Resque.size(:high)
+  end
+
 end


### PR DESCRIPTION
Adds `Job#blocking_reserve` as an alternative to `Job#reserve`: blocks on an empty queue(list) until a job becomes available or the timeout expires.

Used in `Worker#work` when available: instead of sleeping for _n_ seconds, the worker blocks for _n or less_ seconds. Disabled when using distributed Redis.
