### PR TITLE
Making all the failure backends have the same method signature for self....

### DIFF
--- a/lib/resque/failure/base.rb
+++ b/lib/resque/failure/base.rb
@@ -32,7 +32,7 @@ module Resque
       end
 
       # The number of failures.
-      def self.count(queue = nil)
+      def self.count(queue = nil, class_name = nil)
         0
       end
 

--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -23,8 +23,8 @@ module Resque
       end
 
       # The number of failures.
-      def self.count
-        classes.first.count
+      def self.count(queue = nil, class_name = nil)
+        classes.first.count(queue, class_name)
       end
 
       # Returns a paginated array of failure objects.

--- a/lib/resque/failure/thoughtbot.rb
+++ b/lib/resque/failure/thoughtbot.rb
@@ -13,7 +13,7 @@ module Resque
           klass.configure(&block)
         end
 
-        def count
+        def count(queue = nil, class_name = nil)
           # We can't get the total # of errors from Hoptoad so we fake it
           # by asking Resque how many errors it has seen.
           Stat[:failed]


### PR DESCRIPTION
...count so failure.rb line 67 can use the same arity and not cause ArgumentErrors.

As it is now, you can't use a Multi failure backend because failure.rb line 67 calls backend.count with two arguments which was throwing an ArgumentError. This commit makes all the failure backends have the same signature so that isn't a concern.
