### PR TITLE
Retry reconnect

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -176,7 +176,7 @@ module Resque
       tries = 0
       begin
         redis.client.reconnect
-      rescue BaseConnectionError => e
+      rescue Redis::BaseConnectionError => e
         if (tries += 1) < 3
           log "Error reserving job: #{e.inspect}"
           log e.backtrace.join("\n")


### PR DESCRIPTION
Continuing on from #677 -- once we were passing exceptions raised in the worker to the failure backend, we found that we had a lot of Redis connection timeouts due to the introduction of the reconnect in #587. We found that rescuing and retrying in those cases solved the issue. 
