### PR TITLE
Attempt to fix #932

### DIFF
--- a/lib/resque/config.rb
+++ b/lib/resque/config.rb
@@ -3,7 +3,7 @@ require "resque/core_ext/hash"
 module Resque
   # A container for configuration parameters
   class Config
-    attr_accessor :redis
+    attr_writer :redis
     
     # @param options [Hash<Symbol,Object>]
     # @option options [Redis::Namespace,Redis::Distributed] :redis
@@ -11,6 +11,14 @@ module Resque
       options.each do |key, value|
         public_send("#{key}=", value)
       end
+    end
+
+    # Returns the current redis connection, or raises
+    # an exception if it doesn't exist.
+    # @return [Redis::Namespace,Redis::Distributed]
+    # @raise [RuntimeError] if redis is not configured.
+    def redis
+      @redis || raise('redis connection not configured!')
     end
 
     # Get the ID of the underlying redis connection

--- a/test/resque/config_test.rb
+++ b/test/resque/config_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'mock_redis'
 
 describe Resque::Config do
   
@@ -25,6 +26,22 @@ describe Resque::Config do
       require 'redis/distributed'
       config.redis = Redis::Distributed.new(%w(redis://localhost:6379 redis://localhost:6380))
       assert_equal config.redis_id, "redis://localhost:6379/0, redis://localhost:6380/0"
+    end
+  end
+
+  describe '#redis' do
+    describe 'when the underlying connection doesn\'t exist' do
+      it 'should raise' do
+        config.redis = nil
+        assert_raises(RuntimeError) { config.redis }
+      end
+    end
+    describe 'when the underlying connection is a redis connection' do
+      it 'should not raise' do
+        redis_connection = Redis::Namespace.new(:resque, redis: MockRedis.new)
+        config.redis = redis_connection
+        assert_equal redis_connection, config.redis
+      end
     end
   end
 end

--- a/test/resque/config_test.rb
+++ b/test/resque/config_test.rb
@@ -38,7 +38,7 @@ describe Resque::Config do
     end
     describe 'when the underlying connection is a redis connection' do
       it 'should not raise' do
-        redis_connection = Redis::Namespace.new(:resque, redis: MockRedis.new)
+        redis_connection = Redis::Namespace.new(:resque, :redis => MockRedis.new)
         config.redis = redis_connection
         assert_equal redis_connection, config.redis
       end


### PR DESCRIPTION
This attempts to fix #932 by raising when accessing `Resque::Config#resque` if there is no connection present.