### PR TITLE
Replaced regex with string operation

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -35,7 +35,7 @@ module Resque
   def redis=(server)
     case server
     when String
-      if server =~ /redis\:\/\//
+      if server['redis://']
         redis = Redis.connect(:url => server, :thread_safe => true)
       else
         server, namespace = server.split('/', 2)


### PR DESCRIPTION
May be negligable but the string operation is faster:

``` ruby
Benchmark.bm do |b|
  server = "redis://"
  b.report("regex") do
    1.upto(1000) do
      server =~ /redis\:\/\//
    end
  end
  b.report("string") do
    1.upto(1000) do
      server["redis://"]
    end
  end
end
```

regex real: 0.00320
string real: 0.00273
