### PR TITLE
Resque.dequeue should return number of jobs when removing all jobs of the specified class.

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -280,11 +280,13 @@ module Resque
     end
     return if before_hooks.any? { |result| result == false }
 
-    Job.destroy(queue_from_class(klass), klass, *args)
+    destroyed = Job.destroy(queue_from_class(klass), klass, *args)
 
     Plugin.after_dequeue_hooks(klass).each do |hook|
       klass.send(hook, *args)
     end
+    
+    destroyed
   end
 
   # Given a class, try to extrapolate an appropriate queue based on a

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -80,9 +80,9 @@ context "Resque" do
     assert Resque.enqueue(SomeIvarJob, 20, '/tmp')
     assert_equal 5, Resque.size(:ivar)
 
-    assert Resque.dequeue(SomeIvarJob, 30, '/tmp')
+    assert_equal 1, Resque.dequeue(SomeIvarJob, 30, '/tmp')
     assert_equal 4, Resque.size(:ivar)
-    assert Resque.dequeue(SomeIvarJob)
+    assert_equal 3, Resque.dequeue(SomeIvarJob)
     assert_equal 1, Resque.size(:ivar)
   end
 


### PR DESCRIPTION
Resque.dequeue(GitHub::Jobs::UpdateNetworkGraph) wasn't returning the count.
