### PR TITLE
1.x : no array wrap while running failure hooks

### DIFF
--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -217,7 +217,8 @@ module Resque
 
     def run_failure_hooks(exception)
       begin
-        failure_hooks.each { |hook| payload_class.send(hook, exception, *Array.wrap(args)) } unless @failure_hooks_ran
+        job_args = args || []
+        failure_hooks.each { |hook| payload_class.send(hook, exception, *job_args) } unless @failure_hooks_ran
       ensure
         @failure_hooks_ran = true
       end


### PR DESCRIPTION
When ActiveSupport isn't loaded, Array.wrap is undefined. This breaks failure_hooks, and the tests are blind to this issue because hoptoad/airbrake depend on ActiveSupport.

I could highlight this by failing tests after running "git clone ...; rvm use resquegemset; gem install bundler; bundle; gem uninstall activesupport". This yielded 5 errors on "NoMethodError: undefined method `wrap' for Array:Class" and a couple of likely related errors.

There was only a single occurrence of Array.wrap in the whole project. I tuned this by forwarding job args in the same fashion that resque code generally displays. 

The tests all pass again, even without activesupport !
