### PR TITLE
Correctly join file path to include redis yml

### DIFF
--- a/lib/generators/resque/templates/resque.rb
+++ b/lib/generators/resque/templates/resque.rb
@@ -1,3 +1,2 @@
 # Load the redis configuration from resque.yml
-
-Resque.redis = YAML.load_file(Rails.root.join("/config/resque.yml"))[Rails.env.to_s]
+Resque.redis = YAML.load_file(File.join(Rails.root, "config", "resque.yml"))[Rails.env.to_s]


### PR DESCRIPTION
In Rails 4.0.0.rc1 and ruby 2.0.0-p0, the Rails.root doesn't extend the path correctly via Rails.root.join, resulting in an error to include the yml file. 
This patch uses ruby's File.join to join the dirs together into a correct, full path.
