### PR TITLE
Somehow, somewhere my Rails 2.3.14 application is getting a Rails.applic...

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -49,7 +49,7 @@ namespace :resque do
 
   # Preload app files if this is Rails
   task :preload => :setup do
-    if defined?(Rails) && Rails.respond_to?(:application)
+    if defined?(Rails) && Rails.respond_to?(:application) && Rails.version >= '3.0.0'
       # Rails 3
       Rails.application.eager_load!
     elsif defined?(Rails::Initializer)


### PR DESCRIPTION
...ation set which then triggers resque to think that my app is Rails 3 when it isn't. I can't find where it's getting set but since both versions of rails have a #version method, why not use it?
