### PR TITLE
The output of executed command may contain invalid utf-8 byte.

### DIFF
--- a/lib/resque/process_coordinator.rb
+++ b/lib/resque/process_coordinator.rb
@@ -25,6 +25,9 @@ module Resque
 
       raise 'System call for ps command failed. Please make sure that you have a compatible ps command in the path!' unless $?.success?
 
+      # output may contain invalid byte sequence in UTF-8
+      output = output.unpack('C*').pack('U*') if !output.valid_encoding?
+
       output.split($/).each do |line|
         next unless line =~ /resque/i
         next if line =~ /resque-web/


### PR DESCRIPTION
- On my local machine, `test/legacy/worker_test.rb` test will fail
  because in `worker_pids returns pids` test, `ps -A -o pid,command`
  command result contains invalid byte sequence in UTF-8.
  And an error will be raised when spliting an invalid UTF-8 stirng.
