### PR TITLE
Fix bug causing working to always return the max

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -36,7 +36,7 @@ module Resque
       names.map! { |name| "worker:#{name}" }
 
       reportedly_working = redis.mapped_mget(*names).reject do |key, value|
-        value.nil?
+        value.nil? || value.empty?
       end
       reportedly_working.keys.map do |key|
         find key.sub("worker:", '')


### PR DESCRIPTION
Apparently value isn't (always?) nil, but an empty hash, if the worker
isn't working.
