### PR TITLE
When the failed jobs are shown in reverse order, pass the right Redis li...

### DIFF
--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -40,12 +40,19 @@ module Resque
 
       def self.each(offset = 0, limit = self.count, queue = :failed, class_name = nil, order = 'desc')
         all_items = Array(all(offset, limit, queue))
+        reversed = false
         if order.eql? 'desc'
           all_items.reverse!
+          reversed = true
         end
         all_items.each_with_index do |item, i|
           if !class_name || (item['payload'] && item['payload']['class'] == class_name)
-            yield offset + i, item
+            if reversed
+              id = (all_items.length - 1) - (offset + i)
+            else
+              id = offset + i
+            end
+            yield id, item
           end
         end
       end


### PR DESCRIPTION
...st index to be used for retry/remove.

---

Another problem from @alexeyfrank's the pull request, #917.
