### PR TITLE
Add the ability to specify low-priority queues after a splat and preserve order

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -223,9 +223,11 @@ module Resque
 
     # Returns a list of queues to use when searching for a job.
     # A splat ("*") means you want every queue (in alpha order) - this
-    # can be useful for dynamically adding new queues.
+    # can be useful for dynamically adding new queues. Low priority queues
+    # can be placed after a splat to ensure execution after all other dynamic
+    # queues.
     def queues
-      @queues.map {|queue| queue == "*" ? Resque.queues.sort : queue }.flatten.uniq
+      @queues.map {|queue| queue == "*" ? (Resque.queues - @queues).sort : queue }.flatten.uniq
     end
 
     # Not every platform supports fork. Here we do our magic to

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -171,6 +171,15 @@ describe "Resque::Worker" do
     assert_equal 0, Resque.size(:beer)
   end
 
+  it "preserves order with a wildcard in the middle of a list" do
+    Resque::Job.create(:critical, GoodJob)
+    Resque::Job.create(:bulk, GoodJob)
+
+    worker = Resque::Worker.new(:beer, "*", :bulk)
+
+    assert_equal %w( beer critical jobs bulk ), worker.queues
+  end
+
   it "processes * queues in alphabetical order" do
     Resque::Job.create(:high, GoodJob)
     Resque::Job.create(:critical, GoodJob)


### PR DESCRIPTION
This simple change allows queues to be specified with a low-priority queue as well. For example, "critical,*,bulk" will ensure that critical is at the beginning and bulk is at the end with everything else being in between, alph order.
