### PR TITLE
Add timestamp and pid to verbose logging

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -517,9 +517,7 @@ module Resque
 
     # Log a message to STDOUT if we are verbose or very_verbose.
     def log(message)
-      if verbose
-        puts "*** #{message}"
-      elsif very_verbose
+      if verbose || very_verbose
         time = Time.now.strftime('%H:%M:%S %Y-%m-%d')
         puts "** [#{time}] #$$: #{message}"
       end


### PR DESCRIPTION
I had a time debugging one tricky issue and it was suprise to not have timestamp in Resque logs.
Found this pull request: https://github.com/defunkt/resque/pull/323

But pid information is useful as well. Code looks cleaner and all important info is logged.

Please apply this or #323 pull request, because without timestamp it's totally impossible to debug something with VERBOSE level, and using VVERBOSE in production is too chatty and overkill.
