### PR TITLE
Resque.enqueue: validate job earliers than running before_enqueue hooks

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -240,6 +240,7 @@ module Resque
   #
   # This method is considered part of the `stable` API.
   def enqueue_to(queue, klass, *args)
+    validate(klass, queue)
     # Perform before_enqueue hooks. Don't perform enqueue if any hook returns false
     before_hooks = Plugin.before_enqueue_hooks(klass).collect do |hook|
       klass.send(hook, *args)

--- a/test/job_hooks_test.rb
+++ b/test/job_hooks_test.rb
@@ -255,7 +255,6 @@ context "Resque::Job before_enqueue" do
   include PerformJob
 
   class ::BeforeEnqueueJob
-    @queue = :jobs
     def self.before_enqueue_record_history(history)
       history << :before_enqueue
     end
@@ -277,7 +276,7 @@ context "Resque::Job before_enqueue" do
   test "the before enqueue hook should run" do
     history = []
     @worker = Resque::Worker.new(:jobs)
-    assert Resque.enqueue(BeforeEnqueueJob, history)
+    assert Resque.enqueue_to(:jobs, BeforeEnqueueJob, history)
     @worker.work(0)
     assert_equal history, [:before_enqueue], "before_enqueue was not run"
   end
@@ -287,6 +286,18 @@ context "Resque::Job before_enqueue" do
     @worker = Resque::Worker.new(:jobs)
     assert_nil Resque.enqueue(BeforeEnqueueJobAbort, history)
     assert_equal 0, Resque.size(:jobs)
+  end
+
+  test "before enqueue hook should not run if no queue given" do
+    begin
+      history = []
+      @worker = Resque::Worker.new(:jobs)
+      Resque.enqueue_to(nil, BeforeEnqueueJob, history)
+      assert false # should never be executed
+    rescue Resque::NoQueueError
+    ensure
+      assert_equal [], history, "before_enqueue was run"
+    end
   end
 end
 


### PR DESCRIPTION
Some plugins interact with redis with their `before_enqueue` hooks.

Example from resque-lock

``` ruby
def before_enqueue_lock(*args)
  Resque.redis.setnx(lock(*args), true)
end
```

If the job doesn't have queue specified - this may cause job to be lock forever until lock will be manually removed.

In order to fix that let's validate job before running `before_enqueue` hooks.
