### PR TITLE
Add ability to require a specific file when loading.

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -57,8 +57,12 @@ namespace :resque do
   # Preload app files if this is Rails
   task :preload => :setup do
     if defined?(Rails) && Rails.respond_to?(:application)
-      # Rails 3
-      Rails.application.eager_load!
+      if ENV["REQUIRE"].present?
+        require ENV["REQUIRE"]
+      else
+        # Rails 3
+        Rails.application.eager_load!
+      end
     elsif defined?(Rails::Initializer)
       # Rails 2.3
       $rails_rake_task = false


### PR DESCRIPTION
Adding this allows the user to specify the location of the Rails application to require or a file that lists the requirements.

We were having issues where eager_load! wasn't working so adding this fixed the issue.
