### PR TITLE
Avoiding NaN days ago on resque web

### DIFF
--- a/lib/resque/server/public/jquery.relatize_date.js
+++ b/lib/resque/server/public/jquery.relatize_date.js
@@ -67,21 +67,21 @@
      * @param {Boolean} Include the time in the output
      */
     distanceOfTimeInWords: function(fromTime, toTime, includeTime) {
-      var delta = parseInt((toTime.getTime() - fromTime.getTime()) / 1000);
+      var delta = parseInt((toTime.getTime() - fromTime.getTime()) / 1000, 10);
       if (delta < 60) {
           return 'just now';
       } else if (delta < 120) {
           return 'about a minute ago';
       } else if (delta < (45*60)) {
-          return (parseInt(delta / 60)).toString() + ' minutes ago';
+          return (parseInt(delta / 60, 10)).toString() + ' minutes ago';
       } else if (delta < (120*60)) {
           return 'about an hour ago';
       } else if (delta < (24*60*60)) {
-          return 'about ' + (parseInt(delta / 3600)).toString() + ' hours ago';
+          return 'about ' + (parseInt(delta / 3600, 10)).toString() + ' hours ago';
       } else if (delta < (48*60*60)) {
           return '1 day ago';
       } else {
-        var days = (parseInt(delta / 86400)).toString();
+        var days = (parseInt(delta / 86400, 10)).toString();
         if (days > 5) {
           var fmt  = '%B %d, %Y'
           if (includeTime) fmt += ' %I:%M %p'

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -463,7 +463,7 @@ module Resque
     def working_on(job)
       data = encode \
         :queue   => job.queue,
-        :run_at  => Time.now.strftime("%Y/%m/%d %H:%M:%S %Z"),
+        :run_at  => Time.now.utc.iso8601,
         :payload => job.payload
       redis.set("worker:#{self}", data)
     end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -31,6 +31,13 @@ context "Resque::Worker" do
       @worker.perform job
     end
   end
+  
+  test "register 'run_at' time on UTC timezone in ISO8601 format" do
+    job = Resque::Job.new(:jobs, {'class' => 'GoodJob', 'args' => "blah"})
+    now = Time.now.utc.iso8601
+    @worker.working_on(job)
+    assert_equal now, @worker.processing['run_at']
+  end
 
   test "fails uncompleted jobs with DirtyExit by default on exit" do
     job = Resque::Job.new(:jobs, {'class' => 'GoodJob', 'args' => "blah"})


### PR DESCRIPTION
Hi,

the date stored on worker data is in a format that the Date class on javascript not understand, which produces a "NaN days ago" when showing how many time a worker is processing.

I changed the date format to ISO8601 on UTC timezone, with that everything works no matter from where the user is accessing the web interface.

Also set the base on parseInt call to decimal avoiding problems of parse, since this isn't the default value.

I hope you appreciate this patch.

Regards,
Wandenberg
