### PR TITLE
provide a default redis server if not specified

### DIFF
--- a/lib/resque/cli.rb
+++ b/lib/resque/cli.rb
@@ -14,7 +14,7 @@ module Resque
         @options = YAML.load_file(options[:config]).symbolize_keys.merge(@options.symbolize_keys)
       end
 
-      Resque.redis = options[:redis]
+      Resque.redis = options[:redis] || "localhost:6379/resque"
     end
 
     desc "work", "Start processing jobs."


### PR DESCRIPTION
All the tests run successfully on my local machine with this change, however I am not sure how to test this. Also, I can start the server without specifying the redis info.

aarti@local$bin/resque work --queues=default
I, [2013-04-20T19:09:40.220856 #5554]  INFO -- : ["default"]
D, [2013-04-20T19:09:40.220972 #5554] DEBUG -- : resque-2.0.0.pre.1: Starting
