### PR TITLE
Hash core ext conditional definition

### DIFF
--- a/lib/resque/core_ext/hash.rb
+++ b/lib/resque/core_ext/hash.rb
@@ -4,15 +4,15 @@ class Hash
       options[(key.to_sym rescue key) || key] = value
       options
     end
-  end
+  end unless Hash.respond_to?(:symbolize_keys)
 
   def symbolize_keys!
     self.replace(self.symbolize_keys)
-  end
+  end unless Hash.respond_to?(:symbolize_keys!)
 
   def slice(*keys)
     hash = self.class.new
     keys.each { |k| hash[k] = self[k] if has_key?(k) }
     hash
-  end
+  end unless Hash.respond_to?(:slice)
 end


### PR DESCRIPTION
Define core ext hash methods only if they do not exist already. If we have this for other core exts, we should have it for `Hash` as well.

Also, it struck me that those methods are pulled straight from Rails (ActiveSupport) source code. Shouldn't we include info about that in comments or somewhere?

To be honest, I have no idea how this licensing thing works ;) Asking for a friend (cc @steveklabnik)
