### PR TITLE
Ensure environment can be loaded before preloading app files

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -41,7 +41,7 @@ namespace :resque do
   end
 
   # Preload app files if this is Rails
-  task :preload do
+  task :preload => :setup  do
     if defined? Rails
       Dir["#{Rails.root}/app/**/*.rb"].each do |file|
         require file


### PR DESCRIPTION
This fixes potential "uninitialized constant" errors.

The cause was that the :preload rake task ran before :setup (because it
appears before :setup in the dependencies for :work). So the app files
being preloaded could reference other files that had not yet been loaded
and wouldn't automatically be loaded by Rails.

For example, if there is a controller named alphabetically before
ApplicationController, it would reference ApplicationController which
would not have been loaded yet, causing "uninitialized constant
ApplicationController".

So if :setup is called before :preload then :setup can depend on
:environment and ApplicationController will be loaded before any other
app file.
