### PR TITLE
add before_reporting_error hooks

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -94,6 +94,10 @@ The available hooks are:
 * `on_failure`: Called with the exception and job args if any exception occurs
   while performing the job (or hooks), this includes Resque::DirtyExit.
 
+* `before_reporting_failure`: Called with the same args that would be passed to 
+  `Failure.create` before passing a failure to the Failure backend. If the hook 
+  returns false, the failure will not be reported.
+
 Hooks are easily implemented with superclasses or modules. A superclass could
 look something like this.
 

--- a/lib/resque/plugin.rb
+++ b/lib/resque/plugin.rb
@@ -62,5 +62,10 @@ module Resque
     def before_dequeue_hooks(job)
       job.methods.grep(/^before_dequeue/).sort
     end
+
+    # Given an object, returns a list `before_reporting_failure` hook names.
+    def before_reporting_failure_hooks(job)
+      job.methods.grep(/^before_reporting_failure/).sort
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -87,9 +87,17 @@ end
 # Helper to perform job classes
 #
 module PerformJob
+  def build_job(klass,*args)
+    Resque::Job.new(:testqueue, 'class' => klass, 'args' => args)
+  end
   def perform_job(klass, *args)
-    resque_job = Resque::Job.new(:testqueue, 'class' => klass, 'args' => args)
-    resque_job.perform
+    job = build_job(klass,*args)
+    job.perform
+  end
+  def perform_job_in_worker(klass,*args)
+    worker = Resque::Worker.new(:test_queue)
+    job = build_job(klass,*args)
+    worker.process( job )
   end
 end
 


### PR DESCRIPTION
Gives a job the ability to handle reporting itself to the failure backend on
its own, either in addition to or as a replacement to the existing process.

A plugin that I'm working on connects jobs together with metadata; when a
child job fails, the whole tree effectively fails. This patch gives us the
ability to report the root job failed to the backend, enabling swifter
recovery in Resque Web.

Others may find this useful to special-case certain job types to, for example,
report to some controller that the current worker is apparently over an
external API's rate limit, since the worker and current queue are both
available at this juncture.
