### PR TITLE
Automatically start polling with bookmarkable location hash

### DIFF
--- a/lib/resque/server/public/ranger.js
+++ b/lib/resque/server/public/ranger.js
@@ -35,9 +35,9 @@ $(function() {
     return false
   })
 
-  $('a[rel=poll]').click(function() {
-    var href = $(this).attr('href')
-    $(this).parent().text('Starting...')
+  var poll_start = function(el) {
+    var href = el.attr('href')
+    el.parent().text('Starting...')
     $("#main").addClass('polling')
 
     setInterval(function() {
@@ -47,8 +47,14 @@ $(function() {
       }})
     }, poll_interval * 1000)
 
+    location.hash = '#poll'
+
     return false
-  })
+  };
+
+  if (location.hash == '#poll') poll_start($('a[rel=poll]'))
+
+  $('a[rel=poll]').click(function() { return poll_start($(this)) })
 
   $('ul.failed li').hover(function() {
     $(this).addClass('hover');


### PR DESCRIPTION
This patch makes the URL bookmarkable when you click the "Live Poll" action, so that when you open the page from the bookmark or reload the page it will automatically start the live poll.

Handy for environments where you display resque-web with big ops monitors/TV screens.
