### PR TITLE
Removes broken namespace methods.

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -73,14 +73,6 @@ module Resque
     config.redis_id
   end
 
-  def namespace=(val)
-    config.namespace = val
-  end
-
-  def namespace
-    config.namespace
-  end
-
   # Encapsulation of encode/decode. Overwrite this to use it across Resque.
   # This defaults to JSON for backwards compatibility.
   def coder


### PR DESCRIPTION
`Resque` providing a namespace accessor seems to presume that everyone will be using a backend configured for Redis::Namespace. From what I gather Redis::Distributed doesn't have an analog to this.
