### PR TITLE
windows_worker_pids can also support cygwin

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -560,7 +560,7 @@ module Resque
     def worker_pids
       if RUBY_PLATFORM =~ /solaris/
         solaris_worker_pids
-      elsif RUBY_PLATFORM =~ /mingw32/
+      elsif RUBY_PLATFORM =~ /mingw32/ || RUBY_PLATFORM =~ /cygwin/
         windows_worker_pids
       else
         linux_worker_pids


### PR DESCRIPTION
Cygwin support. Uses same windows_worker_pids method as mingw32.
