### PR TITLE
Adds -r flag to resque-web for redis connection

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -445,6 +445,10 @@ You can also set the namespace directly using `resque-web`:
 
     $ resque-web -p 8282 -N myapp
 
+or set the Redis connection string if you need to do something like select a different database:
+
+    $ resque-web -p 8282 -r localhost:6379:2
+
 ### Passenger
 
 Using Passenger? Resque ships with a `config.ru` you can use. See

--- a/bin/resque-web
+++ b/bin/resque-web
@@ -20,4 +20,8 @@ Vegas::Runner.new(Resque::Server, 'resque-web', {
     runner.logger.info "Using Redis namespace '#{namespace}'"
     Resque.redis.namespace = namespace
   }
+  opts.on('-r redis-connection', "--redis redis-connection", "set the Redis connection string") {|redis_conf|
+    runner.logger.info "Using Redis connection '#{redis_conf}'"
+    Resque.redis = redis_conf
+  }
 end


### PR DESCRIPTION
-r or --redis can now be used to specify the
redis connection string.

TODO: A string like redis://:secret@localhost is encountering an
error, even though it works in irb doing:

irb> require 'redis'
irb> r = Redis.connect(:url => "redis://:secret@localhost")
 => #<Redis client v2.2.2 connected to redis://localhost:6379/0 (Redis
 v2.2.12)>
