### PR TITLE
Don't invoke :before_fork and :after_fork hooks when not forking - fixes fd leak when used with NewRelic

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -183,7 +183,7 @@ module Resque
     # Processes a given job in the child.
     def perform(job)
       begin
-        run_hook :after_fork, job
+        run_hook :after_fork, job unless @cant_fork
         job.perform
       rescue Object => e
         log "#{job.inspect} failed: #{e.inspect}"

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -421,6 +421,19 @@ context "Resque::Worker" do
     assert $AFTER_FORK_CALLED
   end
 
+  test "Will not call an after_fork hook when the worker can't fork" do
+    Resque.redis.flushall
+    $AFTER_FORK_CALLED = false
+    Resque.after_fork = Proc.new { $AFTER_FORK_CALLED = true }
+    workerA = Resque::Worker.new(:jobs)
+    workerA.cant_fork = true
+
+    assert !$AFTER_FORK_CALLED
+    Resque::Job.create(:jobs, SomeJob, 20, '/tmp')
+    workerA.work(0)
+    assert !$AFTER_FORK_CALLED
+  end
+
   test "returns PID of running process" do
     assert_equal @worker.to_s.split(":")[1].to_i, @worker.pid
   end


### PR DESCRIPTION
On platforms that don't support `Kernel.fork` or in situations where you explicitly don't want to fork (by setting `worker.cant_fork = true` explicitly) we musn't invoke the `:before_fork` hooks and the `:after_fork` hooks.

In my case setting `worker.cant_fork = true` was causing a file-descriptor leak and gradual CPU usage increase in combination with the NewRelic agent. The NewRelic agent creates a pipe with the (to be created) child process in its `Resque.before_fork` hook for each job performed. But because we prevented the proces from forking (by settings `worker.cant_fork = true`) these pipe would never be closed (since closing the pipes is done in the exit handling of the child process).

This patch the 'normal' case where we do fork unchanged. It makes sure that `before_fork` and `after_fork` hooks are only called when we know for sure that we will fork a worker.
