### PR TITLE
Support passing of args in around_perform

### DIFF
--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -134,8 +134,12 @@ module Resque
               end
             else
               lambda do
-                job.send(hook, *job_args) do
-                  result = job.perform(*job_args)
+                job.send(hook, *job_args) do |*args|
+                  # If the hook yields its own arguments use those,
+                  # else use the original job_args
+                  args_to_pass = (args.empty?) ? job_args : args
+                  result = job.perform(*args_to_pass)
+                  
                   job_was_performed = true
                   result
                 end

--- a/test/job_hooks_test.rb
+++ b/test/job_hooks_test.rb
@@ -111,6 +111,22 @@ context "Resque::Job around_perform" do
     assert_equal history, [:start_around_perform, :perform, :finish_around_perform]
   end
 
+  class ::AroundPerformJobWithItsOwnArgsYielded
+    def self.perform(which_args)
+      which_args.shift if which_args.length > 1
+    end
+    def self.around_perform_change_args(which_args)
+      which_args << "those passed from around"
+      yield(which_args)
+    end    
+  end
+
+  test "it uses the args passed to yield" do
+    result = perform_job(AroundPerformJobWithItsOwnArgsYielded, which_args=["those passed to perform"])
+    assert_equal true, result, "perform returned true"
+    assert_equal which_args, ["those passed from around"]
+  end
+
   class ::AroundPerformJobFailsBeforePerforming
     def self.perform(history)
       history << :perform


### PR DESCRIPTION
Sometimes it's useful for an around_perform hook to be able to pass its
own arguments to perform. This commit lets you do just that! If no args
are passed in yield, it will still use the original args passed to
`enqueue`.
