### PR TITLE
/failed/requeue/all throws exception if has multiple failed jobs

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -192,7 +192,7 @@ module Resque
 
     post "/failed/requeue/all" do
       Resque::Failure.count.times do |num|
-        Resque::Failure.requeue_and_remove(num)
+        Resque::Failure.requeue_and_remove(0)
       end
       redirect u('failed')
     end

--- a/lib/resque/server/test_helper.rb
+++ b/lib/resque/server/test_helper.rb
@@ -9,6 +9,13 @@ module Resque
         Resque::Server.new
       end
 
+      def add_failed_jobs
+        Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(:test), :queue => "queue", :payload => {'class' => 'TestClass'})
+        Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(:test), :queue => "queue", :payload => {'class' => 'TestClass'})
+        Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(:test), :queue => "queue", :payload => {'class' => 'TestClass'})
+        Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(:test), :queue => "queue", :payload => {'class' => 'TestClass'})
+      end
+
       def self.should_respond_with_success
         it "should respond with success" do
           assert last_response.ok?, last_response.errors

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -57,3 +57,15 @@ describe "also works with slash at the end" do
 
   should_respond_with_success
 end
+
+describe "on POST to /failed/requeue/all" do
+  before {
+    add_failed_jobs
+    post "/failed/requeue/all"
+  }
+
+  it "should redirect to /failed and contain '0 jobs'" do
+    follow_redirect!
+    assert last_response.body.include?('<b>0</b> jobs')
+  end
+end


### PR DESCRIPTION
We are calling requeue_and_remove `Resque::Failure.count` times but after calling remove method we won't have `Resque::Failure.count` much index anymore. That's why `item = all(index)` returns nil at some point and `item['retried_at']` causes undefined method exception.
