### PR TITLE
Fixes Redis::Failure::RedisMultiQueue#filter_backtrace to match Redis::Failure::Redis#filter_backtrace

### DIFF
--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -72,8 +72,7 @@ module Resque
       end
 
       def filter_backtrace(backtrace)
-        index = backtrace.index { |item| item.include?('/lib/resque/job.rb') }
-        backtrace.first(index.to_i)
+        backtrace.take_while { |item| !item.include?('/lib/resque/job.rb') }
       end
     end
   end


### PR DESCRIPTION
This is a minor fix that should have been made when `Redis::Failure::Redis#filter_backtrace` was modified. I guess it was omitted because of the high level of code duplication between `Redis::Failure::Redis` and `Redis::Failure::RedisMultiQueue`. It would be nice to refactor these.
