### PR TITLE
Backing up job payload to prevent data loss between LPOP and job.perform.

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -64,6 +64,18 @@ module Resque
     end
   end
 
+  # Enable/Disable lpoprpush
+  # Accepts:
+  #   truthy value
+  def use_lpoprpush=(new_use_lpoprpush)
+    @use_lpoprpush = new_use_lpoprpush
+  end
+
+  # Returns truthy value of whether or not lpoprpush is enabled
+  def use_lpoprpush?
+    @use_lpoprpush ||= false
+  end
+
   # The `before_first_fork` hook will be run in the **parent** process
   # only once, before forking to run the first job. Be careful- any
   # changes you make will be permanent for the lifespan of the
@@ -155,7 +167,7 @@ module Resque
   #
   # Returns a Ruby object.
   def pop(queue)
-    decode lpoprpush("queue:#{queue}", "backup-queue:#{queue}")
+    decode(use_lpoprpush? ? lpoprpush("queue:#{queue}", "backup-queue:#{queue}") : redis.lpop("queue:#{queue}"))
   end
 
   # Removes a job _from_ queue and pushes it on _to_ another queue.

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -159,7 +159,7 @@ module Resque
     end
 
     def do_perform(job, job_args)
-      Resque.remove_backup(queue, payload)
+      Resque.remove_backup(queue, payload) if Resque.use_lpoprpush?
       job.perform(*job_args)
     end    
 

--- a/test/job_hooks_test.rb
+++ b/test/job_hooks_test.rb
@@ -426,8 +426,10 @@ context "Resque::Job all hooks" do
   end
   
   test "the backup job is removed from the job's backup queue" do
+    Resque.stubs(:use_lpoprpush? => true)
     Resque.redis.rpush("backup-queue:testqueue", Resque.encode("class" => "VerifyBackupRemovalJob", "args" => ["foo" => "bar"]))
     perform_job("VerifyBackupRemovalJob", "foo" => "bar")
     assert_equal [], Resque.redis.lrange("backup-queue:testqueue", 0, -1)
+    Resque.unstub(:use_lpoprpush?)
   end  
 end

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -170,8 +170,10 @@ context "Resque" do
   end
 
   test "can backup items when they are pulled off a queue" do
+    Resque.stubs(:use_lpoprpush? => true)
     Resque.pop(:people)
     assert_equal({ 'name' => 'chris' }, Resque.decode(Resque.redis.lpop("backup-queue:people")))
+    Resque.unstub(:use_lpoprpush?)
   end  
 
   test "knows how big a queue is" do


### PR DESCRIPTION
Still need to re-enqueue the data. (In a subsequent patch.)
