### PR TITLE
Problem with versions of Redis when using Resque scheduler

### DIFF
--- a/resque.gemspec
+++ b/resque.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "LICENSE", "README.markdown" ]
   s.rdoc_options      = ["--charset=UTF-8"]
 
-  s.add_dependency "redis-namespace", "~> 1.0.2"
+  s.add_dependency "redis-namespace", "~> 1.2.0"
   s.add_dependency "vegas",           "~> 0.1.2"
   s.add_dependency "sinatra",         ">= 0.9.2"
   s.add_dependency "multi_json",      "~> 1.0"


### PR DESCRIPTION
Hello,

I used resque and resque-scheduler - both from git master repos, and got problem when installing by bundle:

resque-scheduler needs redis ~> 3.0.1
resque needs redis < 3.0.0 (dependency by redis-namespace 1.0.2)

I tried changing dependency and bundle install has no problems

Please look at this issue
