### PR TITLE
Unregister signal handlers in child processes.

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -141,6 +141,7 @@ module Resque
             procline "Forked #{@child} at #{Time.now.to_i}"
             Process.wait(@child)
           else
+            unregister_signal_handlers unless @cant_fork
             procline "Processing #{job.queue} since #{Time.now.to_i}"
             perform(job, &block)
             exit! unless @cant_fork
@@ -282,6 +283,18 @@ module Resque
       end
 
       log! "Registered signals"
+    end
+
+    def unregister_signal_handlers
+      trap('TERM', 'DEFAULT')
+      trap('INT', 'DEFAULT')
+
+      begin
+        trap('QUIT', 'DEFAULT')
+        trap('USR1', 'DEFAULT')
+        trap('USR2', 'DEFAULT')
+      rescue ArgumentError
+      end
     end
 
     # Schedule this worker for shutdown. Will finish processing the


### PR DESCRIPTION
Signal handlers are inherited by child processes, and as a result the signal handlers for the child worker are completely inappropriate. This causes signals meant for exiting the process to be completely ignored.

For example:
- `trap('QUIT') { shutdown }` just sets `@shutdown = true`, which isn't used by the child process
- `trap('USR1') { kill_child }` will do nothing for the child since `@child` is `nil`
- TERM and INT just do `shutdown` and `kill_child`, so also do nothing
- USR2 will set `@paused = true` which also does nothing for the child process

I used the following script to confirm that signal handlers are inherited:

``` ruby
trap('USR1') { exit 42 }

child_pid = fork do
  loop {}
end

Process.kill('USR1', child_pid)

Process.wait

puts "child exited with code #{$?.exitstatus}"
```

Running it shows that the chid exited in the signal handler registered by the parent process.

This pull request simply unregisters the signal handlers so the default ruby signal handlers are used.
