### PR TITLE
Fixing the worker execution call in the sinatra example.

### DIFF
--- a/examples/sinatra/README.markdown
+++ b/examples/sinatra/README.markdown
@@ -22,7 +22,7 @@ Now in another shell terminal start the worker:
 
     $ cd resque/examples/sinatra
     $ bundle install
-    $ bundle exec resque work -q default,failing -r ./job
+    $ bundle exec resque work -q default,failing -r ./job.rb
 
 You should see the following output:
 


### PR DESCRIPTION
At least in my machine (ruby 1.9.3) I had to append the .rb when requiring the job file.
