### PR TITLE
Fix LoadError for mocha/setup

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require 'bundler/setup'
 require 'minitest/autorun'
 require 'redis/namespace'
-require 'mocha/setup'
 
 $dir = File.dirname(File.expand_path(__FILE__))
 $LOAD_PATH.unshift $dir + '/../lib'


### PR DESCRIPTION
The Resque tests will no longer pass for me with this line. I get:

```
/Users/tarcieri/dev/resque/test/test_helper.rb:5:in `require': cannot
load such file -- mocha/setup (LoadError)
```

Removing the line fixes the issue.
