### PR TITLE
Fixes #587 - don't share a redis connection between parent and child

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -142,6 +142,7 @@ module Resque
             Process.wait(@child)
           else
             procline "Processing #{job.queue} since #{Time.now.to_i}"
+            redis.client.reconnect # Don't share connection with parent
             perform(job, &block)
             exit! unless @cant_fork
           end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -440,4 +440,10 @@ describe "Resque::Worker" do
     assert_equal queue2, Resque::Failure.all(0)['queue']
     assert_equal 1, Resque::Failure.count
   end
+
+  it "reconnects to redis after fork" do
+    original_connection = Resque.redis.client.connection.instance_variable_get("@sock")
+    @worker.work(0)
+    assert_not_equal original_connection, Resque.redis.client.connection.instance_variable_get("@sock")
+  end
 end


### PR DESCRIPTION
Fixes #587
