### PR TITLE
persisting live poll status between pages

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -119,7 +119,7 @@ module Resque
 
       def poll
         if @polling
-          text = "Last Updated: #{Time.now.strftime("%H:%M:%S")}"
+          text = "Last Updated: #{Time.now.strftime("%H:%M:%S")} <br/><a href='#stop' rel='stop_poll'>Stop Poll</a>"
         else
           text = "<a href='#{u(request.path_info)}.poll' rel='poll'>Live Poll</a>"
         end

--- a/lib/resque/server/public/jquery.Storage.js
+++ b/lib/resque/server/public/jquery.Storage.js
@@ -1,0 +1,68 @@
+/**
+ * Storage plugin
+ * Provides a simple interface for storing data such as user preferences.
+ * Storage is useful for saving and retreiving data from the user's browser.
+ * For newer browsers, localStorage is used.
+ * If localStorage isn't supported, then cookies are used instead.
+ * Retrievable data is limited to the same domain as this file.
+ *
+ * Usage:
+ * This plugin extends jQuery by adding itself as a static method.
+ * $.Storage - is the class name, which represents the user's data store, whether it's cookies or local storage.
+ *             <code>if ($.Storage)</code> will tell you if the plugin is loaded.
+ * $.Storage.set("name", "value") - Stores a named value in the data store.
+ * $.Storage.set({"name1":"value1", "name2":"value2", etc}) - Stores multiple name/value pairs in the data store.
+ * $.Storage.get("name") - Retrieves the value of the given name from the data store.
+ * $.Storage.remove("name") - Permanently deletes the name/value pair from the data store.
+ *
+ * @author Dave Schindler
+ *
+ * Distributed under the MIT License
+ *
+ * Copyright (c) 2010 Dave Schindler
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+(function($) {
+	// Private data
+	var isLS=typeof window.localStorage!=='undefined';
+	// Private functions
+	function wls(n,v){var c;if(typeof n==="string"&&typeof v==="string"){localStorage[n]=v;return true;}else if(typeof n==="object"&&typeof v==="undefined"){for(c in n){if(n.hasOwnProperty(c)){localStorage[c]=n[c];}}return true;}return false;}
+	function wc(n,v){var dt,e,c;dt=new Date();dt.setTime(dt.getTime()+31536000000);e="; expires="+dt.toGMTString();if(typeof n==="string"&&typeof v==="string"){document.cookie=n+"="+v+e+"; path=/";return true;}else if(typeof n==="object"&&typeof v==="undefined"){for(c in n) {if(n.hasOwnProperty(c)){document.cookie=c+"="+n[c]+e+"; path=/";}}return true;}return false;}
+	function rls(n){return localStorage[n];}
+	function rc(n){var nn, ca, i, c;nn=n+"=";ca=document.cookie.split(';');for(i=0;i<ca.length;i++){c=ca[i];while(c.charAt(0)===' '){c=c.substring(1,c.length);}if(c.indexOf(nn)===0){return c.substring(nn.length,c.length);}}return null;}
+	function dls(n){return delete localStorage[n];}
+	function dc(n){return wc(n,"",-1);}
+
+	/**
+	* Public API
+	* $.Storage - Represents the user's data store, whether it's cookies or local storage.
+	* $.Storage.set("name", "value") - Stores a named value in the data store.
+	* $.Storage.set({"name1":"value1", "name2":"value2", etc}) - Stores multiple name/value pairs in the data store.
+	* $.Storage.get("name") - Retrieves the value of the given name from the data store.
+	* $.Storage.remove("name") - Permanently deletes the name/value pair from the data store.
+	*/
+	$.extend({
+		Storage: {
+			set: isLS ? wls : wc,
+			get: isLS ? rls : rc,
+			remove: isLS ? dls :dc
+		}
+	});
+})(jQuery);

--- a/lib/resque/server/public/ranger.js
+++ b/lib/resque/server/public/ranger.js
@@ -1,5 +1,6 @@
 $(function() {
   var poll_interval = 2
+  var polling_on = $.Storage.get("resque_polling_on") || false;
 
   var relatizer = function(){
     var dt = $(this).text(), relatized = $.relatizeDate(this)
@@ -36,6 +37,7 @@ $(function() {
   })
 
   $('a[rel=poll]').click(function() {
+    $.Storage.set("resque_polling_on", "true")
     var href = $(this).attr('href')
     $(this).parent().text('Starting...')
     $("#main").addClass('polling')
@@ -47,6 +49,12 @@ $(function() {
       }})
     }, poll_interval * 1000)
 
+    return false
+  })
+
+  $('a[rel=stop_poll]').live('click', function() {
+    $.Storage.remove("resque_polling_on")
+    window.location.reload(true);
     return false
   })
 
@@ -69,5 +77,8 @@ $(function() {
     return false;
   })
 
+  if (polling_on) {
+    $('a[rel=poll]').trigger('click');
+  }
 
 })

--- a/lib/resque/server/views/layout.erb
+++ b/lib/resque/server/views/layout.erb
@@ -7,6 +7,7 @@
   <link href="<%=u 'style.css' %>" media="screen" rel="stylesheet" type="text/css">
   <script src="<%=u 'jquery-1.3.2.min.js' %>" type="text/javascript"></script>
   <script src="<%=u 'jquery.relatize_date.js' %>" type="text/javascript"></script>
+  <script src="<%=u 'jquery.Storage.js' %>" type="text/javascript"></script>
   <script src="<%=u 'ranger.js' %>" type="text/javascript"></script>
 </head>
 <body>


### PR DESCRIPTION
Hi,

one of the annoying things when using live poll is, when we move to another tab and come back to the home page the live poll has stopped.

I added jQuery Storage plugin and made some small changes to keep the live poll status during the site navigation.

I hope you enjoy the patch.
