### PR TITLE
Changed version number in README.md to use the same as version.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ them. :metal:
 To install Resque, add the gem to your Gemfile:
 
 ```
-gem "resque", "~> 2.0"
+gem "resque", "~> 2.0.0.pre.1"
 ```
 
 Then run `bundle`. If you're not using Bundler, just `gem install resque`.


### PR DESCRIPTION
Hey,

I realize that you are using README driven development for Resque 2.0, but I think it'd be useful to have the right version number in there.

I am currently migrating from 1-x-stable to 2.0 because I need one of the latest patches. 

What do you think @steveklabnik?

Thanks,
Ernesto
