### PR TITLE
Fix worker_test failure under Ruby 1.8.7

### DIFF
--- a/test/resque/worker_test.rb
+++ b/test/resque/worker_test.rb
@@ -6,7 +6,7 @@ require 'socket'
 describe Resque::Worker do
   describe "#state" do
     it "gives us the current state" do
-      worker = Resque::Worker.new :queue => "foo"
+      worker = Resque::Worker.new [:foo, :bar]
       registry = MiniTest::Mock.new.expect(:state, "working")
 
       worker.stub(:worker_registry, registry) do
@@ -17,11 +17,11 @@ describe Resque::Worker do
 
   describe "#to_s, #inspect" do
     it "gives us string representations of a worker" do
-      worker = Resque::Worker.new(:queue => "foo")
+      worker = Resque::Worker.new [:foo, :bar]
       Socket.stub(:gethostname, "test.com") do
         worker.stub(:pid, "1234") do
-          assert_equal "test.com:1234:{:queue=>\"foo\"}", worker.to_s
-          assert_equal "#<Worker test.com:1234:{:queue=>\"foo\"}>", worker.inspect
+          assert_equal "test.com:1234:foo,bar", worker.to_s
+          assert_equal "#<Worker test.com:1234:foo,bar>", worker.inspect
         end
       end
     end


### PR DESCRIPTION
Resque test failed under Ruby 1.8.7 env. https://travis-ci.org/resque/resque/jobs/6367594

The reason why worker_test failed under 1.8.7 is `Hash#to_s` in 1.8.7
is different from other versions(1.9/2.0).

`{:a => 1}.to_s` under 1.8.7 is `a1`, but under 1.9/2.0 is `{:a=>1}`.

And also, the original way to new a resque worker seems not right,
we should pass either an array of queues' names or just one name,
but not a Hash object.

cc @steveklabnik @sshingler
