### PR TITLE
Fix: Preload app files on Rails 3.x. See: http://guides.rubyonrails.org/initialization.html#require-app_path

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -43,8 +43,12 @@ namespace :resque do
   # Preload app files if this is Rails
   task :preload do
     if defined? Rails
-      Dir["#{Rails.root}/app/**/*.rb"].each do |file|
-        require file
+      if Rails.version >= '3'
+        require 'rails/all'
+      else
+        Dir["#{Rails.root}/app/**/*.rb"].each do |file|
+          require file
+        end
       end
     end
   end


### PR DESCRIPTION
Fix: Preload app files on Rails 3.x. See: http://guides.rubyonrails.org/initialization.html#require-app_path

I fix that because when I try to run this rake task:

`rake resque:work QUEUE='*' --trace`

I have this error:

`** Invoke resque:work (first_time)
** Invoke resque:preload (first_time)
** Execute resque:preload
rake aborted!
uninitialized constant Admin
/Users/willywg/proyectos/rails/colegios/app/controllers/admin/admin_users_controller.rb:1:in `<top (required)>'
`

This happend because when you use:

``` ruby
Dir["#{Rails.root}/app/**/*.rb"].each do |file|
   require file
end
```

This load the files but in an alphabetic order (I think). For this reason my Admin modulo don't load correctly. 

I sent my fix for Rails 3, but for Rails 2.3.x i can't :S
