### PR TITLE
fix build for 1.9.2

### DIFF
--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -40,7 +40,7 @@ context "Resque::Worker" do
   end
 
   class ::SimpleJobWithFailureHandling
-    def self.on_failure_record_failure(exception)
+    def self.on_failure_record_failure(exception, *job_args)
       @@exception = exception
     end
     


### PR DESCRIPTION
fixes the build for ruby 1.9.2 and 1.9.3rc1 for me. I was getting this error before:

https://gist.github.com/e6208257593e401229b8
