### PR TITLE
Require all the things as needed in tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,12 @@ anything.
 A simple `bundle exec rake` will run all the tests. Make sure they pass when
 you submit a pull request.
 
+To run a specific test, for example:
+
+```
+bundle exec ruby -Ilib -Itest/resque test/resque/job_performer_test.rb
+```
+
 Please include tests with your pull request.
 
 Documentation

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -30,9 +30,6 @@ module Resque
     yield config
   end
 
-  # Returns the current Redis connection. If none has been created, will
-  # create a new one.
-
   def redis_id
     config.redis_id
   end

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -2,7 +2,6 @@ require 'mono_logger'
 require 'redis/namespace'
 
 require 'resque/version'
-require 'resque/config'
 
 require 'resque/errors'
 
@@ -10,6 +9,7 @@ require 'resque/failure/base'
 require 'resque/failure'
 require 'resque/failure/redis'
 
+require 'resque/globals'
 require 'resque/stat'
 require 'resque/logging'
 require 'resque/job'
@@ -20,50 +20,14 @@ require 'resque/plugin'
 require 'resque/queue'
 require 'resque/multi_queue'
 require 'resque/coder'
-require 'resque/json_coder'
-require 'resque/hook_register'
 
 require 'forwardable'
 
 module Resque
   extend self
 
-  def encode(object)
-    Resque.coder.encode(object)
-  end
-
-  def decode(object)
-    Resque.coder.decode(object)
-  end
-
-  extend Forwardable
-
-  def self.config=(options = {})
-    @config = Config.new(options)
-  end
-
-  def self.config
-    @config ||= Config.new
-  end
-
   def self.configure
     yield config
-  end
-
-  def backend
-    @backend ||= Backend.new(config.redis, Resque.logger)
-  end
-
-  def redis=(server)
-    config.redis = server
-
-    @queues = Hash.new do |h,name|
-      h[name] = Resque::Queue.new(name, config.redis, coder)
-    end
-
-    @backend = Backend.new(config.redis, Resque.logger)
-
-    config.redis
   end
 
   # Returns the current Redis connection. If none has been created, will
@@ -81,88 +45,8 @@ module Resque
     config.namespace
   end
 
-  # Encapsulation of encode/decode. Overwrite this to use it across Resque.
-  # This defaults to JSON for backwards compatibility.
-  def coder
-    @coder ||= JsonCoder.new
-  end
-  attr_writer :coder
-
-  # Set or retrieve the current logger object
-  attr_accessor :logger
-
-  @hook_register = HookRegister.new
-
-  def_delegators :@hook_register,
-    :before_first_fork,
-    :before_first_fork=,
-    :before_fork,
-    :before_fork=,
-    :after_fork,
-    :after_fork=,
-    :before_pause,
-    :before_pause=,
-    :after_pause,
-    :after_pause=,
-    :before_perform,
-    :before_perform=,
-    :after_perform,
-    :after_perform=
-
   def to_s
     "Resque Backend connected to #{redis_id}"
-  end
-
-  # If 'inline' is true Resque will call #perform method inline
-  # without queuing it into Redis and without any Resque callbacks.
-  # The 'inline' is false Resque jobs will be put in queue regularly.
-  attr_writer :inline
-
-  def inline(&block)
-    block ? inline_block(&block) : inline?
-  end
-
-  def inline_block
-    self.inline = true
-    yield
-  ensure
-    self.inline = false
-  end
-
-  def inline?
-    @inline if defined?(@inline)
-  end
-
-  #
-  # queue manipulation
-  #
-
-  # Pushes a job onto a queue. Queue name should be a string and the
-  # item should be any JSON-able Ruby object.
-  #
-  # Resque workers generally expect the `item` to be a hash with the following
-  # keys:
-  #
-  #   class - The String name of the job to run.
-  #    args - An Array of arguments to pass the job. Usually passed
-  #           via `class.to_class.perform(*args)`.
-  #
-  # Example
-  #
-  #   Resque.push('archive', 'class' => 'Archive', 'args' => [ 35, 'tar' ])
-  #
-  # Returns nothing
-  def push(queue, item)
-    queue(queue) << item
-  end
-
-  # Pops a job off a queue. Queue name should be a string.
-  #
-  # Returns a Ruby object.
-  def pop(queue)
-    queue(queue).pop(true)
-  rescue ThreadError
-    nil
   end
 
   # Returns an integer representing the size of a queue.
@@ -191,34 +75,11 @@ module Resque
     end
   end
 
-  # Does the dirty work of fetching a range of items from a Redis list
-  # and converting them into Ruby objects.
-  def list_range(key, start = 0, count = 1)
-    if count == 1
-      decode(backend.store.lindex(key, start))
-    else
-      Array(backend.store.lrange(key, start, start+count-1)).map do |item|
-        decode(item)
-      end
-    end
-  end
-
-  # Returns an array of all known Resque queues as strings.
-  def queues
-    Array(backend.store.smembers(:queues))
-  end
-
   # Given a queue name, completely deletes the queue.
   def remove_queue(queue)
     queue(queue).destroy
     @queues.delete(queue.to_s)
   end
-
-  # Return the Resque::Queue object for a given name
-  def queue(name)
-    @queues[name.to_s]
-  end
-
 
   #
   # job shortcuts
@@ -336,23 +197,6 @@ module Resque
       klass.instance_variable_get(:@queue)
     else
       (klass.respond_to?(:queue) and klass.queue)
-    end
-  end
-
-  # Validates if the given klass could be a valid Resque job
-  #
-  # If no queue can be inferred this method will raise a `Resque::NoQueueError`
-  #
-  # If given klass is nil this method will raise a `Resque::NoClassError`
-  def validate(klass, queue = nil)
-    queue ||= queue_from_class(klass)
-
-    unless queue
-      raise NoQueueError.new("Jobs must be placed onto a queue.")
-    end
-
-    if klass.to_s.empty?
-      raise NoClassError.new("Jobs must be given a class.")
     end
   end
 

--- a/lib/resque/backend.rb
+++ b/lib/resque/backend.rb
@@ -1,3 +1,6 @@
+require 'redis-namespace'
+require 'redis/distributed'
+
 ##
 # Resque::Backend is a wrapper around all things Redis.
 #

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -1,5 +1,8 @@
 require 'time'
+require 'resque/failure'
+require 'resque/failure/base'
 require 'resque/failure/each'
+require 'resque/job'
 
 module Resque
   module Failure

--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -1,4 +1,7 @@
+require 'resque/failure'
+require 'resque/failure/base'
 require 'resque/failure/each'
+require 'resque/job'
 
 module Resque
   module Failure

--- a/lib/resque/globals.rb
+++ b/lib/resque/globals.rb
@@ -1,0 +1,168 @@
+require 'resque/json_coder'
+require 'resque/backend'
+require 'resque/config'
+require 'resque/hook_register'
+
+module Resque
+
+  class << self
+
+    extend Forwardable
+
+    def hook_register
+      @hook_register ||= HookRegister.new
+    end
+
+    def_delegators :hook_register,
+      :before_first_fork,
+      :before_first_fork=,
+      :before_fork,
+      :before_fork=,
+      :after_fork,
+      :after_fork=,
+      :before_pause,
+      :before_pause=,
+      :after_pause,
+      :after_pause=,
+      :before_perform,
+      :before_perform=,
+      :after_perform,
+      :after_perform=
+
+    def config=(options = {})
+      @config = Config.new(options)
+    end
+
+    def config
+      @config ||= Config.new
+    end
+
+    # If 'inline' is true Resque will call #perform method inline
+    # without queuing it into Redis and without any Resque callbacks.
+    # The 'inline' is false Resque jobs will be put in queue regularly.
+    attr_writer :inline
+
+    def inline(&block)
+      block ? inline_block(&block) : inline?
+    end
+
+    def inline_block
+      self.inline = true
+      yield
+    ensure
+      self.inline = false
+    end
+
+    def inline?
+      @inline if defined?(@inline)
+    end
+
+
+    #
+    # queue manipulation
+    #
+
+    # Pushes a job onto a queue. Queue name should be a string and the
+    # item should be any JSON-able Ruby object.
+    #
+    # Resque workers generally expect the `item` to be a hash with the following
+    # keys:
+    #
+    #   class - The String name of the job to run.
+    #    args - An Array of arguments to pass the job. Usually passed
+    #           via `class.to_class.perform(*args)`.
+    #
+    # Example
+    #
+    #   Resque.push('archive', 'class' => 'Archive', 'args' => [ 35, 'tar' ])
+    #
+    # Returns nothing
+    def push(queue, item)
+      queue(queue) << item
+    end
+
+    # Pops a job off a queue. Queue name should be a string.
+    #
+    # Returns a Ruby object.
+    def pop(queue)
+      queue(queue).pop(true)
+    rescue ThreadError
+      nil
+    end
+
+    # Returns an array of all known Resque queues as strings.
+    def queues
+      Array(backend.store.smembers(:queues))
+    end
+
+    # Return the Resque::Queue object for a given name
+    def queue(name)
+      @queues[name.to_s]
+    end
+
+    # Validates if the given klass could be a valid Resque job
+    #
+    # If no queue can be inferred this method will raise a `Resque::NoQueueError`
+    #
+    # If given klass is nil this method will raise a `Resque::NoClassError`
+    def validate(klass, queue = nil)
+      queue ||= queue_from_class(klass)
+
+      unless queue
+        raise NoQueueError.new("Jobs must be placed onto a queue.")
+      end
+
+      if klass.to_s.empty?
+        raise NoClassError.new("Jobs must be given a class.")
+      end
+    end
+
+    def redis=(server)
+      config.redis = server
+
+      @queues = Hash.new do |h,name|
+        h[name] = Resque::Queue.new(name, config.redis, coder)
+      end
+
+      @backend = Backend.new(config.redis, Resque.logger)
+
+      config.redis
+    end
+
+    def backend
+      @backend ||= Backend.new(config.redis, Resque.logger)
+    end
+
+    def encode(object)
+      Resque.coder.encode(object)
+    end
+
+    def decode(object)
+      Resque.coder.decode(object)
+    end
+
+    # Does the dirty work of fetching a range of items from a Redis list
+    # and converting them into Ruby objects.
+    def list_range(key, start = 0, count = 1)
+      if count == 1
+        decode(backend.store.lindex(key, start))
+      else
+        Array(backend.store.lrange(key, start, start+count-1)).map do |item|
+          decode(item)
+        end
+      end
+    end
+
+    # Set or retrieve the current logger object
+    attr_accessor :logger
+
+    # Encapsulation of encode/decode. Overwrite this to use it across Resque.
+    # This defaults to JSON for backwards compatibility.
+    def coder
+      @coder ||= JsonCoder.new
+    end
+    attr_writer :coder
+
+  end
+
+end

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -1,6 +1,7 @@
 require 'resque/core_ext/string'
 require 'resque/errors'
 require 'resque/job_performer'
+require 'resque/queue'
 
 module Resque
   # A Resque::Job represents a unit of work. Each job lives on a

--- a/lib/resque/job_performer.rb
+++ b/lib/resque/job_performer.rb
@@ -1,3 +1,4 @@
+require 'resque/errors'
 module Resque
   class JobPerformer
     attr_reader :job, :job_args, :hooks

--- a/test/resque/backend_test.rb
+++ b/test/resque/backend_test.rb
@@ -1,5 +1,7 @@
 require 'test_helper'
 require 'tempfile'
+require 'logger'
+require 'redis'
 
 require 'resque/backend'
 

--- a/test/resque/child_process_test.rb
+++ b/test/resque/child_process_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
+require 'resque/globals'
 require 'resque/child_process'
+require 'resque/worker'
 
 describe Resque::ChildProcess do
   let(:client) { MiniTest::Mock.new }

--- a/test/resque/coder_test.rb
+++ b/test/resque/coder_test.rb
@@ -1,5 +1,7 @@
 require 'test_helper'
 
+require 'resque/coder'
+
 describe Resque::Coder do
   before do
     @coder = Resque::Coder.new

--- a/test/resque/config_test.rb
+++ b/test/resque/config_test.rb
@@ -1,4 +1,8 @@
 require 'test_helper'
+require 'redis'
+
+require 'resque/config'
+require 'resque/backend'
 
 describe Resque::Config do
   let(:config){ Resque::Config.new }

--- a/test/resque/core_ext/string_test.rb
+++ b/test/resque/core_ext/string_test.rb
@@ -1,5 +1,7 @@
 require 'test_helper'
 
+require 'resque/core_ext/string'
+
 describe String do
   it "#constantize" do
     assert_same Kernel, "Kernel".constantize

--- a/test/resque/failure/each_test.rb
+++ b/test/resque/failure/each_test.rb
@@ -1,7 +1,14 @@
 require 'test_helper'
+
+require 'resque/globals'
 require 'resque/failure/redis'
 
 describe Resque::Failure::Each do
+  before do
+    #Previously this was getting set by the CLI test being run first
+    #Should the knowledge of the default 'localhost:6379/resque' be consolidated somewhere?
+    Resque.redis = "localhost:6379/resque"
+  end
   after do
     Resque::Failure.clear
   end

--- a/test/resque/failure/redis_multi_queue_test.rb
+++ b/test/resque/failure/redis_multi_queue_test.rb
@@ -1,8 +1,14 @@
 require 'test_helper'
+
+require 'resque/globals'
 require 'resque/failure/redis_multi_queue'
 
 describe Resque::Failure::RedisMultiQueue do
   before do
+    #Previously this was getting set by the CLI test being run first
+    #Should the knowledge of the default 'localhost:6379/resque' be consolidated somewhere?
+    Resque.redis = "localhost:6379/resque"
+
     Resque::Failure.backend = Resque::Failure::RedisMultiQueue
   end
 

--- a/test/resque/failure/redis_test.rb
+++ b/test/resque/failure/redis_test.rb
@@ -1,7 +1,14 @@
 require 'test_helper'
+
+require 'resque/globals'
 require 'resque/failure/redis'
 
 describe Resque::Failure::Redis do
+  before do
+    #Previously this was getting set by the CLI test being run first
+    #Should the knowledge of the default 'localhost:6379/resque' be consolidated somewhere?
+    Resque.redis = "localhost:6379/resque"
+  end
   after do
     Resque.backend.store.flushall
   end

--- a/test/resque/job_performer_test.rb
+++ b/test/resque/job_performer_test.rb
@@ -1,3 +1,4 @@
+require 'resque/job_performer'
 require 'test_helper'
 
 describe Resque::JobPerformer do

--- a/test/resque/logging_test.rb
+++ b/test/resque/logging_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
 require 'minitest/mock'
 
+require 'resque/globals'
+require 'resque/logging'
+
 actual_logger = Resque.logger
 
 describe "Resque::Logging" do

--- a/test/resque/worker_queue_list_test.rb
+++ b/test/resque/worker_queue_list_test.rb
@@ -1,4 +1,6 @@
 require 'test_helper'
+
+require 'resque/globals'
 require 'resque/worker_queue_list'
 
 describe Resque::WorkerQueueList do

--- a/test/resque/worker_test.rb
+++ b/test/resque/worker_test.rb
@@ -1,10 +1,17 @@
 require 'test_helper'
+require 'mono_logger'
 
+require 'resque/globals'
 require 'resque/worker'
 require 'resque/errors'
 require 'socket'
 
 describe Resque::Worker do
+  before do
+    # copied from resque.rb:
+    # Should the default logger be a concern of logger class instead?
+    Resque.logger = MonoLogger.new(STDOUT)
+  end
   let(:client) { MiniTest::Mock.new }
   let(:awaiter) { MiniTest::Mock.new }
 


### PR DESCRIPTION
create resque/globals to avoid having to require main resque module
(this is probably a sign that the remaining things in the resque module
are un-tested)

continuation of #1011