### PR TITLE
Fix failure counts when a class is given

### DIFF
--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -64,7 +64,7 @@ module Resque
 
     # Returns the int count of how many failures we have seen.
     def self.count(queue = nil, class_name = nil)
-      backend.count(queue, class_name = nil)
+      backend.count(queue, class_name)
     end
 
     # Returns an array of all the failures, paginated.


### PR DESCRIPTION
This previously always assigned the class name to nil and therefore gave
inaccurate counts when a class was specified. Now it doesn't!
