### PR TITLE
Fix Resque::Failure::Redis.each when there is a single failed job.

### DIFF
--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -39,7 +39,6 @@ module Resque
       end
 
       def self.each(offset = 0, limit = self.count, queue = :failed, class_name = nil, order = 'desc')
-        #all_items = Array(all(offset, limit, queue))
         all_items = limit == 1 ? [all(offset,limit,queue)] : Array(all(offset, limit, queue))
         reversed = false
         if order.eql? 'desc'

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -39,7 +39,8 @@ module Resque
       end
 
       def self.each(offset = 0, limit = self.count, queue = :failed, class_name = nil, order = 'desc')
-        all_items = Array(all(offset, limit, queue))
+        #all_items = Array(all(offset, limit, queue))
+        all_items = limit == 1 ? [all(offset,limit,queue)] : Array(all(offset, limit, queue))
         reversed = false
         if order.eql? 'desc'
           all_items.reverse!

--- a/test/resque_failure_redis_test.rb
+++ b/test/resque_failure_redis_test.rb
@@ -3,6 +3,7 @@ require 'resque/failure/redis'
 
 context "Resque::Failure::Redis" do
   setup do
+    Resque::Failure::Redis.clear
     @bad_string    = [39, 52, 127, 86, 93, 95, 39].map { |c| c.chr }.join
     exception      = StandardError.exception(@bad_string)
     worker         = Resque::Worker.new(:test)
@@ -16,4 +17,35 @@ context "Resque::Failure::Redis" do
     @redis_backend.save
     Resque::Failure::Redis.all # should not raise an error
   end
+
+  test '.each iterates correctly (does nothing) for no failures' do
+    assert_equal 0, Resque::Failure::Redis.count
+    Resque::Failure::Redis.each do |id, item|
+      raise "Should not get here"
+    end
+  end
+
+  test '.each iterates thru a single hash if there is a single failure' do
+    @redis_backend.save
+    assert_equal 1, Resque::Failure::Redis.count
+    num_iterations = 0
+    Resque::Failure::Redis.each do |id, item|
+      num_iterations += 1
+      assert_equal Hash, item.class
+    end
+    assert_equal 1, num_iterations
+  end
+
+  test '.each iterates thru hashes if there is are multiple failures' do
+    @redis_backend.save
+    @redis_backend.save
+    num_iterations = 0
+    assert_equal 2, Resque::Failure::Redis.count
+    Resque::Failure::Redis.each do |id, item|
+      num_iterations += 1
+      assert_equal Hash, item.class
+    end
+    assert_equal 2, num_iterations
+  end 
+
 end


### PR DESCRIPTION
This fixes #1102.

Each works around the weird behavior of Array() when passed a single hash.