### PR TITLE
Can't get worker pid from Resque.workers anymore

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -23,6 +23,7 @@ namespace :resque do
           abort "env var BACKGROUND is set, which requires ruby >= 1.9"
       end
       Process.daemon(true)
+      worker.reset_pid
     end
 
     if ENV['PIDFILE']

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -493,7 +493,12 @@ module Resque
 
     # Returns Integer PID of running worker
     def pid
-      Process.pid
+      @pid ||= to_s.split(":")[1].to_i
+    end
+
+    def reset_pid
+      @pid = nil
+      @to_s = nil
     end
 
     # Returns an Array of string pids of all the other workers on this


### PR DESCRIPTION
Following 60b157d the Worker#pid method no longer references the @pid instance variable. So now, Worker#pid always returns the _current_ process, even if it's not the local worker object. This has implications for, as an example (and my particular use case), a rake task which kills the resque workers to restart them.
