### PR TITLE
add yarddoc to lib/resque.rb

### DIFF
--- a/lib/resque/config.rb
+++ b/lib/resque/config.rb
@@ -10,6 +10,8 @@ module Resque
       end
     end
 
+    # Get the ID of the underlying redis connection
+    # @return [String]
     def redis_id
       if redis.respond_to?(:nodes) # distributed
         redis.nodes.map(&:id).join(', ')


### PR DESCRIPTION
I'm adding this in a few pieces at a time in order to avoid merge-conflict hell. You can plan on the rest of the code getting similar treatment in 4-5 PR's over the next 2 weeks.

The one actual code-change moves the `extend Forwardable` closer to the point that it is actually used.
