### PR TITLE
Adds Redis pipelining around multiple commands that are independent, see...

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -169,8 +169,10 @@ module Resque
   #
   # Returns nothing
   def push(queue, item)
-    watch_queue(queue)
-    redis.rpush "queue:#{queue}", encode(item)
+    redis.pipelined do
+      watch_queue(queue)
+      redis.rpush "queue:#{queue}", encode(item)
+    end
   end
 
   # Pops a job off a queue. Queue name should be a string.
@@ -217,8 +219,10 @@ module Resque
 
   # Given a queue name, completely deletes the queue.
   def remove_queue(queue)
-    redis.srem(:queues, queue.to_s)
-    redis.del("queue:#{queue}")
+    redis.pipelined do
+      redis.srem(:queues, queue.to_s)
+      redis.del("queue:#{queue}")
+    end
   end
 
   # Used internally to keep track of which queues we've created.


### PR DESCRIPTION
... http://redis.io/topics/pipelining for more info and benchmarks on pipelining.

This pull I adds pipelining around independent Redis commands. I don't expect this to save too much time when used moderately (since these are small pipelines), but I think any speed improvements that don't add unnecessarily complication are good here; we run millions of Resque jobs per day. If we can save 1ms every 10 jobs, that can still equate to hours of compute time per day saved.

---

Also, unrelated, but I had intended to update from the JSON gem (which I saw in master) to MultiJson. The reason is that with MultiJson you get to choose the engine; we use [Oj](http://www.ohler.com/dev/need_for_speed/need_for_speed.html) in our API ([docs](http://www.ohler.com/oj/)); Oj is the fastest JSON library out there for Ruby. When we switched our API to use it instead of the default, we saw a noticeable speed increase in API response times, as our profiler indicated that much time was spent in JSON encoding. However, I see that 1-x-stable is still using MultiJson despite the changelog for 1.24.0 saying that you removed it? If that is in error, I'd advise sticking with MultiJson: Rails uses MultiJson and it lets you swap out the engine, so if someone comes along and writes yet another faster JSON parser, it's trivial to switch.
