### PR TITLE
Add Resque module configuration option

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -2,6 +2,7 @@ require 'logger'
 require 'redis/namespace'
 
 require 'resque/version'
+require 'resque/config'
 
 require 'resque/errors'
 

--- a/lib/resque/config.rb
+++ b/lib/resque/config.rb
@@ -1,0 +1,20 @@
+module Resque
+  Config = Struct.new(:background, :count, :failure_backend, :fork_per_job,
+                      :interval, :pid_file, :queues, :resque_term_timeout)
+
+  @config = Config.new(
+    ENV['BACKGROUND'],
+    ENV['COUNT'],
+    ENV['FAILURE_BACKEND'] || 'redis',
+    ENV['FORK_PER_JOB'].nil? || ENV['FORK_PER_JOB'] == 'true',
+    ENV['INTERVAL'] || 5,
+    ENV['PID_FILE'],
+    (ENV['QUEUES'] || ENV['QUEUE'] || '*').to_s.split(','),
+    ENV['RESCUE_TERM_TIMEOUT'] || 4.0
+  )
+
+  def self.config
+    yield @config if block_given?
+    @config
+  end
+end

--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -33,7 +33,7 @@ module Resque
     def self.backend
       return @backend if @backend
 
-      case ENV['FAILURE_BACKEND']
+      case Resque.config.failure_backend
       when 'redis_multi_queue'
         require 'resque/failure/redis_multi_queue'
         @backend = Failure::RedisMultiQueue
@@ -41,7 +41,7 @@ module Resque
         require 'resque/failure/redis'
         @backend = Failure::Redis
       else
-        raise ArgumentError, "invalid failure backend: #{FAILURE_BACKEND}"
+        raise ArgumentError, "invalid failure backend: #{Resque.config.failure_backend}"
       end
     end
 

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -534,9 +534,9 @@ module Resque
     def idle?
       state == :idle
     end
-    
+
     def will_fork?
-      !@cant_fork && !$TESTING && (ENV["FORK_PER_JOB"] != 'false')
+      !@cant_fork && !$TESTING && Resque.config.fork_per_job
     end
 
     # Returns a symbol representing the current worker state,


### PR DESCRIPTION
Takes its defaults from environment variables. Populates Resque.config, a struct that is used where ENV['...'] used to be.
