### PR TITLE
Adds Resque#redis reader.

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -87,6 +87,12 @@ module Resque
     config.redis
   end
 
+  # Get the redis connection
+  # @return [Redis::Namespace,Redis::Distributed]
+  def redis
+    config.redis
+  end
+
   # Returns information about the current Redis connection.
   # @return (see Resque::Config#redis_id)
   def redis_id


### PR DESCRIPTION
I find myself typing Resque.config.redis (or Resque.backend.store) a lot when working with plugins. Would be nice and perhaps not unexpected to be able to read the redis instance from the top-level Resque class, especially since that is where it's also set.

This method existed in the past, so I'm not sure if there was some other reason it was removed.
