### PR TITLE
Fix log formatters not appending a new line

### DIFF
--- a/lib/resque/log_formatters/verbose_formatter.rb
+++ b/lib/resque/log_formatters/verbose_formatter.rb
@@ -1,7 +1,7 @@
 module Resque
   class VerboseFormatter
     def call(serverity, datetime, progname, msg)
-      "*** #{msg}"
+      "*** #{msg}\n"
     end
   end
 end

--- a/lib/resque/log_formatters/very_verbose_formatter.rb
+++ b/lib/resque/log_formatters/very_verbose_formatter.rb
@@ -2,7 +2,7 @@ module Resque
   class VeryVerboseFormatter
     def call(serverity, datetime, progname, msg)
       time = Time.now.strftime('%H:%M:%S %Y-%m-%d')
-      "** [#{time}] #$$: #{msg}"
+      "** [#{time}] #$$: #{msg}\n"
     end
   end
 end


### PR DESCRIPTION
That's how Ruby does it by default

https://github.com/ruby/ruby/blob/v1_9_3_385/lib/logger.rb#L496-L497
