### PR TITLE
Really (really?) fix tab highlight

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -30,6 +30,10 @@ module Resque
         url_path request.path_info.sub('/','').split('/')[0].downcase
       end
 
+      def current_subtab
+        url_path request.path_info.sub('/','').split('/')[0, 2].join('/').downcase
+      end
+
       def current_page
         url_path request.path_info.sub('/','')
       end
@@ -44,7 +48,7 @@ module Resque
       end
 
       def class_if_current(path = '')
-        'class="current"' if current_page[0, path.size] == path
+        'class="current"' if [current_section, current_subtab].include?(path)
       end
 
       def tab(name)


### PR DESCRIPTION
**Problem**
A bug occur when two tabs begin with the same letters and the longest one is selected.

For instance :
- **test**
- **test_bug** (current)
- another

test and test_bug are both highlighted.

**Solution**
To solve this problem I created a new method called **current_subtab** and now **class_if_current** checks if current path is equal to the current section or the current subtab.
