### PR TITLE
Adds redis-retry support.

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -1,4 +1,5 @@
 require 'redis/namespace'
+require 'redis/retry'
 
 require 'resque/version'
 
@@ -31,24 +32,8 @@ module Resque
   #   5. An instance of `Redis`, `Redis::Client`, `Redis::DistRedis`,
   #      or `Redis::Namespace`.
   def redis=(server)
-    case server
-    when String
-      if server =~ /redis\:\/\//
-        redis = Redis.connect(:url => server, :thread_safe => true)
-      else
-        server, namespace = server.split('/', 2)
-        host, port, db = server.split(':')
-        redis = Redis.new(:host => host, :port => port,
-          :thread_safe => true, :db => db)
-      end
-      namespace ||= :resque
+    @redis = wrap_redis_with_retry( init_redis( server ) )
 
-      @redis = Redis::Namespace.new(namespace, :redis => redis)
-    when Redis::Namespace
-      @redis = server
-    else
-      @redis = Redis::Namespace.new(:resque, :redis => server)
-    end
     @queues = Hash.new { |h,name|
       h[name] = Resque::Queue.new(name, @redis, coder)
     }
@@ -433,6 +418,33 @@ module Resque
   # Retrieve all hooks of a given name.
   def hooks(name)
     (@hooks && @hooks[name]) || []
+  end
+
+  def init_redis(server)
+    case server
+    when String
+      if server =~ /redis\:\/\//
+        redis = Redis.new(:url => server, :thread_safe => true)
+      else
+        server, namespace = server.split('/', 2)
+        host, port, db = server.split(':')
+        redis = wrap_redis_with_retry(
+          Redis.new(:host => host, :port => port, :thread_safe => true, :db => db)
+        )
+      end
+      namespace ||= :resque
+
+      Redis::Namespace.new(namespace, :redis => redis)
+    when Redis::Namespace
+      server
+    else
+      Redis::Namespace.new(:resque, :redis => server)
+    end
+  end
+
+  def wrap_redis_with_retry(redis)
+    return redis if redis.is_a?(Redis::Retry)
+    Redis::Retry.new(:tries => 3, :wait => 5, :redis => redis)
   end
 end
 

--- a/lib/resque/multi_queue.rb
+++ b/lib/resque/multi_queue.rb
@@ -19,8 +19,7 @@ module Resque
       @redis      = redis
 
       queues.each do |queue|
-        key = @redis.is_a?(Redis::Namespace) ? "#{@redis.namespace}:" : ""
-        key += queue.redis_name
+        key = "#{@redis.namespace}:#{queue.redis_name}"
         @queue_hash[key] = queue
       end
     end

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.rdoc_options      = ["--charset=UTF-8"]
 
   s.add_dependency "redis-namespace", "~> 1.0"
+  s.add_dependency "redis-retry",     "~> 0.1.0"
   s.add_dependency "vegas",           "~> 0.1.2"
   s.add_dependency "sinatra",         ">= 0.9.2"
   s.add_dependency "json"


### PR DESCRIPTION
Extract redis initialization logic into a new helper and add tests for all types of server specifications.

Always wrap the initialized redis instance in a Redis::Retry instance.
