### PR TITLE
fix encoding error in Polish locale on Windows [1-x]

### DIFF
--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -5,7 +5,7 @@ module Resque
     class Redis < Base
       def save
         data = {
-          :failed_at => Time.now.strftime("%Y/%m/%d %H:%M:%S %Z"),
+          :failed_at => UTF8Util.clean(Time.now.strftime("%Y/%m/%d %H:%M:%S %Z")),
           :payload   => payload,
           :exception => exception.class.to_s,
           :error     => UTF8Util.clean(exception.to_s),


### PR DESCRIPTION
In Polish (perhaps in other locales too) result of `Time.now.strftime("%Y/%m/%d %H:%M:%S %Z")` contains national characters on Windows, which is out of scope of default US-ASCII encoding. This results in an error thrown when trying to log failure using default Redis backend: `*** Received exception when reporting failure: #<Encoding::InvalidByteSequenceError: "\x8C" on US-ASCII>` and no information about the failure is saved.

When string with timezone name is cleaned, everything works as expected.

```
irb(main):011:0> Time.now.strftime("%Y/%m/%d %H:%M:%S %Z")
"2013/06/27 18:19:18 \x8Crodkowoeuropejski czas letni"
```
