### PR TITLE
  Remove ugliness of checking redis.is_a namespace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gemspec
+gem "redis-namespace", :git => "https://github.com/resque/redis-namespace.git"
 
 group :development do
   gem 'rake'
@@ -18,4 +19,5 @@ group :test do
   gem "json"
   gem "minitest", '4.7.0'
   gem "sinatra"
+  gem 'mock_redis', :git => "https://github.com/causes/mock_redis.git"
 end

--- a/lib/resque/multi_queue.rb
+++ b/lib/resque/multi_queue.rb
@@ -19,8 +19,7 @@ module Resque
       @redis      = redis
 
       queues.each do |queue|
-        key = @redis.is_a?(Redis::Namespace) ? "#{@redis.namespace}:" : ""
-        key += queue.redis_name
+        key = queue.redis_name
         @queue_hash[key] = queue
       end
     end
@@ -58,7 +57,7 @@ module Resque
           synchronize do
             value = @redis.blpop(*(queue_names + [1])) until value
             queue_name, payload = value
-          queue = @queue_hash["#{@redis.namespace}:#{queue_name}"]
+          queue = @queue_hash[queue_name]
             [queue, queue.decode(payload)]
           end
         else
@@ -78,7 +77,7 @@ module Resque
         return unless payload
 
         synchronize do
-          queue = @queue_hash["#{@redis.namespace}:#{queue_name}"]
+          queue = @queue_hash[queue_name]
           [queue, queue.decode(payload)]
         end
       else

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.rdoc_options      = ["--charset=UTF-8"]
 
   s.add_dependency "thor",            "~> 0.17"
-  s.add_dependency "redis-namespace", "~> 1.0", "< 1.3.0"
+  s.add_dependency "redis-namespace", ">= 1.3.0"
   s.add_dependency "json"
   s.add_dependency "mono_logger", "~> 1.0"
 


### PR DESCRIPTION
Upgrade redis-namspace to latest from git
Upgrade mock_redis to a version that works with newer redis

You wouldn't know it from the diff, but the original bug I'm fixing here is an inconsistency between redis and mock_redis... which leads to an implementation in resque that is completely non-operational in practice

Whenever you try to run a job you'd get

```
#<NoMethodError: undefined method `decode' for nil:NilClass>
/Users/ey/Projects/resque/lib/resque/multi_queue.rb:83:in `block in poll'
```

Because the blpop call returns the actual Q name (so maybe it could be considered a bug in redis namespace)
And then we search for the Q with the namespace added, and Q resque:resque:queue:default does not exist in real redis. While in mock_redis we'd look for resque:queue:default which does exist.

Updating to the latest redis-namespace (and fixing a completely unrelated mock_redis inconsistency) seems to do the trick
