### PR TITLE
Don't log "found job" if a job isn't actually found

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -393,8 +393,10 @@ module Resque
         queue, job = multi_queue.poll(interval)
       end
 
-      logger.debug "Found job on #{queue}"
-      Job.new(queue.name, job) if (queue && job)
+      if queue && job
+        logger.debug "Found job on #{queue}"
+        Job.new(queue.name, job)
+      end
     end
 
     def graceful_term?


### PR DESCRIPTION
Minor issue: "Found job" was being logged even if no job was found on the queues. Seems incorrect & confusing.
