### PR TITLE
Extracted a new WorkerQueueList class out of Rescue::Worker

### DIFF
--- a/lib/resque/worker_queue_list.rb
+++ b/lib/resque/worker_queue_list.rb
@@ -1,0 +1,42 @@
+module Resque
+
+  class WorkerQueueList
+    attr_reader :queues
+
+    def initialize(queues)
+      @queues = (queues.is_a?(Array) ? queues : [queues]).map { |queue| queue.to_s.strip }
+    end
+
+    def empty?
+      queues.nil? || queues.empty?
+    end
+
+    def size
+      queues.size
+    end
+
+    def first
+      search_order.first
+    end
+
+    def to_s
+      queues.join(',')
+    end
+
+    # Returns a list of queues to use when searching for a job.
+    # A splat ("*") means you want every queue (in alpha order) - this
+    # can be useful for dynamically adding new queues. Low priority queues
+    # can be placed after a splat to ensure execution after all other dynamic
+    # queues.
+    def search_order
+      queues.map do |queue|
+        if queue == "*"
+          (Resque.queues - queues).sort
+        else
+          queue
+        end
+      end.flatten.uniq
+    end
+  end
+
+end


### PR DESCRIPTION
Currently Rescue::Worker is responsible for several things, this is an
attempt to move the queue management logic into a seperate class.

I left Rescue::Worker#queues method in due to legacy tests failing if I
removed it. Instead I let it delegate its work to the new
WorkerQueueList class. But if no external class is calling it then it should be
safe to remove it.
- Extracted @queues from Rescue::Worker into a WorkerQueueList class
- Modified Rescue::Worker to use the the new WorkerQueueList class.
