### PR TITLE
Remove some unnecessary "begin" keywords

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -160,11 +160,9 @@ module Resque
   #
   # Returns a Ruby object.
   def pop(queue)
-    begin
-      queue(queue).pop(true)
-    rescue ThreadError
-      nil
-    end
+    queue(queue).pop(true)
+  rescue ThreadError
+    nil
   end
 
   # Returns an integer representing the size of a queue.

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -132,19 +132,17 @@ module Resque
     # Calls #perform on the class given in the payload with the
     # arguments given in the payload.
     def perform
-      begin
-        hooks = {
-          :before => before_hooks,
-          :around => around_hooks,
-          :after => after_hooks
-        }
-        JobPerformer.new.perform(payload_class, args, hooks)
-      # If an exception occurs during the job execution, look for an
-      # on_failure hook then re-raise.
-      rescue Object => e
-        run_failure_hooks(e)
-        raise e
-      end
+      hooks = {
+        :before => before_hooks,
+        :around => around_hooks,
+        :after => after_hooks
+      }
+      JobPerformer.new.perform(payload_class, args, hooks)
+    # If an exception occurs during the job execution, look for an
+    # on_failure hook then re-raise.
+    rescue Object => e
+      run_failure_hooks(e)
+      raise e
     end
 
     # Returns the actual class constant represented in this job's payload.
@@ -185,16 +183,14 @@ module Resque
     # the Failure module.
     def fail(exception)
       Resque.logger.info "#{inspect} failed: #{exception.inspect}"
-      begin
-        run_failure_hooks(exception) if has_payload_class?
-        Failure.create \
-          :payload   => payload,
-          :exception => exception,
-          :worker    => worker,
-          :queue     => queue
-      rescue Exception => e
-        Resque.logger.info "Received exception when reporting failure: #{e.inspect}"
-      end
+      run_failure_hooks(exception) if has_payload_class?
+      Failure.create \
+        :payload   => payload,
+        :exception => exception,
+        :worker    => worker,
+        :queue     => queue
+    rescue Exception => e
+      Resque.logger.info "Received exception when reporting failure: #{e.inspect}"
     end
 
     # Creates an identical job, essentially placing this job back on
@@ -233,16 +229,14 @@ module Resque
     end
 
     def run_failure_hooks(exception)
-      begin
-        job_args = args || []
-        unless @failure_hooks_ran
-          failure_hooks.each do |hook|
-            payload_class.send(hook, exception, *job_args)
-          end
+      job_args = args || []
+      unless @failure_hooks_ran
+        failure_hooks.each do |hook|
+          payload_class.send(hook, exception, *job_args)
         end
-      ensure
-        @failure_hooks_ran = true
       end
+    ensure
+      @failure_hooks_ran = true
     end
 
     protected

--- a/lib/resque/job_performer.rb
+++ b/lib/resque/job_performer.rb
@@ -26,12 +26,10 @@ module Resque
 
     private
     def call_before_hooks
-      begin
-        call_hooks(:before)
-        true
-      rescue Resque::DontPerform
-        false
-      end
+      call_hooks(:before)
+      true
+    rescue Resque::DontPerform
+      false
     end
 
     def execute_job

--- a/lib/resque/json_coder.rb
+++ b/lib/resque/json_coder.rb
@@ -11,21 +11,16 @@ module Resque
 
   class JsonCoder < Coder
     def encode(object)
-      begin
-        JSON.dump object
-      rescue ENCODING_EXCEPTION => e
-        raise EncodeException, e.message, e.backtrace
-      end
+      JSON.dump object
+    rescue ENCODING_EXCEPTION => e
+      raise EncodeException, e.message, e.backtrace
     end
 
     def decode(object)
       return unless object
-
-      begin
-        JSON.load object
-      rescue JSON::ParserError => e
-        raise DecodeException, e.message, e.backtrace
-      end
+      JSON.load object
+    rescue JSON::ParserError => e
+      raise DecodeException, e.message, e.backtrace
     end
   end
 end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -246,18 +246,16 @@ module Resque
     # Processes a given job in the child.
     def perform(job)
       procline "Processing #{job.queue} since #{Time.now.to_i} [#{job.payload_class_name}]"
-      begin
-        worker_hooks.run_hook :before_perform, job
-        job.perform
-        worker_hooks.run_hook :after_perform, job
-      rescue Object => e
-        job.fail(e)
-        failed!
-      else
-        logger.info "done: #{job.inspect}"
-      ensure
-        yield job if block_given?
-      end
+      worker_hooks.run_hook :before_perform, job
+      job.perform
+      worker_hooks.run_hook :after_perform, job
+    rescue Object => e
+      job.fail(e)
+      failed!
+    else
+      logger.info "done: #{job.inspect}"
+    ensure
+      yield job if block_given?
     end
 
     protected


### PR DESCRIPTION
`begin` [is a code smell](http://youtu.be/qEHn46YtRM8?t=27m25s), so I've looked into Resque's usage of this keyword.

When `begin` is applied to an entire method, it can be replaced by the idiomatic method-level exception clause. This is what I've done in this pull request.

There are 31 remaining instances of `begin` (8 in lib, 23 in test) and most of them are smells that indicate refactoring should be done. But I'll leave that for future pull requests.
