### PR TITLE
Delete pid_file after work

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -88,6 +88,7 @@ module Resque
       startup
       work_loop(&block)
       worker_registry.unregister
+      delete_pid_file(options[:pid_file]) if options[:pid_file]
     rescue Exception => exception
       worker_registry.unregister(exception)
     end
@@ -299,6 +300,11 @@ module Resque
     # Save worker's pid to file
     def write_pid_file(path = nil)
       File.open(path, 'w'){ |f| f << self.pid } if path
+    end
+
+    # Delete worker's pid file
+    def delete_pid_file(path = nil)
+      File.delete(path)
     end
 
     # Enables GC Optimizations if you're running REE.

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -303,8 +303,8 @@ module Resque
     end
 
     # Delete worker's pid file
-    def delete_pid_file(path = nil)
-      File.delete(path)
+    def delete_pid_file(path)
+      File.delete(path) if path
     end
 
     # Enables GC Optimizations if you're running REE.


### PR DESCRIPTION
Pidfile is made when I specify `ENV['PIDFILE']`.
But a file is not deleted when worker is finished.