### PR TITLE
Fix bad logic on standard Redis failed queue adapter

### DIFF
--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -18,7 +18,7 @@ module Resque
       end
 
       def self.count(queue = nil, class_name = nil)
-        raise ArgumentError, "invalid queue: #{queue}" if queue && queue.to_s != "failed"
+        check_queue(queue)
 
         if class_name
           n = 0
@@ -34,7 +34,7 @@ module Resque
       end
 
       def self.all(offset = 0, limit = 1, queue = nil)
-        raise ArgumentError, "invalid queue: #{queue}" if queue && queue.to_s == "failed"
+        check_queue(queue)
         Resque.list_range(:failed, offset, limit)
       end
 
@@ -47,7 +47,7 @@ module Resque
       end
 
       def self.clear(queue = nil)
-        raise ArgumentError, "invalid queue: #{queue}" if queue && queue.to_s == "failed"
+        check_queue(queue)
         Resque.redis.del(:failed)
       end
 
@@ -82,6 +82,10 @@ module Resque
             i += 1
           end
         end
+      end
+
+      def self.check_queue(queue)
+        raise ArgumentError, "invalid queue: #{queue}" if queue && queue.to_s != "failed"
       end
 
       def filter_backtrace(backtrace)


### PR DESCRIPTION
There were some checks for the queue name in this adapter, in place to
provide a similar API to the multi-queue backend, but with assertions
that we were operating on the right queue.

Problem is: the logic was backwards! D'oh!

This centralizes the check in a method with the correct logic.
