### PR TITLE
Defining the missing jruby? method

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -185,12 +185,12 @@ module Resque
         workers_queues = workers_queues_raw.split(",")
         unless worker_queues.all_queues? || (workers_queues.to_set == worker_queues.to_set)
           # If the worker we are trying to prune does not belong to the queues
-          # we are listening to, we should not touch it. 
+          # we are listening to, we should not touch it.
           # Attempt to prune a worker from different queues may easily result in
-          # an unknown class exception, since that worker could easily be even 
+          # an unknown class exception, since that worker could easily be even
           # written in different language.
           next
-        end        
+        end
         next unless host == hostname
         next if known_workers.include?(pid)
         logger.debug "Pruning dead worker: #{worker}"
@@ -327,6 +327,10 @@ module Resque
       SignalTrapper.trap_or_warn('USR2') { pause_processing }
 
       logger.debug "Registered signals"
+    end
+
+    def jruby?
+      defined?(JRUBY_VERSION)
     end
 
     # Tell Redis we've processed a job.

--- a/test/legacy/worker_test.rb
+++ b/test/legacy/worker_test.rb
@@ -30,7 +30,7 @@ describe "Resque::Worker" do
       worker.work
       assert_equal 1, Resque::Failure.count
     ensure
-      Resque.redis = $mock_redis 
+      Resque.redis = $mock_redis
     end
   end
 
@@ -84,6 +84,10 @@ describe "Resque::Worker" do
     registry = Resque::WorkerRegistry.new(worker)
     registry.working_on worker, job
     assert_equal now, registry.processing['run_at']
+  end
+
+  it "defines the jruby? method" do
+    assert worker.respond_to? :jruby?
   end
 
   unless jruby?


### PR DESCRIPTION
This defines the jruby? method used in d4e5693d but never defined. This
was discussed in #1003.
