### PR TITLE
Pass exceptions raised by the worker into the Failure backend

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -154,8 +154,9 @@ module Resque
         end
       end
 
-    ensure
       unregister_worker
+    rescue Exception => exception
+      unregister_worker(exception)
     end
 
     # DEPRECATED. Processes a single job. If none is given, it will
@@ -370,7 +371,7 @@ module Resque
     end
 
     # Unregisters ourself as a worker. Useful when shutting down.
-    def unregister_worker
+    def unregister_worker(exception = nil)
       # If we're still processing a job, make sure it gets logged as a
       # failure.
       if (hash = processing) && !hash.empty?
@@ -378,7 +379,7 @@ module Resque
         # Ensure the proper worker is attached to this job, even if
         # it's not the precise instance that died.
         job.worker = self
-        job.fail(DirtyExit.new)
+        job.fail(exception || DirtyExit.new)
       end
 
       redis.srem(:workers, self)

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -32,11 +32,20 @@ context "Resque::Worker" do
     end
   end
 
-  test "fails uncompleted jobs on exit" do
+  test "fails uncompleted jobs with DirtyExit by default on exit" do
     job = Resque::Job.new(:jobs, {'class' => 'GoodJob', 'args' => "blah"})
     @worker.working_on(job)
     @worker.unregister_worker
     assert_equal 1, Resque::Failure.count
+    assert_equal('Resque::DirtyExit', Resque::Failure.all['exception'])
+  end
+
+  test "fails uncompleted jobs with worker exception on exit" do
+    job = Resque::Job.new(:jobs, {'class' => 'GoodJob', 'args' => "blah"})
+    @worker.working_on(job)
+    @worker.unregister_worker(StandardError.new)
+    assert_equal 1, Resque::Failure.count
+    assert_equal('StandardError', Resque::Failure.all['exception'])
   end
 
   class ::SimpleJobWithFailureHandling


### PR DESCRIPTION
We're having trouble upgrading Resque and came across #655. With a bit of investigating, we realized that worker failures were not passed to the failure backend, which made debugging difficult. This fixes that. 
