### PR TITLE
Change `Resque::Failure#each` to accept an options hash

### DIFF
--- a/lib/resque/cli.rb
+++ b/lib/resque/cli.rb
@@ -86,7 +86,7 @@ module Resque
       require 'resque/failure/redis'
 
       warn "Sorting #{Resque::Failure.count} failures..."
-      Resque::Failure.each(0, Resque::Failure.count) do |_, failure|
+      Resque::Failure.each do |_, failure|
         data = Resque.encode(failure)
         Resque.backend.store.rpush(Resque::Failure.failure_queue_name(failure['queue']), data)
       end

--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -80,14 +80,14 @@ module Resque
     end
 
     # Iterate across all failures with the given options
-    # @param offset (see Resque::Failure::Base::each)
-    # @param limit (see Resque::Failure::Base::each) (Resque::Failure::count)
-    # @param queue (see Resque::Failure::Base::each)
+    # @param options (see Resque::Failure::Base::each)
     # @return (see Resque::Failure::Base::each)
     # @yieldparam (see Resque::Failure::Base::each)
     # @yieldreturn (see Resque::Failure::Base::each)
-    def self.each(offset = 0, limit = self.count, queue = nil, class_name = nil, &block)
-      backend.each(offset, limit, queue, class_name, &block)
+    def self.each(options = {}, &block)
+      default_options = { :queue => nil }
+      options = default_options.merge(options.symbolize_keys)
+      backend.each(options, &block)
     end
 
     # The string url of the backend's web interface, if any.

--- a/lib/resque/failure/base.rb
+++ b/lib/resque/failure/base.rb
@@ -63,7 +63,7 @@ module Resque
 
       # Iterate across failed objects
       # @overload (see Resque::Failure::Each#each)
-      def self.each(*args)
+      def self.each(options = {})
       end
 
       # A URL where someone can go to view failures.

--- a/lib/resque/failure/each.rb
+++ b/lib/resque/failure/each.rb
@@ -2,11 +2,11 @@ module Resque
   module Failure
     # A module mixed into Resque::Failure::Base subclasses to provide #each
     module Each
-      # @param options [Hash<#to_sym,Object>]         - options to filter failtures to iterator over
-      # @option options offset [Integer] (0)          - beginning offset
-      # @option options limit [Integer] (#count)      - maximum quantity to loop over
-      # @option options queue [#to_s] (:failed)       - the queue to iterate over
-      # @option options class_name [String,nil] (nil) - if provided, limit to given class name
+      # @param options [Hash<#to_sym,Object>] options to filter failtures to iterator over
+      # @option options [Integer]    :offset (0)       - beginning offset
+      # @option options [Integer]    :limit (#count)   - maximum quantity to loop over
+      # @option options [#to_s]      :queue (:failed)  - the queue to iterate over
+      # @option options [String,nil] :class_name (nil) - if provided, limit to given class name
       def each(options = {})
         options = default_options.merge(options.symbolize_keys)
         items = all(options[:offset], options[:limit], options[:queue])

--- a/lib/resque/failure/each.rb
+++ b/lib/resque/failure/each.rb
@@ -2,17 +2,32 @@ module Resque
   module Failure
     # A module mixed into Resque::Failure::Base subclasses to provide #each
     module Each
-      # @param offset [Integer] (0)     - beginning offset
-      # @param limit [Integer] (#count) - maximum quantity to loop over
-      # @param queue [#to_s] (:failed)  - the queue to iterate over
-      # @param class_name [String,nil] (nil)  - if provided, limit to given class name
-      def each(offset = 0, limit = self.count, queue = :failed, class_name = nil)
-        items = all(offset, limit, queue)
+      # @param options [Hash<#to_sym,Object>]         - options to filter failtures to iterator over
+      # @option options offset [Integer] (0)          - beginning offset
+      # @option options limit [Integer] (#count)      - maximum quantity to loop over
+      # @option options queue [#to_s] (:failed)       - the queue to iterate over
+      # @option options class_name [String,nil] (nil) - if provided, limit to given class name
+      def each(options = {})
+        options = default_options.merge(options.symbolize_keys)
+        items = all(options[:offset], options[:limit], options[:queue])
         items.each_with_index do |item, i|
-          if !class_name || (item['payload'] && item['payload']['class'] == class_name)
-            yield offset + i, item
+          if options[:class_name].nil? ||
+            (item['payload'] && item['payload']['class'] == options[:class_name])
+
+            yield options[:offset] + i, item
           end
         end
+      end
+
+      private
+
+      def default_options
+        {
+          :offset => 0,
+          :limit => self.count,
+          :queue => :failed,
+          :class_name => nil
+        }
       end
     end
   end

--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -51,8 +51,8 @@ module Resque
       # @override (see Resque::Failure::Each#each)
       # @param (see Resque::Failure::Each#each)
       # @return (see Resque::Failure::Each#each)
-      def self.each(*args, &block)
-        classes.first.each(*args, &block)
+      def self.each(options = {}, &block)
+        classes.first.each(options, &block)
       end
 
       # A URL where someone can go to view failures.

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -33,7 +33,11 @@ module Resque
 
         if class_name
           n = 0
-          each(0, count(queue), queue, class_name) { n += 1 } 
+          each(
+            :limit => count(queue),
+            :queue => queue,
+            :class_name => class_name
+          ) { n += 1 }
           n
         else
           Resque.backend.store.llen(:failed).to_i

--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -29,7 +29,11 @@ module Resque
         if queue
           if class_name
             n = 0
-            each(0, count(queue), queue, class_name) { n += 1 } 
+            each(
+              :limit => count(queue),
+              :queue => queue,
+              :class_name => class_name
+            ) { n += 1 }
             n
           else
             Resque.backend.store.llen(queue).to_i
@@ -91,7 +95,10 @@ module Resque
       # @return [void]
       def self.requeue_queue(queue)
         failure_queue = Resque::Failure.failure_queue_name(queue)
-        each(0, count(failure_queue), failure_queue) { |id, _| requeue(id, failure_queue) }
+        each(
+          :limit => count(failure_queue),
+          :queue => failure_queue
+        ) { |id, _| requeue(id, failure_queue) }
       end
 
       # Remove all items from failed queue where their original queue was

--- a/test/resque/failure/each_test.rb
+++ b/test/resque/failure/each_test.rb
@@ -14,7 +14,7 @@ describe Resque::Failure::Each do
       Resque::Failure::Redis.each do |i, failure|
         assert_equal 0, i
         assert_equal 'T1', failure['payload']['class']
-        n = n + 1
+        n += 1
       end
 
       assert_equal 1, n
@@ -28,7 +28,7 @@ describe Resque::Failure::Each do
       Resque::Failure::Redis.each do |i, failure|
         assert_equal n, i
         assert_equal expected_failure_classes[n], failure['payload']['class']
-        n = n + 1
+        n += 1
       end
 
       assert_equal 2, n
@@ -38,10 +38,10 @@ describe Resque::Failure::Each do
       save_failures('T1', 'T2', 'T3')
 
       n = 0
-      Resque::Failure::Redis.each(1, 1) do |i, failure|
+      Resque::Failure::Redis.each(:offset => 1, :limit => 1) do |i, failure|
         assert_equal 1, i
         assert_equal 'T2', failure['payload']['class']
-        n = n + 1
+        n += 1
       end
 
       assert_equal 1, n
@@ -51,10 +51,14 @@ describe Resque::Failure::Each do
       save_failures('T1', 'T2')
 
       n = 0
-      Resque::Failure::Redis.each(0, 2, :failed, 'T2') do |i, failure|
+      Resque::Failure::Redis.each(
+        :limit => 2,
+        :queue => :failed,
+        :class_name => 'T2'
+      ) do |i, failure|
         assert_equal 1, i
         assert_equal 'T2', failure['payload']['class']
-        n = n + 1
+        n += 1
       end
 
       assert_equal 1, n
@@ -64,10 +68,15 @@ describe Resque::Failure::Each do
       save_failures('T1', 'T2', 'T2', 'T3')
 
       n = 0
-      Resque::Failure::Redis.each(2, 4, :failed, 'T2') do |i, failure|
+      Resque::Failure::Redis.each(
+        :offset => 2,
+        :limit => 4,
+        :queue => :failed,
+        :class_name => 'T2'
+      ) do |i, failure|
         assert_equal 2, i
         assert_equal 'T2', failure['payload']['class']
-        n = n + 1
+        n += 1
       end
 
       assert_equal 1, n


### PR DESCRIPTION
This is to accommodate the Failures 2.0 wiki request:
"Too many arguments: Looking at failure.rb#79, Resque::Failure#each already
takes 5 arguments. This seems like a pretty clear candidate for an options
hash."