### PR TITLE
preliminary work for failure backend shared examples

### DIFF
--- a/test/resque/failure/failure_backend_test.rb
+++ b/test/resque/failure/failure_backend_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+require 'resque'
+require 'resque/failure'
+require 'resque/failure/base'
+
+shared_examples_for 'A Failure Backend' do
+  describe '.count' do
+    it 'returns the number of failures' do
+      Resque::Failure.count.must_equal 2
+    end
+  end
+
+  describe '.queues' do
+    it 'returns an array of all the available queues' do
+      Resque::Failure.queues.must_equal ["jobs_failed"]
+    end
+  end
+
+  describe '.all' do
+    it 'returns an array of all the failures' do
+      Resque::Failure.all(0,2,:jobs_failed).must_equal [{"failure_data"=>"blahblah"},{"failure_data"=>"blahblah"}]
+    end
+  end
+
+  describe '.each' do
+    it 'returns an enumerator of all the failures' do
+      Resque::Failure.each do |f|
+        f.must_equal({"failure_data"=>"blahblah"})
+      end
+    end
+  end
+
+  describe '.clear' do
+    it 'removes all failed jobs' do
+      Resque::Failure.clear
+      Resque::Failure.all.must_equal nil
+    end
+  end
+
+  describe '.remove' do
+    it 'removes a single failed job' do
+    end
+  end
+  
+  describe '.requeue' do
+    it 'requeues a job'
+  end
+end

--- a/test/resque/failure/redis_multi_queue_test.rb
+++ b/test/resque/failure/redis_multi_queue_test.rb
@@ -1,0 +1,20 @@
+require 'failure/failure_backend_test'
+require 'resque/failure/redis_multi_queue'
+require 'mock_redis'
+
+describe Resque::Failure::RedisMultiQueue do
+  before :each do
+    Resque.redis = MockRedis.new :host => "localhost", :port => 9736, :db => 0
+    Resque::Failure.backend = Resque::Failure::RedisMultiQueue
+
+    queue = :jobs
+    # make two failures 
+    data = Resque.encode({:failure_data=>:blahblah})
+    2.times { Resque.redis.rpush(Resque::Failure.failure_queue_name(queue), data) }
+  end
+  it_behaves_like 'A Failure Backend'
+
+  it 'saves' do
+
+  end
+end

--- a/test/resque/test_helper.rb
+++ b/test/resque/test_helper.rb
@@ -19,3 +19,25 @@ module Kernel
     defined?(JRUBY_VERSION)
   end
 end
+
+# shared examples taken from https://gist.github.com/jodosha/1560208
+
+MiniTest::Spec.class_eval do
+  def self.shared_examples
+    @shared_examples ||= {}
+  end
+end
+
+module MiniTest::Spec::SharedExamples
+  def shared_examples_for(desc, &block)
+    MiniTest::Spec.shared_examples[desc] = block
+  end
+
+  def it_behaves_like(desc)
+    self.instance_eval do
+      MiniTest::Spec.shared_examples[desc].call
+    end
+  end
+end
+
+Object.class_eval { include(MiniTest::Spec::SharedExamples) }


### PR DESCRIPTION
Hey! So I took a shot at making some shared examples like we talked about in #916. I thought I'd share what I'd have so far to discuss what changes in the API we'd like to make. 
- .all vs. .each, should we pick one or the other? couldn't you just enumerate over .all? I think I'm fine with having both, but can .all always return all the failures and not have a limit argument?
- .remove in base takes one argument, but .remove in redis_multi_queue takes two. this
  doesn't seem to quite work out since the .remove is called in failure.rb like this:
  
  ```
  def self.remove(id)
    backend.remove(id)
  end
  ```
- same problem with .requeue, that's why there is no test for these methods in this patch yet. :)
- self.url doesn't seem to be used. Should it stay?

Let me know if you have any thoughts, and I'll keep working at this. Thanks!
