### PR TITLE
require 'resque' in test_helper so you can run specific tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,12 @@ anything.
 A simple `bundle exec rake` will run all the tests. Make sure they pass when
 you submit a pull request.
 
+To run a specific test, for example:
+
+```
+bundle exec ruby -Ilib -Itest/resque test/resque/job_performer_test.rb
+```
+
 Please include tests with your pull request.
 
 Documentation

--- a/test/resque/test_helper.rb
+++ b/test/resque/test_helper.rb
@@ -1,3 +1,4 @@
+require 'resque'
 require 'simplecov'
 SimpleCov.start do
   add_filter do |source_file|


### PR DESCRIPTION
I had to do this in order to be able to run specific tests

Also updated CONTRIBUTING.md with how I was able to run single tests

If there is a better way, we should document that
