### PR TITLE
Add small Rails 3 resque/server documentation note

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -477,6 +477,7 @@ You can also easily mount Resque on a subpath in your existing Rails 3 app by ad
 mount Resque::Server.new, :at => "/resque"
 ```
 
+You must also require `resque/server` at the top of your routes file for Rails to be able to mount Resque.
 
 Resque vs DelayedJob
 --------------------


### PR DESCRIPTION
Add comment to clarify that resque/server must be required at the top of the Rails routes file. If you don't do this, you get an uninitialized constant error.
