### PR TITLE
make alpha for 1.19.1

### DIFF
--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.19.0'
+  Version = VERSION = '1.19.1.a'
 end


### PR DESCRIPTION
I've working on a gem that relies on some of the new hooks since 1.9.0. 

Can we get a pre-release please?
