### PR TITLE
Set the default encoding to UTF-8 for Resque-web

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -4,6 +4,8 @@ require 'resque'
 require 'resque/version'
 require 'time'
 
+Encoding.default_external = Encoding::UTF_8
+
 module Resque
   class Server < Sinatra::Base
     dir = File.dirname(File.expand_path(__FILE__))


### PR DESCRIPTION
References issue: https://github.com/defunkt/resque/issues/341

Resque-web Byte Sequence Errors

Resque web consistently becomes unusable if a failed job has certain characters in it. It prevents the failed jobs from being used and sometimes also the overview.  This allows UTF-8 characters to be in resque-web without forcing Sinatra errors.
