### PR TITLE
run failure hooks if job cannot be found

### DIFF
--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -105,57 +105,54 @@ module Resque
       job = payload_class
       job_args = args || []
       job_was_performed = false
-
+      # Execute before_perform hook. Abort the job gracefully if
+      # Resque::DontPerform is raised.
       begin
-        # Execute before_perform hook. Abort the job gracefully if
-        # Resque::DontPerform is raised.
-        begin
-          before_hooks.each do |hook|
-            job.send(hook, *job_args)
-          end
-        rescue DontPerform
-          return false
+        before_hooks.each do |hook|
+          job.send(hook, *job_args)
         end
+      rescue DontPerform
+        return false
+      end
 
-        # Execute the job. Do it in an around_perform hook if available.
-        if around_hooks.empty?
-          job.perform(*job_args)
-          job_was_performed = true
-        else
-          # We want to nest all around_perform plugins, with the last one
-          # finally calling perform
-          stack = around_hooks.reverse.inject(nil) do |last_hook, hook|
-            if last_hook
-              lambda do
-                job.send(hook, *job_args) { last_hook.call }
-              end
-            else
-              lambda do
-                job.send(hook, *job_args) do
-                  result = job.perform(*job_args)
-                  job_was_performed = true
-                  result
-                end
+      # Execute the job. Do it in an around_perform hook if available.
+      if around_hooks.empty?
+        job.perform(*job_args)
+        job_was_performed = true
+      else
+        # We want to nest all around_perform plugins, with the last one
+        # finally calling perform
+        stack = around_hooks.reverse.inject(nil) do |last_hook, hook|
+          if last_hook
+            lambda do
+              job.send(hook, *job_args) { last_hook.call }
+            end
+          else
+            lambda do
+              job.send(hook, *job_args) do
+                result = job.perform(*job_args)
+                job_was_performed = true
+                result
               end
             end
           end
-          stack.call
         end
+        stack.call
+      end
 
-        # Execute after_perform hook
-        after_hooks.each do |hook|
-          job.send(hook, *job_args)
-        end
+      # Execute after_perform hook
+      after_hooks.each do |hook|
+        job.send(hook, *job_args)
+      end
 
-        # Return true if the job was performed
-        return job_was_performed
+      # Return true if the job was performed
+      return job_was_performed
 
       # If an exception occurs during the job execution, look for an
       # on_failure hook then re-raise.
-      rescue Object => e
-        run_failure_hooks(e)
-        raise e
-      end
+    rescue Object => e
+      run_failure_hooks(e)
+      raise e
     end
 
     # Returns the actual class constant represented in this job's payload.


### PR DESCRIPTION
wraps the entire Resque::Job#perform method in a rescue. now it includes Resque::Job#payload_class.

Currently functionality is the job gets tossed if the job class cannot be found. At least now the failure hooks would run and potentially notify about the error.
