### PR TITLE
added paused state to web ui and more compact overview

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -197,5 +197,15 @@ module Resque
     def self.tabs
       @tabs ||= ["Overview", "Working", "Failed", "Queues", "Workers", "Stats"]
     end
+
+    def worker_text(worker)
+      worker.paused? ? 'Paused' : 'Waiting for a job...'
+    end
+
+    def worker_row_class(worker)
+      row_class = [worker.state.to_s]
+      row_class << 'paused' if worker.paused?
+      row_class.join(' ')
+    end
   end
 end

--- a/lib/resque/server/public/style.css
+++ b/lib/resque/server/public/style.css
@@ -54,6 +54,7 @@ body { padding:0; margin:0; }
 #main.polling table.workers tr.working td.where a { color:#7ac312;}
 #main.polling table.workers tr.working td.process code { font-weight:bold;}
 
+#main table.workers tr.paused { background-color: #ddd; }
 
 #main table.stats th { font-size:100%; width:40%; color:#000;}
 #main hr { border:0; border-top:5px solid #efefef;  margin:15px 0;}

--- a/lib/resque/server/views/overview.erb
+++ b/lib/resque/server/views/overview.erb
@@ -1,4 +1,15 @@
+<style>
+  #overview-main { margin: 0; padding: 0; }
+  #overview-main #queues { position: relative; float: left; width: 29%; }
+  #overview-main #working { position: relative; float: right; width: 70%; clear:right; }
+</style>
+
+<div id="overview-main">
+  <div id="queues">
 <%= partial :queues %>
-<hr />
-<%= partial :working %>
+  </div>
+  <div id="working">
 <%= poll %>
+    <%= partial :working %>
+  </div>
+</div>

--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -28,7 +28,6 @@
 <% else %>
 
   <h1 class='wi'>Queues</h1>
-  <p class='intro'>The list below contains all the registered queues with the number of jobs currently in the queue. Select a queue from above to view all jobs currently pending on the queue.</p>
   <table class='queues'>
     <tr>
       <th>Name</th>
@@ -46,4 +45,5 @@
     </tr>
   </table>
 
+  <p class='intro'>The list above contains all the registered queues with the number of jobs currently in the queue. Select a queue from above to view all jobs currently pending on the queue.</p>
 <% end %>

--- a/lib/resque/server/views/workers.erb
+++ b/lib/resque/server/views/workers.erb
@@ -28,7 +28,7 @@
           <code><%= data['payload']['class'] %></code>
           <small><a class="queue time" href="<%=u "/working/#{worker}" %>"><%= data['run_at'] %></a></small>
         <% else %>
-          <span class='waiting'>Waiting for a job...</span>
+          <span class='waiting'><%= worker_text(worker) %> </span>
         <% end %>
       </td>
     </tr>
@@ -50,7 +50,8 @@
       <th>Processing</th>
     </tr>
     <% for worker in (workers = resque.workers.sort_by { |w| w.to_s }) %>
-    <tr class="<%=state = worker.state%>">
+      <% state = worker.state %>
+      <tr class="<%= worker_row_class(worker) %>">
       <td class='icon'><img src="<%=u state %>.png" alt="<%= state %>" title="<%= state %>"></td>
 
       <% host, pid, queues = worker.to_s.split(':') %>
@@ -63,7 +64,7 @@
           <code><%= data['payload']['class'] %></code>
           <small><a class="queue time" href="<%=u "/working/#{worker}" %>"><%= data['run_at'] %></a></small>
         <% else %>
-          <span class='waiting'>Waiting for a job...</span>
+            <span class='waiting'><%= worker_text(worker) %></span>
         <% end %>
       </td>
     </tr>

--- a/lib/resque/server/views/working.erb
+++ b/lib/resque/server/views/working.erb
@@ -29,7 +29,6 @@
 
   <% workers = resque.working.reject { |w| w.idle? } %>
   <h1 class='wi'><%= workers.size %> of <%= resque.workers.size %> Workers Working</h1>
-  <p class='intro'>The list below contains all workers which are currently running a job.</p>
   <table class='workers'>
     <tr>
       <th>&nbsp;</th>
@@ -65,4 +64,5 @@
     <% end %>
   </table>
 
+  <p class='intro'>The list above contains all workers which are currently running a job.</p>
 <% end %>


### PR DESCRIPTION
Hi, this branch contains the following changes against v1.10.0:
- more compact overview: show queues and workers side by side, as they don't take much horizontal space. 
  We use this on our current project so that even in a small window we can see all the queues and workers
  at a glance.
- dim paused workers in web ui, so that one can see immediately which workers are paused
