### PR TITLE
Add the worker as a parameter to the before_first_fork hook.

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -245,7 +245,7 @@ module Resque
       enable_gc_optimizations
       register_signal_handlers
       prune_dead_workers
-      run_hook :before_first_fork
+      run_hook :before_first_fork, self
       register_worker
 
       # Fix buffering so we can `rake resque:work > resque.log` and

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -376,6 +376,16 @@ describe "Resque::Worker" do
 #     assert_equal 1, $BEFORE_FORK_CALLED
   end
 
+  it "Passes the worker to the before_first_fork hook" do
+    $BEFORE_FORK_WORKER = nil
+    Resque.before_first_fork = Proc.new { |w| $BEFORE_FORK_WORKER = w.id }
+    workerA = Resque::Worker.new(:jobs)
+
+    Resque::Job.create(:jobs, SomeJob, 20, '/tmp')
+    workerA.work(0)
+    assert_equal workerA.id, $BEFORE_FORK_WORKER
+  end
+
   it "Will call a before_fork hook before forking" do
     $BEFORE_FORK_CALLED = false
     Resque.before_fork = Proc.new { $BEFORE_FORK_CALLED = true }


### PR DESCRIPTION
This allows a hook to be excuted in the worker once that knows the worker information, for example if wanted to register the worker in a separate place, or log the info.
