### PR TITLE
Use HTTP_SCRIPT_NAME aswell because Apache sets it

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -40,7 +40,11 @@ module Resque
       alias_method :u, :url_path
 
       def path_prefix
-        request.env['SCRIPT_NAME']
+        if request.env['SCRIPT_NAME'] == "" and request.env["HTTP_SCRIPT_NAME"]
+          request.env['HTTP_SCRIPT_NAME']
+        else
+          request.env['SCRIPT_NAME']
+        end
       end
 
       def class_if_current(path = '')


### PR DESCRIPTION
Apache sets HTTP_SCRIPT_NAME and not SCRIPT_NAME

Even when using:
RequestHeader set SCRIPT_NAME /resque-web

I ran rake tests, 0 fails, 0 errors.
