### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1026,7 +1026,7 @@ Meta
 
 * Code: `git clone git://github.com/defunkt/resque.git`
 * Home: <https://github.com/defunkt/resque>
-* Docs: <http://rubydoc.info/gems/resque/frames>
+* Docs: <http://defunkt.io/resque/>
 * Bugs: <https://github.com/defunkt/resque/issues>
 * List: <resque@librelist.com>
 * Chat: <irc://irc.freenode.net/resque>


### PR DESCRIPTION
changes the docs URL from rubydoc.info to defunkt.io/resque since the documentation is so much better.
