### PR TITLE
Redirect unauthorized resque-web polling requests to root url 

### DIFF
--- a/lib/resque/server/public/ranger.js
+++ b/lib/resque/server/public/ranger.js
@@ -41,10 +41,15 @@ $(function() {
     $("#main").addClass('polling')
 
     setInterval(function() {
-      $.ajax({dataType: 'text', type: 'get', url: href, success: function(data) {
-        $('#main').html(data)
-        $('#main .time').relatizeDate()
-      }})
+      $.ajax({dataType: 'text', type: 'get', url: href,
+        success: function(data) {
+          $('#main').html(data)
+          $('#main .time').relatizeDate()
+        },
+        error: function(data) {
+          if (data.status == '401') { window.location.href = '/' }
+        }
+      })
     }, poll_interval * 1000)
 
     location.hash = '#poll'


### PR DESCRIPTION
This is the v2 version of https://github.com/defunkt/resque/pull/826, which fixes a minor annoyance that I've come across within resque-web:

If I'm polling resque-web in one tab and then impersonate a user that doesn't have access to resque-web in another tab, my logs get flooded with unauthorized requests. Instead of continuing the polling in that case, I think it would be better to redirect elsewhere.
