### PR TITLE
eliminate global vars, warnings, and fix test time

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -147,12 +147,14 @@ end
 class Time
   # Thanks, Timecop
   class << self
+    attr_accessor :fake_time
+
     alias_method :now_without_mock_time, :now
 
-    def now_with_mock_time
-      $fake_time || now_without_mock_time
+    def now
+      fake_time || now_without_mock_time
     end
-
-    alias_method :now, :now_with_mock_time
   end
+
+  self.fake_time = nil
 end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -355,16 +355,22 @@ context "Resque::Worker" do
   end
 
   test "very verbose works in the afternoon" do
-    require 'time'
-    $last_puts = ""
-    $fake_time = Time.parse("15:44:33 2011-03-02")
-    singleton = class << @worker; self end
-    singleton.send :define_method, :puts, lambda { |thing| $last_puts = thing }
+    begin
+      require 'time'
+      last_puts = ""
+      Time.fake_time = Time.parse("15:44:33 2011-03-02")
 
-    @worker.very_verbose = true
-    @worker.log("some log text")
+      @worker.extend(Module.new {
+        define_method(:puts) { |thing| last_puts = thing }
+      })
 
-    assert_match /\*\* \[15:44:33 2011-03-02\] \d+: some log text/, $last_puts
+      @worker.very_verbose = true
+      @worker.log("some log text")
+
+      assert_match /\*\* \[15:44:33 2011-03-02\] \d+: some log text/, last_puts
+    ensure
+      Time.fake_time = nil
+    end
   end
 
   test "Will call an after_fork hook after forking" do


### PR DESCRIPTION
This commit eliminates global variables, fixes many test warnings, and resets the `Time.now` monkey patch so that test times are sensical again.
