### PR TITLE
trailing slashes at the end of resque servers' URLs

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -149,21 +149,21 @@ module Resque
     end
 
     %w( overview workers ).each do |page|
-      get "/#{page}.poll" do
+      get "/#{page}.poll/?" do
         show_for_polling(page)
       end
 
-      get "/#{page}/:id.poll" do
+      get "/#{page}/:id.poll/?" do
         show_for_polling(page)
       end
     end
 
     %w( overview queues working workers key ).each do |page|
-      get "/#{page}" do
+      get "/#{page}/?" do
         show page
       end
 
-      get "/#{page}/:id" do
+      get "/#{page}/:id/?" do
         show page
       end
     end
@@ -173,7 +173,7 @@ module Resque
       redirect u('queues')
     end
 
-    get "/failed" do
+    get "/failed/?" do
       if Resque::Failure.url
         redirect Resque::Failure.url
       else
@@ -193,7 +193,7 @@ module Resque
       redirect u('failed')
     end
 
-    get "/failed/requeue/:index" do
+    get "/failed/requeue/:index/?" do
       Resque::Failure.requeue(params[:index])
       if request.xhr?
         return Resque::Failure.all(params[:index])['retried_at']
@@ -202,24 +202,24 @@ module Resque
       end
     end
 
-    get "/failed/remove/:index" do
+    get "/failed/remove/:index/?" do
       Resque::Failure.remove(params[:index])
       redirect u('failed')
     end
 
-    get "/stats" do
+    get "/stats/?" do
       redirect url_path("/stats/resque")
     end
 
-    get "/stats/:id" do
+    get "/stats/:id/?" do
       show :stats
     end
 
-    get "/stats/keys/:key" do
+    get "/stats/keys/:key/?" do
       show :stats
     end
 
-    get "/stats.txt" do
+    get "/stats.txt/?" do
       info = Resque.info
 
       stats = []

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -51,3 +51,9 @@ context "on GET to /stats/resque" do
 
   should_respond_with_success
 end
+
+context "also works with slash at the end" do
+  setup { get "/working/" }
+
+  should_respond_with_success
+end


### PR DESCRIPTION
choose between:
- trailing slashes are cool
- allowing the optional trailing slash can be useful in certain proxying environments.
