### PR TITLE
Fix test ordering failures.

### DIFF
--- a/test/job_hooks_test.rb
+++ b/test/job_hooks_test.rb
@@ -252,6 +252,8 @@ end
 
 
 describe "Resque::Job before_enqueue" do
+  before{ Resque.redis.flushall }
+
   include PerformJob
 
   class ::BeforeEnqueueJob


### PR DESCRIPTION
@steveklabnik @ecoffey

The `:jobs` queue needs to be cleared before these tests because they assert on the size of the `:jobs` queue. In some test orderings these examples would fail.
