### PR TITLE
added exemptions to stale.god

### DIFF
--- a/examples/god/stale.god
+++ b/examples/god/stale.god
@@ -2,17 +2,22 @@
 # processes. Their sacrifice is for the greater good.
 
 WORKER_TIMEOUT = 60 * 10 # 10 minutes
+STALE_EXEMPTIONS = ["imports"]
 
 Thread.new do
   loop do
     begin
-      `ps -e -o pid,command | grep [r]esque`.split("\n").each do |line|
+      lines = `ps -e -o pid,command | grep [r]esque`.split("\n")
+      lines.each do |line|
         parts   = line.split(' ')
         next if parts[-2] != "at"
         started = parts[-1].to_i
         elapsed = Time.now - Time.at(started)
 
         if elapsed >= WORKER_TIMEOUT
+          parent = lines.detect { |line| line.split(" ").first == parts[3] }
+          queue = parent.split(" ")[3]
+          next if STALE_EXEMPTIONS.include?(queue)
           ::Process.kill('USR1', parts[0].to_i)
         end
       end


### PR DESCRIPTION
our support people will often need to run long running CSV imports that map across many database tables via a resque task, so we needed a way to exclude certain queues from being killed by stale.god
