### PR TITLE
[resque-web] remove description of -r option for resque-web in README.markdown since it's not relevant anymore

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -454,10 +454,6 @@ You can also set the namespace directly using `resque-web`:
 
     $ resque-web -p 8282 -N myapp
 
-or set the Redis connection string if you need to do something like select a different database:
-
-    $ resque-web -p 8282 -r localhost:6379:2
-
 ### Passenger
 
 Using Passenger? Resque ships with a `config.ru` you can use. See


### PR DESCRIPTION
ruby version => ruby-1.8.7-p352

When I'm trying to start resque-web with -r option as described in README it fails with the following backtrace:

``` sh
$ resque-web -p 8282 -r localhost:6380
WARNING: using the built-in Timeout class which is known to have issues when used for opening connections. Install the SystemTimer gem if you want to make sure the Redis client will not hang.
/home/deploy/.rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/optparse.rb:1450:in `complete': invalid option: -r (OptionParser::InvalidOption)
    from /home/deploy/.rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/optparse.rb:1448:in `catch'
    from /home/deploy/.rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/optparse.rb:1448:in `complete'
    from /home/deploy/.rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/optparse.rb:1287:in `parse_in_order'
    from /home/deploy/.rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/optparse.rb:1254:in `catch'
    from /home/deploy/.rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/optparse.rb:1254:in `parse_in_order'
    from /home/deploy/.rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/optparse.rb:1248:in `order!'
    from /home/deploy/.rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/optparse.rb:1339:in `permute!'
    from /home/deploy/.rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/optparse.rb:1360:in `parse!'
    from /home/deploy/.rvm/gems/ruby-1.8.7-p352/gems/vegas-0.1.8/lib/vegas/runner.rb:287:in `define_options'
    from /home/deploy/.rvm/gems/ruby-1.8.7-p352/gems/vegas-0.1.8/lib/vegas/runner.rb:39:in `initialize'
    from /home/deploy/.rvm/gems/ruby-1.8.7-p352/gems/resque-1.19.0/bin/resque-web:13:in `new'
    from /home/deploy/.rvm/gems/ruby-1.8.7-p352/gems/resque-1.19.0/bin/resque-web:13
    from /home/deploy/.rvm/gems/ruby-1.8.7-p352/bin/resque-web:19:in `load'
    from /home/deploy/.rvm/gems/ruby-1.8.7-p352/bin/resque-web:19
```

--redis option doesn't work as well:

``` sh
$ resque-web -p5679 --redis localhost:6379
WARNING: using the built-in Timeout class which is known to have issues when used for opening connections. Install the SystemTimer gem if you want to make sure the Redis client will not hang.
/home/dsamoilov/.rvm/rubies/ruby-1.8.7-p352/lib/ruby/1.8/optparse.rb:1450:in `complete': invalid option: --redis (OptionParser::InvalidOption)
```

Doesn't work in ruby 1.9.2 either:

``` sh
$ resque-web -r localhost:6379
:public is no longer used to avoid overloading Module#public, use :public_folder instead
    from /home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/gems/resque-1.19.0/lib/resque/server.rb:12:in `<class:Server>'
/home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/gems/vegas-0.1.8/lib/vegas/runner.rb:287:in `define_options': invalid option: -r (OptionParser::InvalidOption)
    from /home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/gems/vegas-0.1.8/lib/vegas/runner.rb:39:in `initialize'
    from /home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/gems/resque-1.19.0/bin/resque-web:13:in `new'
    from /home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/gems/resque-1.19.0/bin/resque-web:13:in `<top (required)>'
    from /home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/bin/resque-web:19:in `load'
    from /home/dsamoilov/.rvm/gems/ruby-1.9.2-p290/bin/resque-web:19:in `<main>'
```

I just edited README.markdown to delete description of this option.
