### PR TITLE
Adapting gemspec after 94945e3c2587592e4f023e1c4ceaac3bbc9e30d1

### DIFF
--- a/resque.gemspec
+++ b/resque.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.extra_rdoc_files  = [ "LICENSE.txt", "HISTORY.md", "README.md" ]
+  s.extra_rdoc_files  = [ "LICENSE.txt", "CHANGELOG.md", "README.md" ]
   s.rdoc_options      = ["--charset=UTF-8"]
 
   s.add_dependency "redis-namespace", "~> 1.0"


### PR DESCRIPTION
History.md had been renamed to CHANGELOG.md, trying to install resque from head via bundler produces "...did not have a valid gemspec. This prevents bundler from installing bins or native extensions, but that may not affect its functionality."
