### PR TITLE
Normalized Ruby style.

### DIFF
--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -31,9 +31,10 @@ module Resque
     # Returns the current backend class. If none has been set, falls
     # back to `Resque::Failure::Redis`
     def self.backend
-      return @backend if @backend
-      require 'resque/failure/redis'
-      @backend = Failure::Redis
+      @backend ||= begin
+                     require 'resque/failure/redis'
+                     Failure::Redis
+                   end
     end
 
     # Returns the int count of how many failures we have seen.
@@ -74,25 +75,28 @@ module Resque
     # Requeues all failed jobs in a specific queue.
     # Queue name should be a string.
     def self.requeue_queue(queue)
-      i=0
-      while job = Resque::Failure.all(i)
+      index = 0
+
+      while job = Resque::Failure.all(index)
         if job['queue'] == queue
-          Resque::Failure.requeue(i)
-        end  
-        i+=1
+          Resque::Failure.requeue(index)
+        end
+
+        index += 1
       end
     end
 
     # Removes all failed jobs in a specific queue.
     # Queue name should be a string.
     def self.remove_queue(queue)
-      i=0
-      while job = Resque::Failure.all(i)
+      index = 0
+
+      while job = Resque::Failure.all(index)
         if job['queue'] == queue
           # This will remove the failure from the array so do not increment the index.
-          Resque::Failure.remove(i)
+          Resque::Failure.remove(index)
         else
-          i+=1    
+          index +=1
         end
       end
     end

--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -46,9 +46,10 @@ module Resque
       end
 
       names = camel_cased_word.split('::')
-      names.shift if names.empty? || names.first.empty?
+      names.shift if (names.empty? || names.first.empty?)
 
       constant = Object
+
       names.each do |name|
         args = Module.method(:const_get).arity != 1 ? [false] : []
 
@@ -58,6 +59,7 @@ module Resque
           constant = constant.const_missing(name)
         end
       end
+
       constant
     end
   end

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -30,8 +30,8 @@ module Resque
     attr_reader :payload
 
     def initialize(queue, payload)
-      @queue = queue
-      @payload = payload
+      @queue             = queue
+      @payload           = payload
       @failure_hooks_ran = false
     end
 
@@ -45,8 +45,10 @@ module Resque
 
       if Resque.inline?
         # Instantiating a Resque::Job and calling perform on it so callbacks run
-        # decode(encode(args)) to ensure that args are normalized in the same manner as a non-inline job
-        new(:inline, {'class' => klass, 'args' => decode(encode(args))}).perform
+        # decode(encode(args)) to ensure that args are normalized in the same
+        # manner as a non-inline job
+        payload = {'class' => klass, 'args' => decode(encode(args))}
+        new(:inline, payload).perform
       else
         Resque.push(queue, 'class' => klass.to_s, 'args' => args)
       end
@@ -77,8 +79,8 @@ module Resque
     # depending on the size of your queue, as it loads all jobs into
     # a Ruby array before processing.
     def self.destroy(queue, klass, *args)
-      klass = klass.to_s
-      queue = "queue:#{queue}"
+      klass     = klass.to_s
+      queue     = "queue:#{queue}"
       destroyed = 0
 
       if args.empty?
@@ -88,7 +90,8 @@ module Resque
           end
         end
       else
-        destroyed += redis.lrem(queue, 0, encode('class' => klass, 'args' => args))
+        payload = encode('class' => klass, 'args' => args)
+        destroyed += redis.lrem(queue, 0, payload)
       end
 
       destroyed
@@ -97,8 +100,9 @@ module Resque
     # Given a string queue name, returns an instance of Resque::Job
     # if any jobs are available. If not, returns nil.
     def self.reserve(queue)
-      return unless payload = Resque.pop(queue)
-      new(queue, payload)
+      if (payload = Resque.pop(queue))
+        new(queue, payload)
+      end
     end
 
     # Attempts to perform the work represented by this job instance.
@@ -106,7 +110,7 @@ module Resque
     # arguments given in the payload.
     def perform
       job = payload_class
-      job_args = args || []
+      job_args = (args || [])
       job_was_performed = false
 
       begin
@@ -142,6 +146,7 @@ module Resque
               end
             end
           end
+
           stack.call
         end
 
@@ -152,10 +157,9 @@ module Resque
 
         # Return true if the job was performed
         return job_was_performed
-
-      # If an exception occurs during the job execution, look for an
-      # on_failure hook then re-raise.
       rescue Object => e
+        # If an exception occurs during the job execution, look for an
+        # on_failure hook then re-raise.
         run_failure_hooks(e)
         raise e
       end
@@ -182,11 +186,13 @@ module Resque
     # the Failure module.
     def fail(exception)
       run_failure_hooks(exception) if has_payload_class?
-      Failure.create \
+
+      Failure.create(
         :payload   => payload,
         :exception => exception,
         :worker    => worker,
         :queue     => queue
+      )
     end
 
     # Creates an identical job, essentially placing this job back on
@@ -197,15 +203,14 @@ module Resque
 
     # String representation
     def inspect
-      obj = @payload
-      "(Job{%s} | %s | %s)" % [ @queue, obj['class'], obj['args'].inspect ]
+      "(Job{#{@queue}} | #{@payload['class']} | #{@payload['args'].inspect})"
     end
 
     # Equality
     def ==(other)
-      queue == other.queue &&
-        payload_class == other.payload_class &&
-        args == other.args
+      (queue == other.queue) &&
+        (payload_class == other.payload_class) &&
+        (args == other.args)
     end
 
     def before_hooks
@@ -226,8 +231,13 @@ module Resque
 
     def run_failure_hooks(exception)
       begin
-        job_args = args || []
-        failure_hooks.each { |hook| payload_class.send(hook, exception, *job_args) } unless @failure_hooks_ran
+        job_args = (args || [])
+
+        unless @failure_hooks_ran
+          failure_hooks.each do |hook|
+            payload_class.send(hook, exception, *job_args)
+          end
+        end
       ensure
         @failure_hooks_ran = true
       end

--- a/lib/resque/json_coder.rb
+++ b/lib/resque/json_coder.rb
@@ -4,16 +4,16 @@ require 'json'
 module Resque
   class JsonCoder < Coder
     def encode(object)
-      JSON.dump object
+      JSON.dump(object)
     end
 
     def decode(object)
-      return unless object
-
-      begin
-        JSON.load object
-      rescue JSON::ParserError => e
-        raise DecodeException, e.message, e.backtrace
+      if object
+        begin
+          JSON.load(object)
+        rescue JSON::ParserError => e
+          raise DecodeException, e.message, e.backtrace
+        end
       end
     end
   end

--- a/lib/resque/stat.rb
+++ b/lib/resque/stat.rb
@@ -29,7 +29,7 @@ module Resque
 
     # Increments a stat by one.
     def <<(stat)
-      incr stat
+      incr(stat)
     end
 
     # For a string stat name, decrements the stat by one.
@@ -42,7 +42,7 @@ module Resque
 
     # Decrements a stat by one.
     def >>(stat)
-      decr stat
+      decr(stat)
     end
 
     # Removes a stat from Redis, effectively setting it to 0.

--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -12,33 +12,31 @@ namespace :resque do
 
     begin
       worker = Resque::Worker.new(*queues)
-      worker.verbose = ENV['LOGGING'] || ENV['VERBOSE']
+      worker.verbose      = (ENV['LOGGING'] || ENV['VERBOSE'])
       worker.very_verbose = ENV['VVERBOSE']
-      worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
+      worker.term_timeout = (ENV['RESQUE_TERM_TIMEOUT'] || 4.0)
     rescue Resque::NoQueueError
       abort "set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work"
     end
 
     if ENV['BACKGROUND']
       unless Process.respond_to?('daemon')
-          abort "env var BACKGROUND is set, which requires ruby >= 1.9"
+        abort "env var BACKGROUND is set, which requires ruby >= 1.9"
       end
+
       Process.daemon(true)
     end
 
     worker.log "Starting worker #{worker}"
 
-    worker.work(ENV['INTERVAL'] || 5) # interval, will block
+    # interval, will block
+    worker.work(ENV['INTERVAL'] || 5)
   end
 
   desc "Start multiple Resque workers. Should only be used in dev mode."
   task :workers do
-    threads = []
-
-    ENV['COUNT'].to_i.times do
-      threads << Thread.new do
-        system "rake resque:work"
-      end
+    threads = Array.new(ENV['COUNT'].to_i) do
+      Thread.new { system "rake resque:work" }
     end
 
     threads.each { |thread| thread.join }


### PR DESCRIPTION
I went over the source code and normalized the style. Hopefully, this will make it easier for others to dig into Resque's code-base.
- `alias` does not need Symbols.
- Prefer `alias` to `alias_method` when aliasing previously defined methods.
- Use less explicit `return`s.
- Keep code within 80 columns.
- Add white-space around important statements or blocks of code.
- Removed trailing white-space.
- Avoid using the ternary operator with densely packed code.
- Break densely packed lines into multiple lines.
- Use parentheses for all method call, except ones used as declarative statements.
- Avoid single-letter variable names.

Tests pass on:
- Ruby 1.9.3-p194.
- Rubinius 2.0.0 (1.8 mode obviously)

Feel free to also adjust style where needed.
