### PR TITLE
fix error: wrong number of arguments (0 for 1)

### DIFF
--- a/lib/resque/cli.rb
+++ b/lib/resque/cli.rb
@@ -17,7 +17,7 @@ module Resque
     def work
       load_config
 
-      load_enviroment(Resque.config.require)
+      load_enviroment(Resque.config.requirement)
       worker = Resque::Worker.new(*Resque.config.queues)
 
       worker.term_timeout = Resque.config.timeout

--- a/lib/resque/config.rb
+++ b/lib/resque/config.rb
@@ -15,7 +15,7 @@ module Resque
         :pid => env(:pid_file) || nil,
         :queues => (env(:queue) || env(:queues) || "*"),
         :timeout => env(:rescue_term_timeout) || 4.0,
-        :require => nil
+        :requirement => nil
       }.merge!(options.symbolize_keys!)
     end
 


### PR DESCRIPTION
rake resque:work
/home/vamereh/.rvm/gems/ruby-1.9.3-p362@crm/gems/activesupport-3.2.13/lib/active_support/testing/mochaing.rb:5: warning: already initialized constant Mocha
DEPRECATION WARNING: Rake tasks are depreacted. Use `resque work` instead
rake aborted!
wrong number of arguments (0 for 1)
/home/vamereh/.rvm/gems/ruby-1.9.3-p362@crm/gems/activesupport-3.2.13/lib/active_support/dependencies.rb:249:in `require'
/home/vamereh/.rvm/gems/ruby-1.9.3-p362@crm/bundler/gems/resque-99166d788ca2/lib/resque/cli.rb:20:in`work'
/home/vamereh/.rvm/gems/ruby-1.9.3-p362@crm/bundler/gems/resque-99166d788ca2/lib/resque/tasks.rb:11:in `block (2 levels) in <top (required)>'
/home/vamereh/.rvm/gems/ruby-1.9.3-p362@crm/bin/ruby_noexec_wrapper:14:in`eval'
/home/vamereh/.rvm/gems/ruby-1.9.3-p362@crm/bin/ruby_noexec_wrapper:14:in `<main>'
