### PR TITLE
Resque#inline accepts a block as alternative to Resque#inline=

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -187,12 +187,25 @@ module Resque
     "Resque Client connected to #{redis_id}"
   end
 
-  attr_accessor :inline
-
   # If 'inline' is true Resque will call #perform method inline
   # without queuing it into Redis and without any Resque callbacks.
   # The 'inline' is false Resque jobs will be put in queue regularly.
-  alias :inline? :inline
+  attr_writer :inline
+
+  def inline(&block)
+    block ? inline_block(&block) : inline?
+  end
+
+  def inline_block
+    self.inline = true
+    yield
+  ensure
+    self.inline = false
+  end
+
+  def inline?
+    @inline
+  end
 
   #
   # queue manipulation

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -303,6 +303,33 @@ describe "Resque" do
     end
   end
 
+  it "inlining jobs with block" do
+    Resque.inline do
+      Resque.enqueue(SomeIvarJob, 20, '/tmp')
+    end
+    assert_equal 0, Resque.size(:ivar)
+    assert !Resque.inline?
+  end
+
+  it "inline block sets inline to false after exception" do
+    assert_raises StandardError do
+      Resque.inline do
+        raise StandardError
+      end
+    end
+    assert !Resque.inline?
+  end
+
+  it "inline without block is alias to inline?" do
+    begin
+      assert_equal Resque.inline?, Resque.inline
+      Resque.inline = true
+      assert_equal Resque.inline?, Resque.inline
+    ensure
+      Resque.inline = false
+    end
+  end
+
   it 'treats symbols and strings the same' do
     assert_equal Resque.queue(:people), Resque.queue('people')
   end


### PR DESCRIPTION
The "inline" attribute is often used only for specific blocks of code, like in test suites. A block is more intuitive, safe, and succinct than #inline= for such use cases because it does not require "ensure" to set #inline=false.

[Gist of before/after usage](https://gist.github.com/4668532#file-resque_inline_with_block-rb)

I'm not sure if this is a valid concern (I'm inexperienced with threading and such) but one potential problem I can think of: people might be unaware that the "inline" setting has a scope not limited to the block, and while it's running another command outside the block gets executed.
