### PR TITLE
fix documentation of INTERVAL, small float value of 0.1 is unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,9 +340,10 @@ worker is started.
 ### Polling frequency
 
 You can pass an INTERVAL option which is a float representing the polling frequency. 
-The default is 5 seconds, but for a semi-active app you may want to use a smaller value.
+The default is 5 seconds, but for a semi-active app you may want to use a smaller
+(integer) value.
 
-    $ INTERVAL=0.1 QUEUE=file_serve rake environment resque:work
+    $ INTERVAL=1 QUEUE=file_serve rake environment resque:work
 
 <a name='section_Workers_Priorities_and_Queue_Lists'></a>
 ### Priorities and Queue Lists


### PR DESCRIPTION
Ever since this commit: https://github.com/defunkt/resque/commit/c7d20216b6c9de45e52f3ae625217954bb5e961d

Only integer INTERVALs are effectively supported.  An INTERVAL of 0.1 will not work as one would naively expect.

While a more extensive change would be nice, for now at least we should update the doc so that it shows currently-supported behavior.
