### PR TITLE
Only filter backtrace for client exceptions

### DIFF
--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -43,8 +43,12 @@ module Resque
       end
 
       def filter_backtrace(backtrace)
-        index = backtrace.index { |item| item.include?('/lib/resque/job.rb') }
-        backtrace.first(index.to_i)
+        index = backtrace.index { |item| item.include?('/lib/resque/job.rb') }.to_i
+        if index == 0
+          backtrace
+        else
+          backtrace.first(index.to_i)
+        end
       end
     end
   end

--- a/test/resque_failure_redis_test.rb
+++ b/test/resque_failure_redis_test.rb
@@ -20,4 +20,21 @@ describe "Resque::Failure::Redis" do
     @redis_backend.save
     Resque::Failure::Redis.all # should not raise an error
   end
+
+  it "only shows the backtrace for client code" do
+    backtrace = ["show", "/lib/resque/job.rb", "hide"]
+
+    failure = Resque::Failure::Redis.new(nil, nil, nil, nil)
+    filtered_backtrace = failure.filter_backtrace(backtrace)
+
+    assert_equal ["show"], filtered_backtrace
+  end
+  it "shows the whole backtrace when the exception happens before client code is reached" do
+    backtrace = ["everything", "is", "shown"]
+
+    failure = Resque::Failure::Redis.new(nil, nil, nil, nil)
+    filtered_backtrace = failure.filter_backtrace(backtrace)
+
+    assert_equal ["everything", "is", "shown"], filtered_backtrace
+  end
 end


### PR DESCRIPTION
The backtrace filtering will now show something when the exception
originates prior to resque/job.rb. This can happen when there is a
bug in resque, or when a hook manages to crash before job has a
chance to start up. This allows users a chance to debug instead of
just giving them an exception message with no backtrace at all.
