### PR TITLE
Fixes #862 (verified on 2.6.32-amazon-xen-r3 kernel)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 * Web UI: Add page list to queues (@ql)
 * Web UI: Fix regression that caused the failure tab to break when clicking on "clear all failures" under certain failure backends, #859 (@jonhyman)
 * Fix regression for Resque hooks where Resque would error out if you assigned multiple hooks using an array, #859 (@jonhyman)
+* Fix regression where a lot of short running jobs can drastically increase swap usage and peg CPU, #862 (@jonhyman)
 
 ## 1.23.1 (2013-3-7)
 

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -138,6 +138,9 @@ module Resque
               unregister_signal_handlers if term_child
               reconnect
               perform(job, &block)
+              # Be sure to have the child exit or the child process can eat up huge amounts of swap space
+              # See https://github.com/defunkt/resque/issues/862
+              exit!
             end
 
             srand # Reseeding


### PR DESCRIPTION
After investigating a few things, it seems like the cause of the swap space issue was that the child process wasn't signaling an exit. I am not sure why this matters (since it's in a block) but at least on the 2.6.32-amazon-xen-r3 kernel on my EC2 machines, it mattered a lot.

Here is a graph of one of my servers' I/O utilization before the fix, after the fix, undoing the fix, and re-applying the fix. I also watched all executions via [iotop](http://guichaz.free.fr/iotop) and confirmed that SWAPIN remains at 0% with this fix. Without the fix, SWAPIN was a constant 35-95% for _each_ Resque worker subprocess. The parent process did not swap out, which indicated an issue with the code in the `Kernel.fork` block.

![swap](https://f.cloud.github.com/assets/832655/268181/5d70978e-8f11-11e2-93f4-c67b74886b71.png)

I am not sure why any issues here were not caught by `Process.waitpid`, so if someone has an idea I'd love to know.
