### PR TITLE
Fixes 1.8-mode by not using 1.9-style literal hashes

### DIFF
--- a/test/resque/core_ext/hash_test.rb
+++ b/test/resque/core_ext/hash_test.rb
@@ -5,7 +5,7 @@ describe Hash do
   it '#symbolize_keys' do
     source = {'foo' => 'bar', 'baz' => 'bingo'}
     result = source.symbolize_keys
-    assert_equal({foo: 'bar', baz: 'bingo'}, result, 'result must have sym keys')
+    assert_equal({:foo => 'bar', :baz => 'bingo'}, result, 'result must have sym keys')
     assert_equal({'foo'=>'bar', 'baz'=>'bingo'}, source, 'source unchanged')
   end
 
@@ -13,13 +13,13 @@ describe Hash do
     source = {'foo' => 'bar', 'baz' => 'bingo'}
     result = source.symbolize_keys!
     assert_same source, result
-    assert_equal({foo: 'bar', baz: 'bingo'}, result, 'result must have sym keys')
+    assert_equal({:foo => 'bar', :baz => 'bingo'}, result, 'result must have sym keys')
 
   end
 
   it '#slice' do
-    source = {foo: 'bar', baz: 'bingo', pop: 'fizz' }
+    source = {:foo => 'bar', :baz => 'bingo', :pop => 'fizz' }
     result = source.slice(:foo, :pop)
-    assert_equal({foo: 'bar', pop: 'fizz'}, result)
+    assert_equal({:foo => 'bar', :pop => 'fizz'}, result)
   end
 end


### PR DESCRIPTION
Either this or remove `jruby-18mode` and `rbx-18mode` from the travis config on `master`.

Thoughts?
