### PR TITLE
Do not prune workers from queues that we don't listen to.

### DIFF
--- a/lib/resque/worker_queue_list.rb
+++ b/lib/resque/worker_queue_list.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Resque
 
   class WorkerQueueList
@@ -21,6 +23,14 @@ module Resque
 
     def to_s
       queues.join(',')
+    end
+
+    def to_set
+      queues.to_set
+    end
+
+    def all_queues?
+      queues.include?("*")
     end
 
     # Returns a list of queues to use when searching for a job.


### PR DESCRIPTION
If the worker we are trying to prune does not belong to the queues we are listening to, we should not touch it.

Port of a fix to 1.x branch: https://github.com/resque/resque/pull/1000
