### PR TITLE
Show a current job's name in procline

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -144,7 +144,7 @@ module Resque
             job.fail(DirtyExit.new($?.to_s)) if $?.signaled?
           else
             unregister_signal_handlers if will_fork? && term_child
-            procline "Processing #{job.queue} since #{Time.now.to_i}"
+            procline "Processing #{job.queue} since #{Time.now.to_i} [#{job.payload_class}]"
             reconnect
             perform(job, &block)
             exit!(true) if will_fork?


### PR DESCRIPTION
Puts currently processed job's class name to worker's procline. 
Added this while modeling deploy process with long/stuck jobs, maybe it would be useful.
