### PR TITLE
Fixing issue where strange encodings in failed job log cause exception

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -230,8 +230,8 @@ module Resque
 
     # Reports the exception and marks the job as failed
     def report_failed_job(job,exception)
-      log "#{job.inspect} failed: #{exception.inspect}"
       begin
+        log "#{job.inspect} failed: #{exception.inspect}".force_encoding('UTF-8')
         job.fail(exception)
       rescue Object => exception
         log "Received exception when reporting failure: #{exception.inspect}"


### PR DESCRIPTION
Fixes an error where log outputs referencing non UTF-8 encoded strings/data causes an encoding incompatibility exception.  Furthermore I moved the log output into the rescue block so that a graceful error message would be reported when Rescue fails to log the exception.

Use case:  dealing with some MessagePack binary data in a job, an exception related to it was raised and the log call tried to reference some ASCII-8BIT encoded data.  The data was passed to the job in the proper format, so this is only an issue because the data was then converted back into a binary representation during the job, and then output alongside some UTF-8 encoded data in the log call.