### PR TITLE
Set ascii-8bit encoding information with invalid utf-8 string

### DIFF
--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -163,7 +163,7 @@ describe "Resque" do
     it "rescues jobs with invalid UTF-8 characters" do
       Resque.logger = DummyLogger.new
       begin
-        Resque.enqueue(SomeMethodJob, "Invalid UTF-8 character \xFF")
+        Resque.enqueue(SomeMethodJob, "Invalid UTF-8 character \xFF".force_encoding("ascii-8bit"))
         messages = Resque.logger.messages
       rescue Exception => e
         assert false, e.message


### PR DESCRIPTION
Ruby2.0.0
Default source encoding is changed to UTF-8. (was US-ASCII)
https://github.com/ruby/ruby/blob/trunk/NEWS
