### PR TITLE
Only call after_fork if will_fork? is true

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -183,7 +183,7 @@ module Resque
     # Processes a given job in the child.
     def perform(job)
       begin
-        run_hook :after_fork, job unless @cant_fork
+        run_hook :after_fork, job if will_fork?
         job.perform
       rescue Object => e
         log "#{job.inspect} failed: #{e.inspect}"

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -409,7 +409,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "Will call an after_fork hook after forking" do
+  test "Will call an after_fork hook if we're forking" do
     Resque.redis.flushall
     $AFTER_FORK_CALLED = false
     Resque.after_fork = Proc.new { $AFTER_FORK_CALLED = true }
@@ -418,7 +418,7 @@ context "Resque::Worker" do
     assert !$AFTER_FORK_CALLED
     Resque::Job.create(:jobs, SomeJob, 20, '/tmp')
     workerA.work(0)
-    assert $AFTER_FORK_CALLED
+    assert $AFTER_FORK_CALLED == workerA.will_fork?
   end
 
   test "Will not call an after_fork hook when the worker can't fork" do


### PR DESCRIPTION
This change provides consistent forking semantics across JRuby running
in both 1.8 and 1.9 mode and resolves the current test failure.
