### PR TITLE
Revamp Resque::Failure

### DIFF
--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -43,10 +43,15 @@ module Resque
 
     # Returns an array of all the failures, paginated.
     #
-    # `start` is the int of the first item in the page, `count` is the
+    # `offset` is the int of the first item in the page, `limit` is the
     # number of items to return.
-    def self.all(start = 0, count = 1)
-      backend.all(start, count)
+    def self.all(offset = 0, limit = 1)
+      backend.all(offset, limit)
+    end
+
+    # Iterate across all failures with the given options
+    def self.each(offset = 0, limit = self.count, &block)
+      backend.each(offset, limit, &block)
     end
 
     # The string url of the backend's web interface, if any.

--- a/lib/resque/failure/base.rb
+++ b/lib/resque/failure/base.rb
@@ -37,8 +37,12 @@ module Resque
       end
 
       # Returns a paginated array of failure objects.
-      def self.all(start = 0, count = 1)
+      def self.all(offset = 0, limit = 1)
         []
+      end
+
+      # Iterate across failed objects
+      def self.each(offset = 0, limit = self.count)
       end
 
       # A URL where someone can go to view failures.

--- a/lib/resque/server/views/failed.erb
+++ b/lib/resque/server/views/failed.erb
@@ -1,28 +1,30 @@
-<%start = params[:start].to_i %>
-<%failed = Resque::Failure.all(start, 20)%>
-<% index = 0 %>
+<%# FIXME: HELP ME I NEED HELPERS!!!! %>
 <% date_format = "%Y/%m/%d %T %z" %>
+<% failures    = Resque::Failure %>
+<% size        = failures.count %>
+<% per_page    = 20 %>
+<% start_at    = params[:start].to_i %>
+<% end_at      = start_at + per_page > size ? size : start_at + per_page %>
 
 <h1>Failed Jobs</h1>
-<%unless failed.empty?%>
+<% unless size.zero? %>
 <form method="POST" action="<%=u 'failed/clear'%>">
   <input type='submit' name='' value='Clear Failed Jobs' />
 </form>
 <form method="POST" action="<%=u 'failed/requeue/all'%>">
   <input type='submit' name='' value='Retry Failed Jobs' />
 </form>
-<%end%>
+<% end %>
 
-<p class='sub'>Showing <%=start%> to <%= start + 20 %> of <b><%= size = Resque::Failure.count %></b> jobs</p>
+<p class='sub'>Showing <%= start_at %> to <%= end_at %> of <b><%= size %></b> jobs</p>
 
 <ul class='failed'>
-  <%for job in failed%>
-    <% index += 1 %>
+  <% failures.each(start_at, per_page) do |id, job| %>
     <li>
       <dl>
         <% if job.nil? %>
         <dt>Error</dt>
-        <dd>Job <%= index%> could not be parsed; perhaps it contains invalid JSON?</dd>
+        <dd>Job <%= id %> could not be parsed; perhaps it contains invalid JSON?</dd>
         <% else %>
         <dt>Worker</dt>
         <dd>
@@ -30,13 +32,13 @@
           <% if job['retried_at'] %>
             <div class='retried'>
               Retried <b><span class="time"><%= Time.parse(job['retried_at']).strftime(date_format) %></span></b>
-              <a href="<%= u "failed/remove/#{start + index - 1}" %>" class="remove" rel="remove">Remove</a>
+              <a href="<%= u "failed/remove/#{id}" %>" class="remove" rel="remove">Remove</a>
             </div>
           <% else %>
             <div class='controls'>
-              <a href="<%= u "failed/requeue/#{start + index - 1}" %>" rel="retry">Retry</a>
+              <a href="<%= u "failed/requeue/#{id}" %>" rel="retry">Retry</a>
               or
-              <a href="<%= u "failed/remove/#{start + index - 1}" %>" rel="remove">Remove</a>
+              <a href="<%= u "failed/remove/#{id}" %>" rel="remove">Remove</a>
             </div>
           <% end %>
         </dd>
@@ -60,8 +62,8 @@
       <div class='r'>
       </div>
     </li>
-  <%end%>
+  <% end %>
 </ul>
 
-<%= partial :next_more, :start => start, :size => size %>
+<%= partial :next_more, :start => start_at, :size => size %>
 


### PR DESCRIPTION
I'd like to add a different failure backend to Resque with support for
multiple queues (and based on Redis sorted sets). However, when I dove
into the failed.erb template in order to facilitate this change, I
discovered it was, well... bad?

This change moves iteration of failures into Resque::Failure.each and
now uses that in the template. Many other minor tweaks to the template
are also added to make it more generic and less wonky.
