### PR TITLE
Update round trip test to compare with page.body

### DIFF
--- a/test/end_to_end/round_trip_test.rb
+++ b/test/end_to_end/round_trip_test.rb
@@ -22,7 +22,7 @@ describe "one full round trip" do
     it "shows a site" do
       visit '/'
 
-      assert_equal 'Hello world!', page.text
+      assert_equal 'Hello world!', page.body
     end
   end
 end


### PR DESCRIPTION
This is an attempt to assist with the caused by MRI-1.8.7 on travis by @steveklabnik here:

https://twitter.com/steveklabnik/status/314171263297933312

I don't have much of an answer for the behavior itself. However, poking around in the debugger I found that page.body works fine. The differences in the two Capybara methods (text and body) may shed some light.

I believe the text method in use is Capybara::Node::Document#text:

http://rubydoc.info/github/jnicklas/capybara/master/Capybara/Node/Document:text

It is looking for the text contained in the /html xpath of the response.

The body & source methods are aliases for the Capybara::Session#html method:

http://rubydoc.info/github/jnicklas/capybara/master/Capybara/Session#html-instance_method

It is returning a DOM snapshot.

I verified that it works locally (Debian testing branch) with MRI-1.8.7-p371 and MRI-2.0.0-p0.
