### PR TITLE
removing bundler and eliminating some test warnings

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -89,6 +89,8 @@ module Resque
     # removed without needing to restart workers using this method.
     def initialize(*queues)
       @queues = queues.map { |queue| queue.to_s.strip }
+      @shutdown = nil
+      @paused = nil
       validate_queues
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,12 @@
 require 'rubygems'
-require 'bundler'
-Bundler.setup(:default, :test)
-Bundler.require(:default, :test)
 
 dir = File.dirname(File.expand_path(__FILE__))
 $LOAD_PATH.unshift dir + '/../lib'
 $TESTING = true
 require 'test/unit'
+
+require 'redis/namespace'
+require 'resque'
 
 begin
   require 'leftright'


### PR DESCRIPTION
This commit removes bundler dependencies in the test helper and eliminates some test warnings.
