### PR TITLE
Send term to child process before kill

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -14,6 +14,7 @@ namespace :resque do
       worker = Resque::Worker.new(*queues)
       worker.verbose = ENV['LOGGING'] || ENV['VERBOSE']
       worker.very_verbose = ENV['VVERBOSE']
+      worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
     rescue Resque::NoQueueError
       abort "set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work"
     end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -20,6 +20,8 @@ module Resque
     # Automatically set if a fork(2) fails.
     attr_accessor :cant_fork
 
+    attr_accessor :term_timeout
+
     attr_writer :to_s
 
     # Returns an array of all worker objects.
@@ -304,7 +306,7 @@ module Resque
         unless Process.waitpid(@child, Process::WNOHANG)
           log! "Sending TERM signal to child #{@child}"
           Process.kill("TERM", @child)
-          50.times do |i|
+          (term_timeout.to_f * 10).round.times do |i|
             sleep(0.1)
             return if Process.waitpid(@child, Process::WNOHANG)
           end


### PR DESCRIPTION
Gives child process 4 seconds (by default, configurable) to terminate itself upon receiving SIGTERM.

Closes #368.
