### PR TITLE
USR1 signal will not kill descendant processes of a worker.

### DIFF
--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -106,56 +106,49 @@ module Resque
       job_args = args || []
       job_was_performed = false
 
-      begin
-        # Execute before_perform hook. Abort the job gracefully if
-        # Resque::DontPerform is raised.
-        begin
-          before_hooks.each do |hook|
-            job.send(hook, *job_args)
-          end
-        rescue DontPerform
-          return false
-        end
 
-        # Execute the job. Do it in an around_perform hook if available.
-        if around_hooks.empty?
-          job.perform(*job_args)
-          job_was_performed = true
-        else
-          # We want to nest all around_perform plugins, with the last one
-          # finally calling perform
-          stack = around_hooks.reverse.inject(nil) do |last_hook, hook|
-            if last_hook
-              lambda do
-                job.send(hook, *job_args) { last_hook.call }
-              end
-            else
-              lambda do
-                job.send(hook, *job_args) do
-                  result = job.perform(*job_args)
-                  job_was_performed = true
-                  result
-                end
+      # Execute before_perform hook. Abort the job gracefully if
+      # Resque::DontPerform is raised.
+      begin
+        before_hooks.each do |hook|
+          job.send(hook, *job_args)
+        end
+      rescue DontPerform
+        return false
+      end
+
+      # Execute the job. Do it in an around_perform hook if available.
+      if around_hooks.empty?
+        job.perform(*job_args)
+        job_was_performed = true
+      else
+        # We want to nest all around_perform plugins, with the last one
+        # finally calling perform
+        stack = around_hooks.reverse.inject(nil) do |last_hook, hook|
+          if last_hook
+            lambda do
+              job.send(hook, *job_args) { last_hook.call }
+            end
+          else
+            lambda do
+              job.send(hook, *job_args) do
+                result = job.perform(*job_args)
+                job_was_performed = true
+                result
               end
             end
           end
-          stack.call
         end
-
-        # Execute after_perform hook
-        after_hooks.each do |hook|
-          job.send(hook, *job_args)
-        end
-
-        # Return true if the job was performed
-        return job_was_performed
-
-      # If an exception occurs during the job execution, look for an
-      # on_failure hook then re-raise.
-      rescue Object => e
-        run_failure_hooks(e)
-        raise e
+        stack.call
       end
+
+      # Execute after_perform hook
+      after_hooks.each do |hook|
+        job.send(hook, *job_args)
+      end
+
+      # Return true if the job was performed
+      return job_was_performed
     end
 
     # Returns the actual class constant represented in this job's payload.

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -385,17 +385,22 @@ module Resque
 
     # Unregisters ourself as a worker. Useful when shutting down.
     def unregister_worker
-      # If we're still processing a job, make sure it gets logged as a
-      # failure.
-      if (hash = processing) && !hash.empty?
-        job = Job.new(hash['queue'], hash['payload'])
-        # Ensure the proper worker is attached to this job, even if
-        # it's not the precise instance that died.
-        job.worker = self
-        job.fail(DirtyExit.new)
+
+      # Multiple workers on a single machine can fail a job, causing
+      # duplicate retries when using retry plugin. Here we're effectively
+      # synchronizing on the srem call to prevent that.
+      if redis.srem(:workers, self)
+        # If we're still processing a job, make sure it gets logged as a
+        # failure.
+        if (hash = processing) && !hash.empty?
+          job = Job.new(hash['queue'], hash['payload'])
+          # Ensure the proper worker is attached to this job, even if
+          # it's not the precise instance that died.
+          job.worker = self
+          job.fail(DirtyExit.new)
+        end
       end
 
-      redis.srem(:workers, self)
       redis.del("worker:#{self}")
       redis.del("worker:#{self}:started")
 

--- a/test/job_hooks_test.rb
+++ b/test/job_hooks_test.rb
@@ -16,7 +16,7 @@ context "Resque::Job before_perform" do
   test "it runs before_perform before perform" do
     result = perform_job(BeforePerformJob, history=[])
     assert_equal true, result, "perform returned true"
-    assert_equal history, [:before_perform, :perform]
+    assert_equal [:before_perform, :perform], history
   end
 
   class ::BeforePerformJobFails
@@ -50,7 +50,7 @@ context "Resque::Job before_perform" do
   test "does not perform if before_perform raises Resque::Job::DontPerform" do
     result = perform_job(BeforePerformJobAborts, history=[])
     assert_equal false, result, "perform returned false"
-    assert_equal history, [:before_perform], "Only before_perform was run"
+    assert_equal [:before_perform], history, "Only before_perform was run"
   end
 end
 
@@ -69,7 +69,7 @@ context "Resque::Job after_perform" do
   test "it runs after_perform after perform" do
     result = perform_job(AfterPerformJob, history=[])
     assert_equal true, result, "perform returned true"
-    assert_equal history, [:perform, :after_perform]
+    assert_equal [:perform, :after_perform], history
   end
 
   class ::AfterPerformJobFails
@@ -87,7 +87,7 @@ context "Resque::Job after_perform" do
     assert_raises StandardError do
       perform_job(AfterPerformJobFails, history)
     end
-    assert_equal history, [:perform, :after_perform], "Only after_perform was run"
+    assert_equal [:perform, :after_perform], history, "Only after_perform was run"
   end
 end
 
@@ -108,7 +108,7 @@ context "Resque::Job around_perform" do
   test "it runs around_perform then yields in order to perform" do
     result = perform_job(AroundPerformJob, history=[])
     assert_equal true, result, "perform returned true"
-    assert_equal history, [:start_around_perform, :perform, :finish_around_perform]
+    assert_equal [:start_around_perform, :perform, :finish_around_perform], history
   end
 
   class ::AroundPerformJobFailsBeforePerforming
@@ -128,7 +128,7 @@ context "Resque::Job around_perform" do
     assert_raises StandardError do
       perform_job(AroundPerformJobFailsBeforePerforming, history)
     end
-    assert_equal history, [:start_around_perform], "Only part of around_perform was run"
+    assert_equal [:start_around_perform], history, "Only part of around_perform was run"
   end
 
   class ::AroundPerformJobFailsWhilePerforming
@@ -152,7 +152,7 @@ context "Resque::Job around_perform" do
     assert_raises StandardError do
       perform_job(AroundPerformJobFailsWhilePerforming, history)
     end
-    assert_equal history, [:start_around_perform, :perform, :ensure_around_perform], "Only part of around_perform was run"
+    assert_equal [:start_around_perform, :perform, :ensure_around_perform], history, "Only part of around_perform was run"
   end
 
   class ::AroundPerformJobDoesNotHaveToYield
@@ -169,7 +169,7 @@ context "Resque::Job around_perform" do
     history = []
     result = perform_job(AroundPerformJobDoesNotHaveToYield, history)
     assert_equal false, result, "perform returns false"
-    assert_equal history, [:start_around_perform, :finish_around_perform], "perform was not run"
+    assert_equal [:start_around_perform, :finish_around_perform], history, "perform was not run"
   end
 end
 
@@ -188,7 +188,7 @@ context "Resque::Job on_failure" do
   test "it does not call on_failure if no failures occur" do
     result = perform_job(FailureJobThatDoesNotFail, history=[])
     assert_equal true, result, "perform returned true"
-    assert_equal history, [:perform]
+    assert_equal [:perform], history
   end
 
   class ::FailureJobThatFails
@@ -206,7 +206,7 @@ context "Resque::Job on_failure" do
     assert_raises StandardError do
       perform_job(FailureJobThatFails, history)
     end
-    assert_equal history, [:perform, "oh no"]
+    assert_equal [:perform], history
   end
 
   class ::FailureJobThatFailsBadly
@@ -224,7 +224,7 @@ context "Resque::Job on_failure" do
     assert_raises SyntaxError do
       perform_job(FailureJobThatFailsBadly, history)
     end
-    assert_equal history, [:perform, "oh no"]
+    assert_equal [:perform], history
   end
 end
 
@@ -246,7 +246,7 @@ context "Resque::Job after_enqueue" do
     @worker = Resque::Worker.new(:jobs)
     Resque.enqueue(AfterEnqueueJob, history)
     @worker.work(0)
-    assert_equal history, [:after_enqueue], "after_enqueue was not run"
+    assert_equal [:after_enqueue], history, "after_enqueue was not run"
   end
 end
 
@@ -279,7 +279,7 @@ context "Resque::Job before_enqueue" do
     @worker = Resque::Worker.new(:jobs)
     assert Resque.enqueue(BeforeEnqueueJob, history)
     @worker.work(0)
-    assert_equal history, [:before_enqueue], "before_enqueue was not run"
+    assert_equal [:before_enqueue], history, "before_enqueue was not run"
   end
 
   test "a before enqueue hook that returns false should prevent the job from getting queued" do
@@ -308,7 +308,7 @@ context "Resque::Job after_dequeue" do
     @worker = Resque::Worker.new(:jobs)
     Resque.dequeue(AfterDequeueJob, history)
     @worker.work(0)
-    assert_equal history, [:after_dequeue], "after_dequeue was not run"
+    assert_equal [:after_dequeue], history, "after_dequeue was not run"
   end
 end
 
@@ -341,7 +341,7 @@ context "Resque::Job before_dequeue" do
     @worker = Resque::Worker.new(:jobs)
     Resque.dequeue(BeforeDequeueJob, history)
     @worker.work(0)
-    assert_equal history, [:before_dequeue], "before_dequeue was not run"
+    assert_equal [:before_dequeue], history, "before_dequeue was not run"
   end
 
   test "a before dequeue hook that returns false should prevent the job from getting dequeued" do
@@ -376,13 +376,13 @@ context "Resque::Job all hooks" do
   test "the complete hook order" do
     result = perform_job(VeryHookyJob, history=[])
     assert_equal true, result, "perform returned true"
-    assert_equal history, [
+    assert_equal [
       :before_perform,
       :start_around_perform,
       :perform,
       :finish_around_perform,
       :after_perform
-    ]
+    ], history
   end
 
   class ::VeryHookyJobThatFails
@@ -411,13 +411,12 @@ context "Resque::Job all hooks" do
     assert_raises StandardError do
       perform_job(VeryHookyJobThatFails, history)
     end
-    assert_equal history, [
+    assert_equal [
       :before_perform,
       :start_around_perform,
       :perform,
       :finish_around_perform,
       :after_perform,
-      "oh no"
-    ]
+    ], history
   end
 end

--- a/test/job_plugins_test.rb
+++ b/test/job_plugins_test.rb
@@ -225,6 +225,6 @@ context "Resque::Plugin ordering on_failure" do
     assert_raises StandardError do
       perform_job(FailureJob, history)
     end
-    assert_equal [:perform, "oh no", "oh no plugin"], history
+    assert_equal [:perform], history
   end
 end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -9,6 +9,7 @@ context "Resque::Worker" do
     Resque.after_fork = nil
 
     @worker = Resque::Worker.new(:jobs)
+    @worker.register_worker
     Resque::Job.create(:jobs, SomeJob, 20, '/tmp')
   end
 
@@ -307,7 +308,8 @@ context "Resque::Worker" do
     workerB.instance_variable_set(:@to_s, "#{`hostname`.chomp}:2:high,low")
     workerB.register_worker
 
-    assert_equal 2, Resque.workers.size
+    # should be 3 counting @worker
+    assert_equal 3, Resque.workers.size
 
     # then we prune them
     @worker.work(0) do


### PR DESCRIPTION
A job might be a process that will fork descendants, a worker just kill its immediate child. There will be lots of zombie processes in this case. 

So modified the kill_child function to kill all descendants. 
