### PR TITLE
Ensure run_at is a string when sorting by it.

### DIFF
--- a/lib/resque/server/views/working.erb
+++ b/lib/resque/server/views/working.erb
@@ -49,7 +49,7 @@
     </tr>
     <% end %>
 
-    <% worker_jobs.sort_by {|w, j| j['run_at'] ? j['run_at'] : '' }.each do |worker, job| %>
+    <% worker_jobs.sort_by {|w, j| j['run_at'] ? j['run_at'].to_s() : '' }.each do |worker, job| %>
       <tr>
         <td class='icon'><img src="<%=u state = worker.state %>.png" alt="<%= state %>" title="<%= state %>"></td>
         <% host, pid, queues = worker.to_s.split(':') %>


### PR DESCRIPTION
When using Resque and Sidekiq at the same time, resque-web errors out if there are any Sidekiq workers processing jobs. It seems it is because "run_at" in Resque is an iso8601 string, whereas in Sidekiq it's a number. As such, #to_s the run_at to ensure that we're dealing with a string (especially since the nil case compares against empty string).