### PR TITLE
remove workers button on resque ui

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -177,6 +177,21 @@ module Resque
       redirect u('queues')
     end
 
+    post "/workers/:id/remove" do
+      worker = Resque::Worker.find(params[:id])
+      if worker
+        worker.unregister_worker
+        host, _ = worker.to_s.split(':')
+        if worker_hosts.keys.include?(host)
+          redirect u("workers/#{host}")
+        else
+          redirect u('workers')
+        end
+      else
+        redirect u('workers')
+      end
+    end
+
     get "/failed/?" do
       if Resque::Failure.url
         redirect Resque::Failure.url

--- a/lib/resque/server/views/workers.erb
+++ b/lib/resque/server/views/workers.erb
@@ -13,6 +13,7 @@
       <th>Processed</th>
       <th>Failed</th>
       <th>Processing</th>
+      <th>&nbsp;</th>
     </tr>
     <tr>
       <td class='icon'><img src="<%=u state = worker.state %>.png" alt="<%= state %>" title="<%= state %>"></td>
@@ -32,6 +33,11 @@
         <% else %>
           <span class='waiting'>Waiting for a job...</span>
         <% end %>
+      </td>
+      <td>
+        <form method="POST" action="<%=u "/workers/#{worker}/remove" %>" class='remove-worker'>
+          <input type='submit' name='' value='Remove Worker' onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
+        </form>
       </td>
     </tr>
   </table>
@@ -56,6 +62,7 @@
       <th>Where</th>
       <th>Queues</th>
       <th>Processing</th>
+      <th>&nbsp;</th>
     </tr>
     <% for worker in (workers = workers.sort_by { |w| w.to_s }) %>
     <tr class="<%=state = worker.state%>">
@@ -73,6 +80,11 @@
         <% else %>
           <span class='waiting'>Waiting for a job...</span>
         <% end %>
+      </td>
+      <td>
+        <form method="POST" action="<%=u "/workers/#{worker}/remove" %>" class='remove-worker'>
+          <input type='submit' name='' value='Remove Worker' onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
+        </form>
       </td>
     </tr>
     <% end %>


### PR DESCRIPTION
Adds a button to clean up old workers. We had dead servers/workers that were still being reported.

It's kind similar to this issue, but a less automatic approach: https://github.com/defunkt/resque/issues/319

![Button](https://f.cloud.github.com/assets/36106/91521/a04876ae-65a3-11e2-96f6-fafb918034b7.png)
