### PR TITLE
In .each, make sure that the proper array is created if there is only

### DIFF
--- a/lib/resque/failure/each.rb
+++ b/lib/resque/failure/each.rb
@@ -2,7 +2,7 @@ module Resque
   module Failure
     module Each
       def each(offset = 0, limit = self.count, queue = :failed, class_name = nil)
-        items = Array(all(offset, limit, queue))
+        items = [all(offset, limit, queue)].flatten
         items.each_with_index do |item, i|
           if !class_name || (item['payload'] && item['payload']['class'] == class_name)
             yield offset + i, item


### PR DESCRIPTION
In Resque::Failure.each, make sure that the proper array is created if there is only on failure.

This fixes resque/resque-web#6

If there is only one failure, the Array method turns the hash into an array of arrays, instead of one Array with a single element, the first hash. Like this:

```
1.9.3p327 :003 > item = {"failed_at"=>"Sat, 30 Mar 2013 21:56:12 -0700", "payload"=>{"class"=>"MyJobClass", "args"=>[166]}, "exception"=>"RuntimeError", "error"=>"failing!"}
 => {"failed_at"=>"Sat, 30 Mar 2013 21:56:12 -0700", "payload"=>{"class"=>"MyJobClass", "args"=>[166]}, "exception"=>"RuntimeError", "error"=>"failing!"} 
1.9.3p327 :004 > Array(item)
 => [["failed_at", "Sat, 30 Mar 2013 21:56:12 -0700"], ["payload", {"class"=>"MyJobClass", "args"=>[166]}], ["exception", "RuntimeError"], ["error", "failing!"]]
```

The only time we actually _don't_ get an array(require us to use `Array()`) is when `Resque.list_range` is called with a count of 1 and use `redis.lindex`, otherwise we use `lrange` which returns an array. 

So it seems to be fine to just use `[items].flatten`, this will still work if we actually get an array instead of a single item. 

```
1.9.3p327 :007 > [item].flatten
 => [{"failed_at"=>"Sat, 30 Mar 2013 21:56:12 -0700", "payload"=>{"class"=>"MyJobClass", "args"=>[166]}, "exception"=>"RuntimeError", "error"=>"failing!"}] 
```

If you have a better idea of how to solve this problem let me know! At first I tried changing the `list_range` method to always return an array, but that caused some tests to fail.

This didn't break any tests, and I'd like to write a new test, but I'm a bit unsure about where to start since it would have to integrate so many things (or stub them out). Should I start a redis server in the test, like the legacy tests do?

Anyway I'll add a test today probably, but I wanted to get my work out there early.
