### PR TITLE
Fixed page range for queues in failed.erb and queues.erb

### DIFF
--- a/lib/resque/server/views/failed.erb
+++ b/lib/resque/server/views/failed.erb
@@ -1,6 +1,7 @@
 <% start = params[:start].to_i %>
 <% per_page = (params[:per_page].to_i > 0) ? params[:per_page].to_i : 20 %>
 <% failed = Resque::Failure.all(start, per_page) %>
+<% size = Resque::Failure.count %>
 <% index = 0 %>
 <% date_format = "%Y/%m/%d %T %z" %>
 
@@ -14,7 +15,7 @@
 </form>
 <%end%>
 
-<p class='sub'>Showing <%=start%> to <%= start + per_page %> of <b><%= size = Resque::Failure.count %></b> jobs</p>
+<%= partial :page_range, :start => start, :size => size, :per_page => per_page %>
 
 <ul class='failed'>
   <%for job in failed%>

--- a/lib/resque/server/views/page_range.erb
+++ b/lib/resque/server/views/page_range.erb
@@ -1,0 +1,3 @@
+<p class='sub'>
+  Showing <%= size == 0 ? 0 : start + 1 %> to <%= (start + per_page) > size ? size : start + per_page %> of <b><%= size %></b> jobs
+</p>

--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -1,18 +1,21 @@
 <% @subtabs = resque.queues unless partial? || params[:id].nil? %>
 
 <% if queue = params[:id] %>
+  <% size = resque.size(queue) %>
+  <% start = params[:start].to_i %>
+  <% per_page = (params[:per_page].to_i > 0) ? params[:per_page].to_i : 20 %>
 
   <h1>Pending jobs on <span class='hl'><%= queue %></span></h1>
   <form method="POST" action="<%=u "/queues/#{queue}/remove" %>" class='remove-queue'>
     <input type='submit' name='' value='Remove Queue' onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
   </form>
-  <p class='sub'>Showing <%= start = params[:start].to_i %> to <%= start + 20 %> of <b><%=size = resque.size(queue)%></b> jobs</p>
+  <%= partial :page_range, :start => start, :size => size, :per_page => per_page %>
   <table class='jobs'>
     <tr>
       <th>Class</th>
       <th>Args</th>
     </tr>
-    <% for job in (jobs = resque.peek(queue, start, 20)) %>
+    <% for job in (jobs = resque.peek(queue, start, per_page)) %>
     <tr>
       <td class='class'><%= job['class'] %></td>
       <td class='args'><%=h job['args'].inspect %></td>


### PR DESCRIPTION
Previously, the queues would show ranges that weren't quite right:

```
0 to 20 of 0     #=> 0 records
0 to 20 of 5     #=> 5 records
20 to 40 of 25   #=> 25 records on second page
```

This pull request extracts that section into a partial and reports the ranges correctly in these views:
- failed.erb
- queues.erb

It also modifies the **queues.erb** view to respond to the `per_page` POST param appropriately. This way both views implement the same range and respond similarly to pagination.
##### Possible addendum

One thing I noticed that might also be worth changing is to make the **next_more.erb** partial respond to `per_page` as well, since it can respond incorrectly with some permutations of `start` and `per_page`. It seems slightly out of scope for this group though, but happy to add.
