### PR TITLE
Remove deprecated Module.public

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -14,11 +14,7 @@ module Resque
 
     set :views,  "#{dir}/server/views"
 
-    if respond_to? :public_folder
-      set :public_folder, "#{dir}/server/public"
-    else
-      set :public, "#{dir}/server/public"
-    end
+    set :public_folder, "#{dir}/server/public"
 
     set :static, true
 


### PR DESCRIPTION
set :public has been deprecated in Sinatra 1.3.0. Resque is currently locked against sinatra ~0.9.2. Bumping the required sinatra version my be required, but I am not familiar enough with sinatra's history to know the exact version number. According to rubygems ~0.9.2 was released in 2009 so a version bump may be a good thing.
