### PR TITLE
When VVERBOSE logging, include the PID.

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -534,7 +534,7 @@ module Resque
         puts "*** #{message}"
       elsif very_verbose
         time = Time.now.strftime('%H:%M:%S %Y-%m-%d')
-        puts "** [#{time}] #$$: #{message}"
+        puts "** [#{time}] #{$$}: #{message}"
       end
     end
 


### PR DESCRIPTION
This fixes an apparent typo #$$ -> #{$$} in the log formatting.
