### PR TITLE
Update HOOKS.md to point to new repository URL

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -5,7 +5,7 @@ You can customize Resque or write plugins using its hook API. In many
 cases you can use a hook rather than mess with Resque's internals.
 
 For a list of available plugins see
-<http://wiki.github.com/defunkt/resque/plugins>.
+<http://wiki.github.com/resque/resque/plugins>.
 
 
 Worker Hooks


### PR DESCRIPTION
This pull request is to update the `HOOKS.md` documentation to point to the wiki at resque/resque instead of defunkt/resque.
