### PR TITLE
Workaround for Sinatra 1.3 backwards incompatibility

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -13,7 +13,7 @@ module Resque
     dir = File.dirname(File.expand_path(__FILE__))
 
     set :views,  "#{dir}/server/views"
-    if Sinatra.const_defined?("VERSION") && Sinatra::VERSION >= "1.3.0"
+    if Sinatra.const_defined?("VERSION") && Gem::Version.new(Sinatra::VERSION) >= Gem::Version.new("1.3.0")
       set :public_folder, "#{dir}/server/public"
     else
       set :public, "#{dir}/server/public"


### PR DESCRIPTION
As per last ticket, this silences startup warnings with Sinatra 1.3.

```
:public is no longer used to avoid overloading Module#public, use :public_folder instead
    from /home/chris/oss/resque/lib/resque/server.rb:16:in `<class:Server>'
```
