### PR TITLE
Add test to ensure that before_first_fork can take the worker object

### DIFF
--- a/test/resque_hook_test.rb
+++ b/test/resque_hook_test.rb
@@ -40,6 +40,15 @@ describe "Resque Hooks" do
     assert_equal(1, counter)
   end
 
+  it 'calls before_first_fork with worker' do
+    trapped_worker = nil
+
+    Resque.before_first_fork { |worker| trapped_worker = worker }
+
+    @worker.work(0)
+    assert_equal(@worker, trapped_worker)
+  end
+
   it 'calls before_fork before each job' do
     counter = 0
 


### PR DESCRIPTION
This was functionality I've monkey patched into my copy of 1.x, was about to add to to master and noticed that my test passed out the gate and the feature was already there :-)

Decided that, hey!, can't hurt to have a test!

Thanks! :heart:
