### PR TITLE
Fix link from "queues" view to "failed" view when there's only one failed queue

### DIFF
--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -40,11 +40,18 @@
       <td class='size'><%= resque.size queue %></td>
     </tr>
     <% end %>
-    <% Resque::Failure.queues.sort_by { |q| q.to_s }.each_with_index do |queue, i| %>
-    <tr class="<%= Resque::Failure.count(queue).zero? ? "failed" : "failure" %><%= " first_failure" if i.zero? %>">
-      <td class='queue failed'><a class="queue" href="<%= u "failed/#{queue}" %>"><%= queue %></a></td>
-      <td class='size'><%= Resque::Failure.count(queue) %></td>
-    </tr>
+    <% if failed_multiple_queues? %>
+      <% Resque::Failure.queues.sort_by { |q| q.to_s }.each_with_index do |queue, i| %>
+      <tr class="<%= Resque::Failure.count(queue).zero? ? "failed" : "failure" %><%= " first_failure" if i.zero? %>">
+        <td class='queue failed'><a class="queue" href="<%= u "failed/#{queue}" %>"><%= queue %></a></td>
+        <td class='size'><%= Resque::Failure.count(queue) %></td>
+      </tr>
+      <% end %>
+    <% else %>
+      <tr class="<%= Resque::Failure.count.zero? ? "failed" : "failure" %>">
+        <td class='queue failed'><a class="queue" href="<%= u :failed %>">failed</a></td>
+        <td class='size'><%= Resque::Failure.count %></td>
+      </tr>
     <% end %>
   </table>
 


### PR DESCRIPTION
When there's only one failed queue, the "failed" link in the "queues" view should link to "/resque/failed", but commit ce6dc794ecac627471fe863c8a6fb48f1a74b9f0 causes it to link to "/resque/failed/failed", which generates an internal server error.
