### PR TITLE
Duplicate reconnect method definition in worker

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -239,24 +239,6 @@ module Resque
       end
     end
 
-    # Reconnect to Redis to avoid sharing a connection with the parent,
-    # retry up to 3 times with increasing delay before giving up.
-    def reconnect
-      tries = 0
-      begin
-        redis.client.reconnect
-      rescue Redis::BaseConnectionError
-        if (tries += 1) <= 3
-          Resque.logger.info "Error reconnecting to Redis; retrying"
-          sleep(tries)
-          retry
-        else
-          Resque.logger.info "Error reconnecting to Redis; quitting"
-          raise
-        end
-      end
-    end
-
     # Returns a list of queues to use when searching for a job.
     # A splat ("*") means you want every queue (in alpha order) - this
     # can be useful for dynamically adding new queues. Low priority queues


### PR DESCRIPTION
I saw this while digging the code, somehow missed during this merge 4b8920f6f0
