### PR TITLE
Added logging to display exception that occurs when a worker dies.

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -162,6 +162,8 @@ module Resque
 
       unregister_worker
     rescue Exception => exception
+      log "Failed to start worker : #{exception.inspect}"
+
       unregister_worker(exception)
     end
 


### PR DESCRIPTION
When starting a worker on 1-x, if there's an unintialized constant, syntax error, etc, the resque worker will fail to start and does not display the exception that occurred.         

Added logging to display the exception that occurred so that the process doesn't die silently.
