### PR TITLE
Adding test for default redis

### DIFF
--- a/test/resque/cli_test.rb
+++ b/test/resque/cli_test.rb
@@ -2,6 +2,18 @@ require 'test_helper'
 require 'resque/cli'
 
 describe Resque::CLI do
+
+  describe "#initialize" do
+    it "uses a default redis without a specified option" do
+      stubbed_redis = lambda { |server|
+        assert_equal 'localhost:6379/resque', server
+      }
+      Resque.stub(:redis=, stubbed_redis) do
+        Resque::CLI.new
+      end
+    end
+  end
+
   describe "#work" do
     it "does its thing" do
       Resque::Worker.stub(:new, MiniTest::Mock.new.expect(:work, "did some work!")) do


### PR DESCRIPTION
Hi, this should hopefully add the missing test for [this commit](https://github.com/resque/resque/commit/cf22381e8738aa132e4e3d18ce518ed8b0c85031).

At least the test is failing without the code in this commit.
