### PR TITLE
added a table of contents to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,14 +30,62 @@ The Resque frontend tells you what workers are doing, what workers are
 not doing, what queues you're using, what's in those queues, provides
 general usage stats, and helps you track failures.
 
-
 The Blog Post
 -------------
 
 For the backstory, philosophy, and history of Resque's beginnings,
 please see [the blog post][0].
 
+Table Of Contents
+-----------------
 
+   * [Overview](#section_Overview)
+   * [Jobs](#section_Jobs)
+      * [Persistence](#section_Jobs_Persistence)
+      * [send_later / async](#section_Jobs_send_later_async)
+      * [Failure](#section_Jobs_Failure)
+   * [Workers](#section_Workers)
+      * [Logging](#section_Workers_Logging)
+      * [Process IDs](#section_Workers_Process_IDs)
+      * [Running in the background](#section_Workers_Running_in_the_background)
+      * [Polling frequency](#section_Workers_Polling_frequency)
+      * [Priorities and Queue Lists](#section_Workers_Priorities_and_Queue_Lists)
+      * [Running All Queues](#section_Workers_Running_All_Queues)
+      * [Running Multiple Workers](#section_Workers_Running_Multiple_Workers)
+      * [Forking](#section_Workers_Forking)
+      * [Parents and Children](#section_Workers_Parents_and_Children)
+      * [Signals](#section_Workers_Signals)
+      * [Mysql::Error: MySQL server has gone away](#section_Workers_Mysql_Error_MySQL_server_has_gone_away)
+   * [The Front End](#section_The_Front_End)
+      * [Standalone](#section_The_Front_End_Standalone)
+      * [Passenger](#section_The_Front_End_Passenger)
+      * [Rack::URLMap](#section_The_Front_End_Rack_URLMap)
+      * [Rails 3](#section_The_Front_End_Rails_3)
+   * [Resque vs DelayedJob](#section_Resque_vs_DelayedJob)
+   * [Installing Redis](#section_Installing_Redis)
+      * [Homebrew](#section_Installing_Redis_Homebrew)
+      * [View Resque](#section_Installing_Redis_Via_Resque)
+   * [Resque Dependencies](#section_Resque_Dependencies)
+   * [Installing Resque](#section_Installing_Resque)
+      * [In a Rack app, as a gem](#section_Installing_Resque_In_a_Rack_app_as_a_gem)
+      * [In a Rails 2.x app, as a gem](#section_Installing_Resque_In_a_Rails_2_x_app_as_a_gem)
+      * [In a Rails 2.x app, as a plugin](#section_Installing_Resque_In_a_Rails_2_x_app_as_a_plugin)
+      * [In a Rails 3 app, as a gem](#section_Installing_Resque_In_a_Rails_3_app_as_a_gem)
+   * [Configuration](#section_Configuration)
+   * [Plugins and Hooks](#section_Plugins_and_Hooks)
+   * [Namespaces](#section_Namespaces)
+   * [Demo](#section_Demo)
+   * [Monitoring](#section_Monitoring)
+      * [god](#section_Monitoring_god)
+      * [monit](#section_Monitoring_monit)
+   * [Questions](#section_Questions)
+   * [Development](#section_Development)
+   * [Contributing](#section_Contributing)
+   * [Mailing List](#section_Mailing_List)
+   * [Meta](#section_Meta)
+   * [Author](#section_Author)
+
+<a name='section_Overview'></a>
 Overview
 --------
 
@@ -107,6 +155,7 @@ multiple machines. In fact they can be run anywhere with network
 access to the Redis server.
 
 
+<a name='section_Jobs'></a>
 Jobs
 ----
 
@@ -133,6 +182,7 @@ sense. You could easily be spidering sites and sticking data which
 needs to be crunched later into a queue.
 
 
+<a name='section_Jobs_Persistence'></a>
 ### Persistence
 
 Jobs are persisted to queues as JSON objects. Let's take our `Archive`
@@ -178,6 +228,7 @@ If your jobs were run against marshaled objects, they could
 potentially be operating on a stale record with out-of-date information.
 
 
+<a name='section_Jobs_send_later_async'></a>
 ### send_later / async
 
 Want something like DelayedJob's `send_later` or the ability to use
@@ -187,6 +238,7 @@ directory for goodies.
 We plan to provide first class `async` support in a future release.
 
 
+<a name='section_Jobs_Failure'></a>
 ### Failure
 
 If a job raises an exception, it is logged and handed off to the
@@ -199,6 +251,7 @@ Keep this in mind when writing your jobs: you may want to throw
 exceptions you would not normally throw in order to assist debugging.
 
 
+<a name='section_Workers'></a>
 Workers
 -------
 
@@ -249,6 +302,7 @@ We don't want the `git_timeout` as high as 10 minutes in our web app,
 but in the Resque workers it's fine.
 
 
+<a name='section_Workers_Logging'></a>
 ### Logging
 
 Workers support basic logging to STDOUT. If you start them with the
@@ -258,6 +312,7 @@ variable.
 
     $ VVERBOSE=1 QUEUE=file_serve rake environment resque:work
 
+<a name='section_Workers_Process_IDs'></a>
 ### Process IDs (PIDs)
 
 There are scenarios where it's helpful to record the PID of a resque
@@ -265,6 +320,7 @@ worker process.  Use the PIDFILE option for easy access to the PID:
 
     $ PIDFILE=./resque.pid QUEUE=file_serve rake environment resque:work
 
+<a name='section_Workers_Running_in_the_background'></a>
 ### Running in the background
 
 (Only supported with ruby >= 1.9). There are scenarios where it's helpful for
@@ -275,6 +331,7 @@ worker is started.
     $ PIDFILE=./resque.pid BACKGROUND=yes QUEUE=file_serve \
         rake environment resque:work
 
+<a name='section_Workers_Polling_frequency'></a>
 ### Polling frequency
 
 You can pass an INTERVAL option which is a float representing the polling frequency. 
@@ -282,6 +339,7 @@ The default is 5 seconds, but for a semi-active app you may want to use a smalle
 
     $ INTERVAL=0.1 QUEUE=file_serve rake environment resque:work
 
+<a name='section_Workers_Priorities_and_Queue_Lists'></a>
 ### Priorities and Queue Lists
 
 Resque doesn't support numeric priorities but instead uses the order
@@ -317,6 +375,7 @@ And workers on our specialized archive machine with this command:
     $ QUEUE=archive rake resque:work
 
 
+<a name='section_Workers_Running_All_Queues'></a>
 ### Running All Queues
 
 If you want your workers to work off of every queue, including new
@@ -327,6 +386,7 @@ queues created on the fly, you can use a splat:
 Queues will be processed in alphabetical order.
 
 
+<a name='section_Workers_Running_Multiple_Workers'></a>
 ### Running Multiple Workers
 
 At GitHub we use god to start and stop multiple workers. A sample god
@@ -342,6 +402,7 @@ This will spawn five Resque workers, each in its own thread. Hitting
 ctrl-c should be sufficient to stop them all.
 
 
+<a name='section_Workers_Forking'></a>
 ### Forking
 
 On certain platforms, when a Resque worker reserves a job it
@@ -384,6 +445,7 @@ complicated.
 Workers instead handle their own state.
 
 
+<a name='section_Workers_Parents_and_Children'></a>
 ### Parents and Children
 
 Here's a parent / child pair doing some work:
@@ -405,6 +467,7 @@ waiting for work on:
     92099 resque: Waiting for file_serve,warm_cache
 
 
+<a name='section_Workers_Signals'></a>
 ### Signals
 
 Resque workers respond to a few different signals:
@@ -427,6 +490,7 @@ If you want to stop processing jobs, but want to leave the worker running
 (for example, to temporarily alleviate load), use `USR2` to stop processing,
 then `CONT` to start it again.
 
+<a name='section_Workers_Mysql_Error_MySQL_server_has_gone_away'></a>
 ### Mysql::Error: MySQL server has gone away
 
 If your workers remain idle for too long they may lose their MySQL
@@ -434,6 +498,7 @@ connection. If that happens we recommend using [this
 Gist](http://gist.github.com/238999).
 
 
+<a name='section_The_Front_End'></a>
 The Front End
 -------------
 
@@ -442,6 +507,7 @@ your queue.
 
 ![The Front End](https://img.skitch.com/20110528-pc67a8qsfapgjxf5gagxd92fcu.png)
 
+<a name='section_The_Front_End_Standalone'></a>
 ### Standalone
 
 If you've installed Resque as a gem running the front end standalone is easy:
@@ -465,6 +531,7 @@ or set the Redis connection string if you need to do something like select a dif
 
     $ resque-web -p 8282 -r localhost:6379:2
 
+<a name='section_The_Front_End_Passenger'></a>
 ### Passenger
 
 Using Passenger? Resque ships with a `config.ru` you can use. See
@@ -473,6 +540,7 @@ Phusion's guide:
 Apache: <http://www.modrails.com/documentation/Users%20guide%20Apache.html#_deploying_a_rack_based_ruby_application>
 Nginx: <http://www.modrails.com/documentation/Users%20guide%20Nginx.html#deploying_a_rack_app>
 
+<a name='section_The_Front_End_Rack_URLMap'></a>
 ### Rack::URLMap
 
 If you want to load Resque on a subpath, possibly alongside other
@@ -489,6 +557,7 @@ run Rack::URLMap.new \
 Check `examples/demo/config.ru` for a functional example (including
 HTTP basic auth).
 
+<a name='section_The_Front_End_Rails_3'></a>
 ### Rails 3
 
 You can also mount Resque on a subpath in your existing Rails 3 app by adding `require 'resque/server'` to the top of your routes file or in an initializer then adding this to `routes.rb`:
@@ -498,6 +567,7 @@ mount Resque::Server.new, :at => "/resque"
 ```
 
 
+<a name='section_Resque_vs_DelayedJob'></a>
 Resque vs DelayedJob
 --------------------
 
@@ -544,6 +614,7 @@ In no way is Resque a "better" DelayedJob, so make sure you pick the
 tool that's best for your app.
 
 
+<a name='section_Installing_Redis'></a>
 Installing Redis
 ----------------
 
@@ -552,6 +623,7 @@ Resque requires Redis 0.900 or higher.
 Resque uses Redis' lists for its queues. It also stores worker state
 data in Redis.
 
+<a name='section_Installing_Redis_Homebrew'></a>
 #### Homebrew
 
 If you're on OS X, Homebrew is the simplest way to install Redis:
@@ -561,6 +633,7 @@ If you're on OS X, Homebrew is the simplest way to install Redis:
 
 You now have a Redis daemon running on 6379.
 
+<a name='section_Installing_Redis_Via_Resque'></a>
 #### Via Resque
 
 Resque includes Rake tasks (thanks to Ezra's redis-rb) that will
@@ -585,6 +658,7 @@ The demo is probably the best way to figure out how to put the parts
 together. But, it's not that hard.
 
 
+<a name='section_Resque_Dependencies'></a>
 Resque Dependencies
 -------------------
 
@@ -592,9 +666,11 @@ Resque Dependencies
     $ bundle install
 
 
+<a name='section_Installing_Resque'></a>
 Installing Resque
 -----------------
 
+<a name='section_Installing_Resque_In_a_Rack_app_as_a_gem'></a>
 ### In a Rack app, as a gem
 
 First install the gem.
@@ -629,6 +705,7 @@ Alternately you can define a `resque:setup` hook in your Rakefile if you
 don't want to load your app every time rake runs.
 
 
+<a name='section_Installing_Resque_In_a_Rails_2_x_app_as_a_gem'></a>
 ### In a Rails 2.x app, as a gem
 
 First install the gem.
@@ -660,6 +737,7 @@ Don't forget you can define a `resque:setup` hook in
 `lib/tasks/whatever.rake` that loads the `environment` task every time.
 
 
+<a name='section_Installing_Resque_In_a_Rails_2_x_app_as_a_plugin'></a>
 ### In a Rails 2.x app, as a plugin
 
     $ ./script/plugin install git://github.com/defunkt/resque
@@ -675,6 +753,7 @@ Don't forget you can define a `resque:setup` hook in
 `lib/tasks/whatever.rake` that loads the `environment` task every time.
 
 
+<a name='section_Installing_Resque_In_a_Rails_3_app_as_a_gem'></a>
 ### In a Rails 3 app, as a gem
 
 First include it in your Gemfile.
@@ -709,6 +788,7 @@ Don't forget you can define a `resque:setup` hook in
 `lib/tasks/whatever.rake` that loads the `environment` task every time.
 
 
+<a name='section_Configuration'></a>
 Configuration
 -------------
 
@@ -760,6 +840,7 @@ Resque.inline = ENV['RAILS_ENV'] == "cucumber"
 ```
 
 
+<a name='section_Plugins_and_Hooks'></a>
 Plugins and Hooks
 -----------------
 
@@ -771,6 +852,7 @@ using hooks (such as `Resque.after_fork`), see
 [docs/HOOKS.md](http://github.com/defunkt/resque/blob/master/docs/HOOKS.md).
 
 
+<a name='section_Namespaces'></a>
 Namespaces
 ----------
 
@@ -792,6 +874,7 @@ We recommend sticking this in your initializer somewhere after Redis
 is configured.
 
 
+<a name='section_Demo'></a>
 Demo
 ----
 
@@ -801,15 +884,18 @@ processed in the background.
 Try it out by looking at the README, found at `examples/demo/README.markdown`.
 
 
+<a name='section_Monitoring'></a>
 Monitoring
 ----------
 
+<a name='section_Monitoring_god'></a>
 ### god
 
 If you're using god to monitor Resque, we have provided example
 configs in `examples/god/`. One is for starting / stopping workers,
 the other is for killing workers that have been running too long.
 
+<a name='section_Monitoring_monit'></a>
 ### monit
 
 If you're using monit, `examples/monit/resque.monit` is provided free
@@ -817,6 +903,7 @@ of charge. This is **not** used by GitHub in production, so please
 send patches for any tweaks or improvements you can make to it.
 
 
+<a name='section_Questions'></a>
 Questions
 ---------
 
@@ -824,6 +911,7 @@ Please add them to the [FAQ](https://github.com/defunkt/resque/wiki/FAQ) or
 ask on the Mailing List. The Mailing List is explained further below
 
 
+<a name='section_Development'></a>
 Development
 -----------
 
@@ -857,6 +945,7 @@ Feel free to ping the mailing list with your problem and we'll try to
 sort it out.
 
 
+<a name='section_Contributing'></a>
 Contributing
 ------------
 
@@ -871,6 +960,7 @@ Once you've made your great commits:
 5. That's it!
 
 
+<a name='section_Mailing_List'></a>
 Mailing List
 ------------
 
@@ -881,6 +971,7 @@ including unsubscribe information.
 The archive can be found at <http://librelist.com/browser/resque/>.
 
 
+<a name='section_Meta'></a>
 Meta
 ----
 
@@ -895,6 +986,7 @@ Meta
 This project uses [Semantic Versioning][sv].
 
 
+<a name='section_Author'></a>
 Author
 ------
 


### PR DESCRIPTION
There are so many sections that this table of contents might be too long (of course this is an indicator maybe README is too long too).  Another option is to only include top-level headers in TOC.  Lemme know what you think.
