### PR TITLE
Fix NaN days ago for worker screens in web-ui

### DIFF
--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -5,7 +5,7 @@ module Resque
     class Redis < Base
       def save
         data = {
-          :failed_at => Time.now.strftime("%Y/%m/%d %H:%M:%S"),
+          :failed_at => Time.now.strftime("%Y/%m/%d %H:%M:%S %Z"),
           :payload   => payload,
           :exception => exception.class.to_s,
           :error     => exception.to_s,

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -381,7 +381,7 @@ module Resque
       job.worker = self
       data = encode \
         :queue   => job.queue,
-        :run_at  => Time.now.strftime("%Y/%m/%d %H:%M:%S"),
+        :run_at  => Time.now.strftime("%Y/%m/%d %H:%M:%S %Z"),
         :payload => job.payload
       redis.set("worker:#{self}", data)
     end


### PR DESCRIPTION
Hey

This commit fixes the NaN days ago bug in web-ui for all workers' screens (including Live Poll).

The previous commit (issue #20) only fixed it for the Failed page.

I still experience a problem where the timings are wrong because the server time zone is different to mine. But this is for a different commit. :)

Might be a good idea to consider using the timeago jQuery plugin instead: https://github.com/rmm5t/jquery-timeago

Thanks. :)
