### PR TITLE
Let yajl-ruby float up to version 1.1.0 from 0.8.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 
 group :test do
   gem "rack-test", "~> 0.5"
-  gem "yajl-ruby", "~>0.8.2", :platforms => :mri
+  gem "yajl-ruby", :platforms => :mri
   gem "json", "~>1.5.3", :platforms => [:jruby, :rbx]
   gem "i18n"
   gem "minitest"


### PR DESCRIPTION
No need to lock this down for tests
