### PR TITLE
Fix format in resque.rb

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -423,4 +423,4 @@ module Resque
 end
 
 # Log to STDOUT by default
-Resque.logger           = MonoLogger.new(STDOUT)
+Resque.logger = MonoLogger.new(STDOUT)


### PR DESCRIPTION
Hello!

I found a strange format in the last line in the lib/resque.rb . It looks like an error and I fix it.
But If I'm wrong and it was made for some reason, just ignore this.
