### PR TITLE
**Always** split `command` output using $/ for Windows.

### DIFF
--- a/examples/god/stale.god
+++ b/examples/god/stale.god
@@ -7,7 +7,7 @@ STALE_EXEMPTIONS = ["imports"]
 Thread.new do
   loop do
     begin
-      lines = `ps -e -o pid,command | grep [r]esque`.split("\n")
+      lines = `ps -e -o pid,command | grep [r]esque`.split($/)
       lines.each do |line|
         parts   = line.split(' ')
         next if parts[-2] != "at"

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -548,7 +548,7 @@ module Resque
     # Returns an Array of string pids of all the other workers on this
     # machine. Useful when pruning dead workers on startup.
     def windows_worker_pids
-      `tasklist  /FI "IMAGENAME eq ruby.exe" /FO list`.split("\n").select { |line| line =~ /^PID:/}.collect{ |line| line.gsub /PID:\s+/, '' }
+      `tasklist  /FI "IMAGENAME eq ruby.exe" /FO list`.split($/).select { |line| line =~ /^PID:/}.collect{ |line| line.gsub /PID:\s+/, '' }
     end
 
     # Find Resque worker pids on Linux and OS X.
@@ -571,7 +571,7 @@ module Resque
        active_worker_pids = []
        output = %x[#{command}]  # output format of ps must be ^<PID> <COMMAND WITH ARGS>
        raise 'System call for ps command failed. Please make sure that you have a compatible ps command in the path!' unless $?.success?
-       output.split("\n").each{|line| 
+       output.split($/).each{|line| 
         next unless line =~ /resque/i
         next if line =~ /resque-web/
         active_worker_pids.push line.split(' ')[0]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,7 +31,7 @@ at_exit do
 
   exit_code = MiniTest::Unit.new.run(ARGV)
 
-  processes = `ps -A -o pid,command | grep [r]edis-test`.split("\n")
+  processes = `ps -A -o pid,command | grep [r]edis-test`.split($/)
   pids = processes.map { |process| process.split(" ")[0] }
   puts "Killing test redis server..."
   pids.each { |pid| Process.kill("TERM", pid.to_i) }


### PR DESCRIPTION
Windows uses "\r\n" as the new-line character, so splitting by "\n" is problematic. Instead, use the special "$/" variable.
