### PR TITLE
Fix CI for 1.8.7 and 1.9.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ group :test do
   gem "rake"
   gem "rack-test", "~> 0.5"
   gem "mocha", :require => false
-  gem "hoptoad_notifier"
   gem "airbrake"
+  gem "activesupport", "~> 3.0"
   gem "i18n"
   gem "minitest", "4.7.0"
 end

--- a/README.markdown
+++ b/README.markdown
@@ -193,7 +193,7 @@ If a job raises an exception, it is logged and handed off to the
 `Resque::Failure` module. Failures are logged either locally in Redis
 or using some different backend.
 
-For example, Resque ships with Hoptoad support.
+For example, Resque ships with Airbrake support.
 
 Keep this in mind when writing your jobs: you may want to throw
 exceptions you would not normally throw in order to assist debugging.

--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -22,8 +22,8 @@ module Resque
     # `Resque::Failure::Base`.
     #
     # Example use:
-    #   require 'resque/failure/hoptoad'
-    #   Resque::Failure.backend = Resque::Failure::Hoptoad
+    #   require 'resque/failure/airbrake'
+    #   Resque::Failure.backend = Resque::Failure::Airbrake
     def self.backend=(backend)
       @backend = backend
     end

--- a/lib/resque/failure/airbrake.rb
+++ b/lib/resque/failure/airbrake.rb
@@ -15,7 +15,7 @@ module Resque
       end
 
       def self.count(queue = nil, class_name = nil)
-        # We can't get the total # of errors from Hoptoad so we fake it
+        # We can't get the total # of errors from Airbrake so we fake it
         # by asking Resque how many errors it has seen.
         Stat[:failed]
       end


### PR DESCRIPTION
Note that this is just the Gemfile, not the gemspec. No change for the actual gem, just affects local development _on_ resque. 

I also excised some old references to hoptoad. 
