### PR TITLE
Don't set worker.verbose

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -12,12 +12,6 @@ namespace :resque do
 
     begin
       worker = Resque::Worker.new(*queues)
-      if ENV['LOGGING'] || ENV['VERBOSE']
-        worker.verbose = ENV['LOGGING'] || ENV['VERBOSE']
-      end
-      if ENV['VVERBOSE']
-        worker.very_verbose = ENV['VVERBOSE']
-      end
       worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
     rescue Resque::NoQueueError
       abort "set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work"


### PR DESCRIPTION
The method no longer exists and would blow up if the environment variables `LOGGING` or `VERBOSE` were set. 
