### PR TITLE
Worker Process.wait call should include child pid

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -134,7 +134,7 @@ module Resque
           if @child = fork
             srand # Reseeding
             procline "Forked #{@child} at #{Time.now.to_i}"
-            Process.wait
+            Process.wait(@child)
           else
             procline "Processing #{job.queue} since #{Time.now.to_i}"
             perform(job, &block)


### PR DESCRIPTION
We were noticing behavior where our resque worker would return and start a new job before the previous job had completed.  We traced this down to two issues

1) NewRelic's rpm_contrib gem seems to fork a child of the worker that becomes a zombie (aka defunct) process.  This happens at worker startup.

2) Resque worker is using Process.Wait (http://www.ruby-doc.org/core-1.9.2/Process.html#method-c-wait) with no arguments, which just waits for the first child process it can find.  This was picking up the aforementioned zombie process, instead of the worker child it had just spawned.  Resque would then start a new job and the old job would finish and become its own zombie child.  This would continue ad infinitum.

Our proposed solution is to have Resque wait on the specific pid of the child it spawned to process the job, that way it won't accidentally pick up any stray children left from other gems.
