### PR TITLE
Refactor to use a block in fork

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -19,7 +19,7 @@ module Resque
     def self.redis
       Resque.redis
     end
-    
+
     # Given a Ruby object, returns a string suitable for storage in a
     # queue.
     def encode(object)
@@ -193,7 +193,7 @@ module Resque
             end
 
             if will_fork?
-             run_at_exit_hooks ? exit : exit!
+              run_at_exit_hooks ? exit : exit!
             end
           end
 


### PR DESCRIPTION
Hey, my mistake. If you rescue SystemExit after a fork It won't exit. The code is currently broken when run_at_exit_hooks is set to true. Now I use a block, which was the first approach (before the variable was introduced) and is somewhat what is currently in master.

A bit of history:

The exit hooks were not called when forking. I didn't like that approach cause many jobs relay on at_exit to clean stuff (mainly because they use tempfile ruby class). I did this commit to allow running at_exit_hooks. https://github.com/resque/resque/commit/0be3134cc054abf4433b944888c3ce557b71a244. After that, due to some heavy hooks that @jonhyman had, this change was reverted in https://github.com/resque/resque/commit/7c848132ab70ad6869a1a5e4c4400d02d2c9b527 and reimplemented in https://github.com/resque/resque/commit/f9ed00bbd6bd7a38d51fa6ead32e6c95d799c86f because you decided in https://github.com/resque/resque/issues/862 that having that configurable was better. The thing is that here a new bug was introduced that made the run_at_exit_hooks unusable (it was deregistering upon termination of the first forked child). I solved that on this PR (https://github.com/resque/resque/pull/1017) but introduced another bug, now children are not exiting. This this solves this.
