### PR TITLE
inline_block no longer assumes inline was false

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -123,10 +123,11 @@ module Resque
   end
 
   def inline_block
+    old_inline = inline?
     self.inline = true
     yield
   ensure
-    self.inline = false
+    self.inline = old_inline
   end
 
   def inline?

--- a/test/legacy/resque_test.rb
+++ b/test/legacy/resque_test.rb
@@ -307,6 +307,16 @@ describe "Resque" do
     assert !Resque.inline?
   end
 
+  it "inline block doesn't change inline to false if already inline" do
+    begin
+      Resque.inline = true
+      Resque.inline { }
+      assert Resque.inline?
+    ensure
+      Resque.inline = false
+    end
+  end
+
   it "inline without block is alias to inline?" do
     begin
       assert_equal Resque.inline?, Resque.inline


### PR DESCRIPTION
Fixes potential bug: If `inline_block` is called with `inline` already true, it incorrectly sets `inline` to false after yielding.
