### PR TITLE
adding MultiQueue#poll to support a blocking pop with a timeout

### DIFF
--- a/test/multi_queue_test.rb
+++ b/test/multi_queue_test.rb
@@ -8,6 +8,13 @@ describe "Resque::MulitQueue" do
     redis.flushall
   end
 
+  it "poll times out and returns nil" do
+    foo   = Resque::Queue.new 'foo', redis
+    bar   = Resque::Queue.new 'bar', redis
+    queue = Resque::MultiQueue.new([foo, bar], redis)
+    assert_nil queue.poll(1)
+  end
+
   it "blocks on pop" do
     foo   = Resque::Queue.new 'foo', redis, coder
     bar   = Resque::Queue.new 'bar', redis, coder


### PR DESCRIPTION
MultiQueue#poll will allow us to use a blocking pop in our runloop, but timeout and check for process shutdown.
