### PR TITLE
Fix worker "NaN days ago" relative dates for workers in resque-web

### DIFF
--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -5,7 +5,7 @@ module Resque
     class Redis < Base
       def save
         data = {
-          :failed_at => Time.now.xmlschema,
+          :failed_at => Time.now.rfc2822,
           :payload   => payload,
           :exception => exception.class.to_s,
           :error     => exception.to_s,
@@ -31,7 +31,7 @@ module Resque
 
       def self.requeue(index)
         item = all(index)
-        item['retried_at'] = Time.now.xmlschema
+        item['retried_at'] = Time.now.rfc2822
         Resque.redis.lset(:failed, index, Resque.encode(item))
         Job.create(item['queue'], item['payload']['class'], *item['payload']['args'])
       end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -392,7 +392,7 @@ module Resque
     def working_on(job)
       data = encode \
         :queue   => job.queue,
-        :run_at  => Time.now.xmlschema,
+        :run_at  => Time.now.rfc2822,
         :payload => job.payload
       redis.set("worker:#{self}", data)
     end
@@ -433,7 +433,7 @@ module Resque
 
     # Tell Redis we've started
     def started!
-      redis.set("worker:#{self}:started", Time.now.xmlschema)
+      redis.set("worker:#{self}:started", Time.now.rfc2822)
     end
 
     # Returns a hash explaining the Job we're currently processing, if any.


### PR DESCRIPTION
This pull request modifies the strftime format string of worker time attributes to parse properly in Javascript. When the time zone information is not understood by the Javascript interpreter an ugly "NaN days ago" relative date will display in resque-web worker tab.

See issue #475 for the discussion.
