### PR TITLE
High-priority queues supported in WorkerQueueList#search_order too.

### DIFF
--- a/lib/resque/worker_queue_list.rb
+++ b/lib/resque/worker_queue_list.rb
@@ -35,9 +35,16 @@ module Resque
 
     # Returns a list of queues to use when searching for a job.
     # A splat ("*") means you want every queue (in alpha order) - this
-    # can be useful for dynamically adding new queues. Low priority queues
-    # can be placed after a splat to ensure execution after all other dynamic
-    # queues.
+    # can be useful for dynamically adding new queues.
+    # High-priority queues can be placed before a splat to ensure execution
+    # before all other dynamic queues, and low-priority queues can be placed
+    # after a splat to ensure execution after all other dynamic queues.
+    #
+    # @example
+    #   wql = WorkerQueueList.new(%w(high1 high2 * low))
+    #   wql.search_order #=> ['high1','high2', 'alpha', 'beta', 'zeta', 'low']
+    #
+    # @return [Array<String>]
     def search_order
       queues.map do |queue|
         if queue == "*"

--- a/test/resque/worker_queue_list_test.rb
+++ b/test/resque/worker_queue_list_test.rb
@@ -84,10 +84,10 @@ describe Resque::WorkerQueueList do
       end
     end
 
-    it "puts dynamic queues (splats) in front" do
-      worker_queue_list = Resque::WorkerQueueList.new(["*", :last])
-      Resque.stub(:queues, ["foo", "bar", "stuff"]) do
-        assert_equal ["bar", "foo", "stuff", "last"], worker_queue_list.search_order
+    it "preserves explicit ordering with dynamic queues (splats)" do
+      worker_queue_list = Resque::WorkerQueueList.new([:first, '*', :last])
+      Resque.stub(:queues, %w(alpha kappa beta first last zeta delta)) do
+        assert_equal  %w(first alpha beta delta kappa zeta last), worker_queue_list.search_order
       end
     end
   end


### PR DESCRIPTION
Until reading the code, I had no idea that high-priority queues could be explicitly declared and ordered before a splat.

This PR updates the relevant test to include both high-priority and low-priority queues, and updates the code documentation to be more clear.
