### PR TITLE
Resque::Helpers#constantize does'nt work correctly on 1.9.2

### DIFF
--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -40,9 +40,23 @@ module Resque
       dashed_word.split('-').each { |part| part[0] = part[0].chr.upcase }.join
     end
 
-    # Given a camel cased word, returns the constant it represents
+    # Tries to find a constant with the name specified in the argument string:
     #
-    # constantize('JobName') # => JobName
+    # constantize("Module") # => Module
+    # constantize("Test::Unit") # => Test::Unit
+    #
+    # The name is assumed to be the one of a top-level constant, no matter
+    # whether it starts with "::" or not. No lexical context is taken into
+    # account:
+    #
+    # C = 'outside'
+    # module M
+    #   C = 'inside'
+    #   C # => 'inside'
+    #   constantize("C") # => 'outside', same as ::C
+    # end
+    #
+    # NameError is raised when the constant is unknown.
     def constantize(camel_cased_word)
       camel_cased_word = camel_cased_word.to_s
 
@@ -55,7 +69,13 @@ module Resque
 
       constant = Object
       names.each do |name|
-        constant = constant.const_get(name) || constant.const_missing(name)
+        args = Module.method(:const_get).arity != 1 ? [false] : []
+
+        if constant.const_defined?(name, *args)
+          constant = constant.const_get(name)
+        else
+          constant = constant.const_missing(name)
+        end
       end
       constant
     end


### PR DESCRIPTION
Using the 'twitter' gem, which defines a `::Twitter` module, I discovered this:

``` Ruby
::Twitter # => Twitter
```

trying to run a job on my Resque job called, `SocialMedia::Messengers::Twitter` resulted in:

```
 #<NoMethodError: undefined method `perform' for Twitter:Module>
```

I learned that it was due to Ruby 1.9.2's addition of the `inherit` parameter to its `Module#const_get` that defaults to true. This makes it search ancestors by default, so the algorithm in `constantize` will fail. All I've done in this commit is implement the changes that were made to `ActiveSupport::Inflector#constantize`

I didn't make a feature branch, because it seemed ridiculous for just one file; but, if it's a problem, I'll go ahead and do that.
