### PR TITLE
change #inline? memoization from ||= to defined?

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -130,7 +130,7 @@ module Resque
   end
 
   def inline?
-    @inline ||= false
+    @inline if defined?(@inline)
   end
 
   #


### PR DESCRIPTION
`||=` doesn't make sense in this case because it's a boolean. If `@inline` is false, it will unnecessarily be written to.
