### PR TITLE
Use capybara 2.0.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,5 @@ group :test do
   gem "json"
   gem "minitest"
   gem "sinatra"
-  gem "capybara"
+  gem "capybara", "~> 2.0.3"
 end


### PR DESCRIPTION
Capybara since 2.1.x have hard version requirement on ruby >= 1.9.3

Fixes tests on travis.
