### PR TITLE
raise needs a string parameter not Exception class

### DIFF
--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -29,7 +29,7 @@ module Resque
       begin
         ::MultiJson.decode(object)
       rescue ::MultiJson::DecodeError => e
-        raise DecodeException, e
+        raise DecodeException, e.message, e.backtrace
       end
     end
 


### PR DESCRIPTION
Hey,

In helpers.rb where DecodeException is getting raised, an exception-typed variable as the message rather than a string. This breaks newrelic and probably others that expect to manipulate the message as a string.

Best,
Trevor
