### PR TITLE
Rescue the exception of run_failure_hooks method

### DIFF
--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -228,6 +228,7 @@ module Resque
       begin
         job_args = args || []
         failure_hooks.each { |hook| payload_class.send(hook, exception, *job_args) } unless @failure_hooks_ran
+      rescue
       ensure
         @failure_hooks_ran = true
       end


### PR DESCRIPTION
I fixed the problem that terminate resque worker process if exception occurs in the run_failure_hooks methods.
