### PR TITLE
ensure Rails environment is loaded before preloading app classes.

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -5,7 +5,7 @@ namespace :resque do
   task :setup
 
   desc "Start a Resque worker"
-  task :work => :setup do
+  task :work => [:preload, :setup] do
     require 'resque'
 
     queues = (ENV['QUEUES'] || ENV['QUEUE']).to_s.split(',')
@@ -39,11 +39,11 @@ namespace :resque do
 
     threads.each { |thread| thread.join }
   end
-end
 
-# Preload app files
-task :environment do
-  Dir['app/**/*.rb'].each do |file|
-    require file
+  # Preload app files
+  task :preload => [:environment] do
+    Dir['app/**/*.rb'].each do |file|
+      require file
+    end
   end
 end


### PR DESCRIPTION
Overriding :environment task breaks rake command on ruby-192.

It caused by 
- Ruby 1.9 does'nt append `.` to `$LOAD_PATH`
- The resque's :environment task invoked before Rails'

And this patch ensures invoking order.

Issue #353 seems same problem.

Thanks
