### PR TITLE
Only call the deprecated Resque::Worker#verbose= and Resque::Worker#very...

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -12,8 +12,12 @@ namespace :resque do
 
     begin
       worker = Resque::Worker.new(*queues)
-      worker.verbose = ENV['LOGGING'] || ENV['VERBOSE']
-      worker.very_verbose = ENV['VVERBOSE']
+      if ENV['LOGGING'] || ENV['VERBOSE']
+        worker.verbose = ENV['LOGGING'] || ENV['VERBOSE']
+      end
+      if ENV['VVERBOSE']
+        worker.very_verbose = ENV['VVERBOSE']
+      end
       worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
       worker.term_child = ENV['TERM_CHILD']
     rescue Resque::NoQueueError


### PR DESCRIPTION
..._verbose= setters if needed

Refs #756
