### PR TITLE
Fix a display issue when a worker's job is empty and it tries to sort on nil

### DIFF
--- a/lib/resque/server/views/working.erb
+++ b/lib/resque/server/views/working.erb
@@ -31,7 +31,7 @@
     workers = resque.working
     jobs = workers.collect {|w| w.job }
     worker_jobs = workers.zip(jobs)
-    worker_jobs = worker_jobs.reject { |w, j| w.idle? }
+    worker_jobs = worker_jobs.reject { |w, j| w.idle? || j.empty? }
   %>
 
   <h1 class='wi'><%= worker_jobs.size %> of <%= resque.workers.size %> Workers Working</h1>
@@ -49,7 +49,7 @@
     </tr>
     <% end %>
 
-    <% worker_jobs.sort_by {|w, j| j['run_at'] ? j['run_at'] : '' }.each do |worker, job| %>
+    <% worker_jobs.sort_by {|w, j| j['run_at'] || '' }.each do |worker, job| %>
       <tr>
         <td class='icon'><img src="<%=u state = worker.state %>.png" alt="<%= state %>" title="<%= state %>"></td>
         <% host, pid, queues = worker.to_s.split(':') %>


### PR DESCRIPTION
If the job is empty, Worker.job will return an empty hash. As idle? and job are called at different moments, they can correspond to different worker states, so the worker can report to be non-idle yet have an empty job from the moment before. 
