### PR TITLE
Fix will_fork? handling for before_fork hooks

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -257,7 +257,7 @@ module Resque
       
       # Only run before_fork hooks if we're actually going to fork
       # (after checking @cant_fork)
-      run_hook :before_fork, job
+      run_hook :before_fork, job if will_fork?
 
       begin
         # IronRuby doesn't support `Kernel.fork` yet

--- a/test/resque_hook_test.rb
+++ b/test/resque_hook_test.rb
@@ -44,7 +44,7 @@ describe "Resque Hooks" do
 
     assert_equal(0, counter)
     @worker.work(0)
-    assert_equal(2, counter)
+    assert_equal(@worker.will_fork? ? 2 : 0, counter)
   end
 
   it 'calls after_fork after each job if forking' do
@@ -102,7 +102,12 @@ describe "Resque Hooks" do
 
     assert(!first && !second)
     @worker.work(0)
-    assert(first && second)
+
+    if @worker.will_fork?
+      assert(first && second)
+    else
+      assert(!first && !second)
+    end
   end
 
   it 'registers multiple after_forks' do

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -447,7 +447,7 @@ describe "Resque::Worker" do
     assert !$BEFORE_FORK_CALLED
     Resque::Job.create(:jobs, SomeJob, 20, '/tmp')
     workerA.work(0)
-    assert $BEFORE_FORK_CALLED
+    assert $BEFORE_FORK_CALLED == workerA.will_fork?
   end
   
   it "Will not call a before_fork hook when the worker can't fork" do


### PR DESCRIPTION
The intended behavior of before_fork, according to a comment:

lib/resque/worker.rb
258:      # Only run before_fork hooks if we're actually going to fork

If this is the case, then this behavior was actually broken on e.g.
JRuby, as there was no guard on the invocation of the hook.

This adds that guard, and cleans up the tests to check will_fork? before
making assertions.
