### PR TITLE
Keep the existing redis connection if fork fails

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -150,7 +150,7 @@ module Resque
             job.fail(DirtyExit.new($?.to_s)) if $?.signaled?
           else
             procline "Processing #{job.queue} since #{Time.now.to_i}"
-            reconnect
+            reconnect unless @cant_fork
             perform(job, &block)
           end
           done_working


### PR DESCRIPTION
When running Rescue in an environment which cannot (or chooses not to) fork children, it is unnecessary to recreate sockets to redis. By removing it, we avoid unnecessary slow-start congestion control on the connection. We also reduce the number of times where minor fluctuations in connectivity can cause a job to fail.
