### PR TITLE
add after_kill hook and tests

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -94,6 +94,11 @@ The available hooks are:
 * `on_failure`: Called with the exception and job args if any exception occurs
   while performing the job (or hooks), this includes Resque::DirtyExit.
 
+* `after_kill`: Called with the job args after a worker is killed mid-process
+  (typically by sending a signal to the worker that invokes worker#kill_child). 
+  This hook should be used with caution, as it is executed in the worker parent
+  fork and therefore has the potential to subject that worker to memory bloat.
+
 Hooks are easily implemented with superclasses or modules. A superclass could
 look something like this.
 

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -213,11 +213,19 @@ module Resque
     def failure_hooks 
       @failure_hooks ||= Plugin.failure_hooks(payload_class)
     end
+
+    def after_kill_hooks
+      @after_kill_hooks ||= Plugin.after_kill_hooks(payload_class)
+    end
     
     def run_failure_hooks(exception)
       job_args = args || []
       failure_hooks.each { |hook| payload_class.send(hook, exception, *job_args) }
     end
 
+    def run_after_kill_hooks
+      job_args = args || []
+      after_kill_hooks.each { |hook| payload_class.send(hook, *job_args) }
+    end
   end
 end

--- a/lib/resque/plugin.rb
+++ b/lib/resque/plugin.rb
@@ -62,5 +62,10 @@ module Resque
     def before_dequeue_hooks(job)
       job.methods.grep(/^before_dequeue/).sort
     end
+
+    # Given an object, returns a list `after_kill` hook names.
+    def after_kill_hooks(job)
+      job.methods.grep(/^after_kill/).sort
+    end
   end
 end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -301,6 +301,7 @@ module Resque
         log! "Killing child at #{@child}"
         if system("ps -o pid,state -p #{@child}")
           Process.kill("KILL", @child) rescue nil
+          run_after_kill_hooks
         else
           log! "Child #{@child} not found, restarting."
           shutdown
@@ -363,6 +364,14 @@ module Resque
       log msg
 
       args.any? ? hook.call(*args) : hook.call
+    end
+
+    # if there is a current job, run its after_kill hooks.
+    def run_after_kill_hooks
+      return unless (hash = processing) && !hash.empty?
+      job = Job.new(hash['queue'], hash['payload'])
+      
+      job.run_after_kill_hooks
     end
 
     # Unregisters ourself as a worker. Useful when shutting down.


### PR DESCRIPTION
The hooks provided around enqueue, dequeue, perform, and failure make an interface for plugins to track metadata in nearly all stages of a job's lifecycle. 

This patch closes the loop by providing a method for hooking functionality after a job is forcefully killed (via `Resque::Worker#kill_child`, usually invoked by sending one of several signals to the worker.).

Patch provides functionality, tests, and updates the documentation.
