### PR TITLE
1-x-stable: Notify failure backend of processes killed by signals.

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -141,12 +141,13 @@ module Resque
             rescue SystemCallError
               nil
             end
+            job.fail(DirtyExit.new($?.to_s)) if $?.signaled?
           else
             unregister_signal_handlers if will_fork? && term_child
             procline "Processing #{job.queue} since #{Time.now.to_i}"
             reconnect
             perform(job, &block)
-            exit! if will_fork?
+            exit!(true) if will_fork?
           end
 
           done_working


### PR DESCRIPTION
Backport of pull request #623 for the 1-x-stable branch.
