### PR TITLE
Adds a default per_page value on next_more so gems which modify resque-s...

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-* No changes.
+* Adds a default value for `per_page` on resque-server for plugins which add tabs (@jonhyman)
 
 ## 1.24.0 (2013-3-21)
 

--- a/lib/resque/server/views/next_more.erb
+++ b/lib/resque/server/views/next_more.erb
@@ -1,3 +1,6 @@
+<% # per_page was added in 1.23.1; gems which add to resque-server don't pass that variable along so it would crash %>
+<% # without a default value %>
+<% per_page ||= 20 %>
 <%if  start - per_page >= 0 || start + per_page <= size%>
 <p class='pagination'>
   <% if start - per_page >= 0 %>


### PR DESCRIPTION
...erver but don't have it defined don't crash (resque-status, resque-retry, and resque-scheduler's tabs all fail with 500 errors at the moment)
