### PR TITLE
Use `exit` instead of `exit!` in worker child

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -137,11 +137,12 @@ module Resque
               procline "Processing #{job.queue} since #{Time.now.to_i}"
               perform(job, &block)
               exit unless @cant_fork
+              
+              nil
             end
           end
 
-          unless @cant_fork
-            @child = thread.value
+          if @child = thread.value
             srand # Reseeding
             procline "Forked #{@child} at #{Time.now.to_i}"
             Process.wait(@child)


### PR DESCRIPTION
I saw another try before, but it was failed because of ensure block (this one https://github.com/defunkt/resque/pull/307)

Lots of my background jobs use Tempfile, which unlink created tempfile in finalizers ( which never runs because of exit! )
Luckily, fork clones only current thread, so we can avoid ensure block
