### PR TITLE
Rake tasks fail when Rails.application.eager_load! is not defined

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -50,7 +50,7 @@ namespace :resque do
 
   # Preload app files if this is Rails
   task :preload => :setup do
-    if defined?(Rails) && Rails.respond_to?(:application)
+    if defined?(Rails) && Rails.respond_to?(:application) && Rails.application.respond_to?(:eager_load!)
       # Rails 3
       Rails.application.eager_load!
     elsif defined?(Rails::Initializer)


### PR DESCRIPTION
Double check to make sure Rails.application.eager_load! is defined before calling it.

I'm using standalone_migrations which creates a Rails.application but it doesn't have eager_load! on it.
