### PR TITLE
Use windows_worker_pids method on mingw environment

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -615,6 +615,8 @@ module Resque
     def worker_pids
       if RUBY_PLATFORM =~ /solaris/
         solaris_worker_pids
+      elsif RUBY_PLATFORM =~ /mingw32/
+        windows_worker_pids
       else
         linux_worker_pids
       end


### PR DESCRIPTION
I want to use resque in Windows.
