### PR TITLE
Issue #461 Show errors for background resque

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -29,7 +29,7 @@ namespace :resque do
       unless Process.respond_to?('daemon')
           abort "env var BACKGROUND is set, which requires ruby >= 1.9"
       end
-      Process.daemon(true)
+      Process.daemon(true, true)
     end
 
     if ENV['PIDFILE']


### PR DESCRIPTION
Don't redirect stdout and stderr to /dev/null when deamonizing, since it
will make resque just exit silently when the connection to redis fails
which is bad ...
