### PR TITLE
Change how we load the Rails environment (due to Rails 3.1 engine issues).

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -50,8 +50,8 @@ namespace :resque do
   # Preload app files if this is Rails
   task :preload => :setup do
     if defined?(Rails) && Rails.respond_to?(:application)
-      # Rails 3
-      Rails.application.eager_load!
+      # Rails 3.x
+      Rake::Task[:environment].invoke
     elsif defined?(Rails::Initializer)
       # Rails 2.3
       $rails_rake_task = false


### PR DESCRIPTION
I was seeing errors running `rake resque:work` in a 3.1 app that boiled down to problems loading engines. The only way I could determine to fix it was to run `rake environment resque:work` or specifying `task "resque:setup" => :environment` in the app's Rakefile. Otherwise I'd see `undefined method 'require_dependency'` errors.

I had initially reported this as a continuation of Issue #354 [see here](https://github.com/defunkt/resque/pull/354#issuecomment-2173157), but that was stupid of me :). I'm not sure if there is a better way to handle this--the pull request is meant to be an RFC.
