### PR TITLE
:public is no longer used to avoid overloading Module#public

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -13,7 +13,7 @@ module Resque
     dir = File.dirname(File.expand_path(__FILE__))
 
     set :views,  "#{dir}/server/views"
-    set :public, "#{dir}/server/public"
+    set :public_folder, "#{dir}/server/public"
     set :static, true
 
     helpers do


### PR DESCRIPTION
as a warning printed.
