### PR TITLE
introduce Resque::Options, delete will_fork?

### DIFF
--- a/lib/resque/child_process.rb
+++ b/lib/resque/child_process.rb
@@ -35,17 +35,10 @@ module Resque
     end
 
     def fork(job, &block)
-      return unless will_fork?
+      return unless worker.options.fork_per_job
 
       worker_hooks.run_hook :before_fork, job
       Kernel.fork(&block)
-    end
-
-    # We cannot simply move this method out of the worker
-    # without breaking the legacy tests (which are stubbing 
-    # the will_fork? method)
-    def will_fork?
-      worker.will_fork?
     end
 
     def reconnect

--- a/lib/resque/options.rb
+++ b/lib/resque/options.rb
@@ -1,0 +1,51 @@
+module Resque
+  class Options
+
+    def initialize(options)
+      @options = default_options.merge(options.symbolize_keys)
+    end
+
+    def [](val)
+      @options[val]
+    end
+
+    def delete(val)
+      @options.delete(val)
+    end
+
+    def fetch(val, &block)
+      @options.fetch(val, &block)
+    end
+
+    def fork_per_job
+      self[:fork_per_job]
+    end
+
+    def to_hash
+      @options
+    end
+
+  private
+
+    def default_options
+      {
+        # Termination timeout
+        :timeout => 5,
+        # Worker's poll interval
+        :interval => 5,
+        # Run as deamon
+        :daemon => false,
+        # Path to file file where worker's pid will be save
+        :pid_file => nil,
+        # Use fork(2) on performing jobs
+        :fork_per_job => true,
+        # When set to true, forked workers will exit with `exit`, calling any `at_exit` code handlers that have been
+        # registered in the application. Otherwise, forked workers exit with `exit!`
+        :run_at_exit_hooks => false,
+        # the logger we're going to use.
+        :logger => Resque.logger,
+      }
+    end
+
+  end
+end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -10,6 +10,7 @@ require 'resque/child_process'
 require 'resque/errors'
 require 'resque/backend'
 require 'resque/ioawaiter'
+require 'resque/options'
 
 module Resque
   # A Resque Worker processes jobs. On platforms that support fork(2),
@@ -45,7 +46,7 @@ module Resque
     # in alphabetical order. Queues can be dynamically added or
     # removed without needing to restart workers using this method.
     def initialize(queues = [], options = {})
-      @options = default_options.merge(options.symbolize_keys)
+      @options = Options.new(options)
       @worker_queues = WorkerQueueList.new(queues)
       @shutdown = nil
       @paused = nil
@@ -259,10 +260,6 @@ module Resque
       end
     end
 
-    def will_fork?
-      options[:fork_per_job]
-    end
-
     protected
     # Stop processing jobs after the current one has completed (if we're
     # currently running one).
@@ -404,27 +401,6 @@ module Resque
 
       logger.debug "Found job on #{queue}"
       Job.new(queue.name, job) if (queue && job)
-    end
-
-  private
-    def default_options
-      {
-        # Termination timeout
-        :timeout => 5,
-        # Worker's poll interval
-        :interval => 5,
-        # Run as deamon
-        :daemon => false,
-        # Path to file file where worker's pid will be save
-        :pid_file => nil,
-        # Use fork(2) on performing jobs
-        :fork_per_job => true,
-        # When set to true, forked workers will exit with `exit`, calling any `at_exit` code handlers that have been
-        # registered in the application. Otherwise, forked workers exit with `exit!`
-        :run_at_exit_hooks => false,
-        # the logger we're going to use.
-        :logger => Resque.logger,
-      }
     end
 
   end

--- a/test/legacy/test_helper.rb
+++ b/test/legacy/test_helper.rb
@@ -197,3 +197,7 @@ def reset_logger
 end
 
 reset_logger
+
+def stub_to_fork(worker, should_fork, &block)
+  worker.options.stub(:fork_per_job, should_fork, &block)
+end

--- a/test/resque/worker_test.rb
+++ b/test/resque/worker_test.rb
@@ -11,12 +11,12 @@ describe Resque::Worker do
   describe "#initialize" do
     it "contains the correct default options" do
       worker = Resque::Worker.new [:foo, :bar]
-      assert_equal worker.options, {:timeout => 5, :interval => 5, :daemon => false, :pid_file => nil, :fork_per_job => true, :run_at_exit_hooks => false }
+      assert_equal worker.options.to_hash, {:timeout => 5, :interval => 5, :daemon => false, :pid_file => nil, :fork_per_job => true, :run_at_exit_hooks => false }
     end
 
     it "overrides default options with its parameter" do
       worker = Resque::Worker.new [:foo, :bar], :interval => 10
-      assert_equal worker.options, {:timeout => 5, :interval => 10, :daemon => false, :pid_file => nil, :fork_per_job => true, :run_at_exit_hooks => false }
+      assert_equal worker.options.to_hash, {:timeout => 5, :interval => 10, :daemon => false, :pid_file => nil, :fork_per_job => true, :run_at_exit_hooks => false }
     end
 
     it "initalizes the specified queues" do


### PR DESCRIPTION
A useful thing to have before I continue with #1019

introduce Resque::Options as a wrapper for the options hash, replace will_fork? with options.fork_per_job. change legacy tests to make this easier to change in future refactorings

I thought this should be a separate commit, agree?
