### PR TITLE
Change behavior of ::all for retrieving failure records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.0.0 (unreleased)
 
+* Change the former implementation of failures ::all to ::slice
+* Allow failures ::all to accept an options hash for retrieving failures
 * Removed rake tasks. All command line stuff is handled by thor.
 * Removed resque-web. It now lives at resque/resque-web.
 

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -242,6 +242,16 @@ module Resque
       end
     end
   end
+  
+  # Retrieves the complete list from Redis with the given key and
+  # converts each item into a Ruby object
+  # @param queue (see #queue)
+  # @return [Array<Hash{String=>Object}>]
+  def full_list(key)
+    Array(backend.store.lrange(key, 0, -1)).map do |item|
+      decode(item)
+    end
+  end
 
   # Returns an array of all known Resque queues as strings.
   # @return [Array<String>]

--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -67,16 +67,23 @@ module Resque
       backend.count(queue, class_name)
     end
 
+    # Returns all failure objects filtered by options
+    # @param opts (see Resque::Failure::Base::all)
+    # @return (see Resque::Failure::Base::all)
+    def self.all(opts = {})
+      backend.all(opts)
+    end
+
     # Returns an array of all the failures, paginated.
     #
     # `offset` is the int of the first item in the page, `limit` is the
     # number of items to return.
-    # @param offset (see Resque::Failure::Base::all)
-    # @param limit (see Resque::Failure::Base::all)
-    # @param queue (see Resque::Failure::Base::all)
-    # @return (see Resque::Failure::Base::all)
-    def self.all(offset = 0, limit = 1, queue = nil)
-      backend.all(offset, limit, queue)
+    # @param offset (see Resque::Failure::Base::slice)
+    # @param limit (see Resque::Failure::Base::slice)
+    # @param queue (see Resque::Failure::Base::slice)
+    # @return (see Resque::Failure::Base::slice)
+    def self.slice(offset = 0, limit = 1, queue = nil)
+      backend.slice(offset, limit, queue)
     end
 
     # Iterate across all failures with the given options

--- a/lib/resque/failure/each.rb
+++ b/lib/resque/failure/each.rb
@@ -7,7 +7,7 @@ module Resque
       # @param queue [#to_s] (:failed)  - the queue to iterate over
       # @param class_name [String,nil] (nil)  - if provided, limit to given class name
       def each(offset = 0, limit = self.count, queue = :failed, class_name = nil)
-        items = all(offset, limit, queue)
+        items = slice(offset, limit, queue)
         items.each_with_index do |item, i|
           if !class_name || (item['payload'] && item['payload']['class'] == class_name)
             yield offset + i, item

--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -39,12 +39,20 @@ module Resque
         classes.first.count(*args)
       end
 
-      # Returns a paginated array of failure objects.
+      # Returns an array of all failure objects, filtered by options
       # @override (see Resque::Failure::Base::all)
       # @param (see Resque::Failure::Base::all)
       # @return (see Resque::Failure::Base::all)
       def self.all(*args)
         classes.first.all(*args)
+      end
+
+      # Returns a paginated array of failure objects.
+      # @override (see Resque::Failure::Base::all)
+      # @param (see Resque::Failure::Base::all)
+      # @return (see Resque::Failure::Base::all)
+      def self.slice(*args)
+        classes.first.slice(*args)
       end
 
       # Iterate across failed objects

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -6,6 +6,8 @@ module Resque
     # A Failure backend that stores exceptions in Redis. Very simple but
     # works out of the box, along with support in the Resque web app.
     class Redis < Base
+      extend Each
+
       # @overload (see Resque::Failure::Base#save)
       # @param (see Resque::Failure::Base#save)
       # @raise (see Resque::Failure::Base#save)
@@ -33,7 +35,7 @@ module Resque
 
         if class_name
           n = 0
-          each(0, count(queue), queue, class_name) { n += 1 } 
+          each(0, count(queue), queue, class_name) { n += 1 }
           n
         else
           Resque.backend.store.llen(:failed).to_i
@@ -48,15 +50,46 @@ module Resque
         [:failed]
       end
 
-      # @overload (see Resque::Failure::Base::all)
-      # @param (see Resque::Failure::Base::all)
-      # @return (see Resque::Failure::Base::all)
-      def self.all(offset = 0, limit = 1, queue = nil)
+      # @overload all(opts = {})
+      #   The main finder method for failure objects.
+      #
+      #   The only queue that is checked in the Redis store is the :failed queue
+      #
+      #   @example
+      #     Resque::Failure::Redis.all
+      #     #=> [{}, {}, ...]
+      #
+      #     Resque::Failure::Redis.all(:class_name => ['Foo', 'Bar'], :offset => 10, :limit => 5)
+      #     #=> [{}, {}, ...]
+      #
+      #   @param [Hash] opts The options to filter the failures by. When omitted, returns all failures in the :failed queue.
+      #   @option opts [String, Array<String>] :class_name - the name of the class(es) to filter by
+      #   @option opts [Integer] :offset - the number of failures to offset the results by (ex. pagination)
+      #   @option opts [Integer] :limit - the maximum number of failures returned (ex. pagination)
+      #   @return [Array<Hash>]
+      def self.all(opts = {})
+        failures = if opts[:offset] || opts[:limit]
+          slice_from_options opts
+        else
+          Resque.full_list(:failed)
+        end
+
+        if opts[:class_name]
+          failures = filter_by_class_name_from failures, opts[:class_name]
+        end
+
+        failures
+      end
+
+      # Returns a paginated array of failure objects.
+      # @param offset [Integer] The index to begin retrieving records from the Redis list
+      # @param limit [Integer] The maximum number of records to return
+      # @param queue [#to_s] The queue to retrieve records from
+      # @return [Array<Hash{String=>Object}>]
+      def self.slice(offset = 0, limit = 1, queue = nil)
         check_queue(queue)
         [Resque.list_range(:failed, offset, limit)].flatten
       end
-
-      extend Each
 
       # @overload (see Resque::Failure::Base::clear)
       # @param (see Resque::Failure::Base::clear)
@@ -70,7 +103,7 @@ module Resque
       # @param (see Resque::Failure::Base::requeue)
       # @return (see Resque::Failure::Base::requeue)
       def self.requeue(id)
-        item = all(id).first
+        item = slice(id).first
         item['retried_at'] = Time.now.rfc2822
         Resque.backend.store.lset(:failed, id, Resque.encode(item))
         Job.create(item['queue'], item['payload']['class'], *item['payload']['args'])
@@ -80,7 +113,7 @@ module Resque
       # @param queue_name [#to_s]
       # @return [void]
       def self.requeue_to(id, queue_name)
-        item = all(id).first
+        item = slice(id).first
         item['retried_at'] = Time.now.rfc2822
         Resque.backend.store.lset(:failed, id, Resque.encode(item))
         Job.create(queue_name, item['payload']['class'], *item['payload']['args'])
@@ -101,7 +134,7 @@ module Resque
       # @return [void]
       def self.requeue_queue(queue)
         i = 0
-        while job = all(i).first
+        while job = slice(i).first
            requeue(i) if job['queue'] == queue
            i += 1
         end
@@ -113,7 +146,7 @@ module Resque
       # @return [void]
       def self.remove_queue(queue)
         i = 0
-        while job = all(i).first
+        while job = slice(i).first
           if job['queue'] == queue
             # This will remove the failure from the array so do not increment the index.
             remove(i)

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -34,9 +34,7 @@ module Resque
         check_queue(queue)
 
         if class_name
-          n = 0
-          each(0, count(queue), queue, class_name) { n += 1 }
-          n
+          all(:class_name => class_name).size
         else
           Resque.backend.store.llen(:failed).to_i
         end

--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -31,16 +31,17 @@ module Resque
       def self.count(queue = nil, class_name = nil)
         if queue
           if class_name
-            n = 0
-            each(0, count(queue), queue, class_name) { n += 1 }
-            n
+            result = all(:queue => queue, :class_name => class_name)
+            if result.is_a? Array
+              result.size
+            else
+              result.values.reduce(0) { |memo, fails| memo += fails.size }
+            end
           else
             Resque.backend.store.llen(queue).to_i
           end
         else
-          total = 0
-          queues.each { |q| total += count(q) }
-          total
+          queues.reduce(0) { |memo, q| memo += count(q) }
         end
       end
 

--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -1,10 +1,13 @@
 require 'resque/failure/each'
+require 'set'
 
 module Resque
   module Failure
     # A Failure backend that stores exceptions in Redis. Very simple but
     # works out of the box, along with support in the Resque web app.
     class RedisMultiQueue < Base
+      extend Each
+
       # @overload (see Resque::Failure::Base#save)
       # @param (see Resque::Failure::Base#save)
       # @return (see Resque::Failure::Base#save)
@@ -29,7 +32,7 @@ module Resque
         if queue
           if class_name
             n = 0
-            each(0, count(queue), queue, class_name) { n += 1 } 
+            each(0, count(queue), queue, class_name) { n += 1 }
             n
           else
             Resque.backend.store.llen(queue).to_i
@@ -41,13 +44,67 @@ module Resque
         end
       end
 
-      # @overload all( offset = 0, limit = 1, queue = :failed)
-      # @param offset (see Resque::Failure::Base::all)
-      # @param limit (see Resque::Failure::Base::all)
-      # @param queue [#to_s] (:failed)
-      # @return (see Resque::Failure::Base::all)
-      def self.all(offset = 0, limit = 1, queue = :failed)
-        [Resque.list_range(queue, offset, limit)].flatten
+      # @overload all(opts = {})
+      #   The main finder method for failure objects.
+      #
+      #   When no options are provided, it will return all failure objects across
+      #   all failure queues in a hash, so be careful if you have tons of failures.
+      #
+      #   If given a single failure queue name as a symbol or string, it will
+      #   return an array of results.
+      #
+      #   If given an array of queue names, it will return a hash with the queue
+      #   name as the key and the failure objects in arrays.
+      #
+      #   @example
+      #     Resque::Failure::RedisMultiQueue.all(:queue => :foo_failed)
+      #     #=> [{}, {}, ...]
+      #
+      #     Resque::Failure::RedisMultiQueue.all(:queue => [:foo_failed, :bar_failed])
+      #     #=> {:foo_failed => [{}, {}, ...], :bar_failed => [{}, {}, ...]}
+      #
+      #   @param [Hash] opts The options to filter the failures by. When omitted, returns all failures across all failure queues.
+      #   @option opts [String, Symbol, Array<String, Symbol>] :queue - the name(s) of the queue(s) to filter by
+      #   @option opts [String, Array<String>] :class_name - the name of the class(es) to filter by
+      #   @option opts [Integer] :offset - the number of failures to offset the results by (ex. pagination)
+      #   @option opts [Integer] :limit - the maximum number of failures returned (ex. pagination)
+      #   @return [Array<Hash>, Hash{Symbol=>Array<Hash>}]
+      def self.all(opts = {})
+        failures = if opts[:offset] || opts[:limit]
+          slice_from_options opts
+        else
+          find_by_queue(opts[:queue] || queues)
+        end
+
+        if opts[:class_name]
+          failures = filter_by_class_name_from failures, opts[:class_name]
+        end
+
+        failures.symbolize_keys! if failures.is_a? Hash
+
+        failures
+      end
+
+      # @overload slice(offset, limit, single_queue_name)
+      #   Returns a paginated array of failure objects.
+      #   @param offset [Integer] The index to begin retrieving records from the Redis list
+      #   @param limit [Integer] The maximum number of records to return
+      #   @param queue [#to_s] The queue to slice from
+      #   @return [Array<Hash{String=>Object}>]
+      # @overload slice(offset, limit, array_of_queue_names)
+      #   Returns a hash with keys as queue names and values as arrays of failure objects
+      #   @param offset [Integer] The index to begin retrieving records from the Redis list
+      #   @param limit [Integer] The maximum number of records to return
+      #   @param queue [Array<#to_s>] The queues to slice from
+      #   @return [<Hash{Symbol=>Array<Hash{String=>Object}>}>]
+      def self.slice(offset = 0, limit = 1, queue = queues)
+        if queue.is_a? Array
+          queue.each_with_object({}) do |queue_name, hash|
+            hash[queue_name.to_sym] = slice offset, limit, queue_name
+          end
+        else
+          [Resque.list_range(Array(queue).first, offset, limit)].flatten
+        end
       end
 
       # @overload (see Resque::Failure::Base::queues)
@@ -56,8 +113,6 @@ module Resque
       def self.queues
         Array(Resque.backend.store.smembers(:failed_queues))
       end
-
-      extend Each
 
       # @overload (see Resque::Failure::Base::clear)
       # @param (see Resque::Failure::Base::clear)
@@ -70,7 +125,7 @@ module Resque
       # @param queue [#to_s]
       # @return (see Resque::Failure::Base::requeue)
       def self.requeue(id, queue = :failed)
-        item = all(id, 1, queue).first
+        item = slice(id, 1, queue).first
         item['retried_at'] = Time.now.strftime("%Y/%m/%d %H:%M:%S")
         Resque.backend.store.lset(queue, id, Resque.encode(item))
         Job.create(item['queue'], item['payload']['class'], *item['payload']['args'])
@@ -107,6 +162,21 @@ module Resque
       # @return [Array<String>]
       def filter_backtrace(backtrace)
         backtrace.take_while { |item| !item.include?('/lib/resque/job.rb') }
+      end
+
+      private
+
+      # Utility method used by ::all.
+      # Finds failures for the given queue(s)
+      # @api private
+      def self.find_by_queue(queue)
+        if queue.is_a? Array
+          queue.each_with_object({}) do |queue, hash|
+            hash[queue] = Resque.full_list queue
+          end
+        else
+          Resque.full_list queue
+        end
       end
     end
   end

--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -172,8 +172,8 @@ module Resque
       # @api private
       def self.find_by_queue(queue)
         if queue.is_a? Array
-          queue.each_with_object({}) do |queue, hash|
-            hash[queue] = Resque.full_list queue
+          queue.each_with_object({}) do |queue_name, hash|
+            hash[queue_name] = find_by_queue queue_name
           end
         else
           Resque.full_list queue

--- a/test/resque/failure/redis_multi_queue_test.rb
+++ b/test/resque/failure/redis_multi_queue_test.rb
@@ -15,7 +15,7 @@ describe Resque::Failure::RedisMultiQueue do
     it 'should requeue a new job to the queue of the failed job' do
       save_failure
 
-      failure = Resque::Failure::RedisMultiQueue.all(0, 1, :failed_failed).first
+      failure = Resque::Failure::RedisMultiQueue.slice(0, 1, :failed_failed).first
       assert_nil failure['retried_at']
 
       Resque::Failure::RedisMultiQueue.requeue(0, :failed_failed)
@@ -24,7 +24,7 @@ describe Resque::Failure::RedisMultiQueue do
       assert_equal 'some_class', job.payload['class']
       assert_equal ['some_args'], job.args
 
-      failure = Resque::Failure::RedisMultiQueue.all(0, 1, :failed_failed).first
+      failure = Resque::Failure::RedisMultiQueue.slice(0, 1, :failed_failed).first
       refute_nil failure['retried_at']
     end
   end
@@ -113,6 +113,371 @@ describe Resque::Failure::RedisMultiQueue do
 
       assert_equal 1, Resque::Failure::RedisMultiQueue.count('queue1_failed', 'some_class')
       assert_equal 2, Resque::Failure::RedisMultiQueue.count('queue1_failed', 'another_class')
+    end
+  end
+
+  describe '#all' do
+    it 'should return an Array of all failures matching a single queue name' do
+      # matching
+      save_failure('queue1')
+
+      # not matching (fails queue name)
+      save_failure('queue2')
+
+      result = Resque::Failure::RedisMultiQueue.all(:queue => :queue1_failed)
+      assert_instance_of Array, result
+      assert_equal 1, result.size
+      assert_equal 'queue1', result.first['queue']
+    end
+
+    it 'should return a Hash of all failures matching an array of queue names' do
+      # matching
+      save_failure('queue1')
+      save_failure('queue2')
+
+      # not matching (fails queue name)
+      save_failure('queue3')
+
+      result = Resque::Failure::RedisMultiQueue.all(
+        :queue => [:queue1_failed, :queue2_failed]
+      )
+      assert_instance_of Hash, result
+      assert_equal 2, result.size
+      assert_equal 'queue1', result[:queue1_failed].first['queue']
+      assert_equal 'queue2', result[:queue2_failed].first['queue']
+    end
+
+    it 'should return an empty array for no results with a single queue name' do
+      result = Resque::Failure::RedisMultiQueue.all(:queue => :foo)
+      assert_equal [], result
+    end
+
+    it 'should return a hash with empty array values for no results with multiple queues' do
+      result = Resque::Failure::RedisMultiQueue.all(:queue => [:foo, :bar])
+      assert_equal({ :foo => [], :bar => [] }, result)
+    end
+
+    it 'should return all failures matching a single class name' do
+      # matching
+      save_failure('queue1', 'class1')
+      save_failure('queue2', 'class1')
+
+      # not matching (fails class name)
+      save_failure('queue1', 'class2')
+
+      result = Resque::Failure::RedisMultiQueue.all(:class_name => 'class1')
+      assert_instance_of Hash, result
+      assert_equal 2, result.size
+      assert_equal 1, result[:queue1_failed].size
+      assert_equal 'class1', result[:queue1_failed].first['payload']['class']
+      assert_equal 'class1', result[:queue2_failed].first['payload']['class']
+    end
+
+    it 'should return all failures matching an array of class names' do
+      # matching
+      save_failure('queue1', 'class1')
+      save_failure('queue2', 'class2')
+
+      # not matching (fails class name)
+      save_failure('queue1', 'class3')
+
+      result = Resque::Failure::RedisMultiQueue.all(
+        :class_name => ['class1', 'class2']
+      )
+      assert_instance_of Hash, result
+      assert_equal 2, result.size
+      assert_equal 1, result[:queue1_failed].size
+      assert_equal 'class1', result[:queue1_failed].first['payload']['class']
+      assert_equal 'class2', result[:queue2_failed].first['payload']['class']
+    end
+
+    it 'should return all failures matching a single queue name and single class name' do
+      # matching
+      save_failure('queue1', 'class1')
+
+      # not matching
+      save_failure('queue1', 'class2') # fails class name
+      save_failure('queue2', 'class1') # fails queue name
+
+      result = Resque::Failure::RedisMultiQueue.all(
+        :queue => 'queue1_failed',
+        :class_name => 'class1'
+      )
+      assert_instance_of Array, result
+      assert_equal 1, result.size
+      assert_equal 'queue1', result.first['queue']
+      assert_equal 'class1', result.first['payload']['class']
+    end
+
+    it 'should return all failures matching a single queue name and an array of class names' do
+      # matching
+      save_failure('queue1', 'class1')
+      save_failure('queue1', 'class2')
+
+      # not matching
+      save_failure('queue1', 'class3') # fails class name
+      save_failure('queue2', 'class1') # fails queue name
+
+      result = Resque::Failure::RedisMultiQueue.all(
+        :queue => 'queue1_failed',
+        :class_name => ['class1', 'class2']
+      )
+      assert_instance_of Array, result
+      assert_equal 2, result.size
+      assert_equal 'queue1', result.first['queue']
+      assert_equal 'class1', result.first['payload']['class']
+      assert_equal 'queue1', result.last['queue']
+      assert_equal 'class2', result.last['payload']['class']
+    end
+
+    it 'should return all failures matching an array of queue names and a single class name' do
+      # matching
+      save_failure('queue1', 'class1')
+      save_failure('queue2', 'class1')
+
+      # not matching
+      save_failure('queue1', 'class2') # fails class name
+      save_failure('queue3', 'class1') # fails queue name
+
+      result = Resque::Failure::RedisMultiQueue.all(
+        :queue => ['queue1_failed', 'queue2_failed'],
+        :class_name => 'class1'
+      )
+      assert_instance_of Hash, result
+      assert_equal 2, result.size
+      assert_equal 'queue1', result[:queue1_failed].first['queue']
+      assert_equal 'class1', result[:queue1_failed].first['payload']['class']
+      assert_equal 'queue2', result[:queue2_failed].first['queue']
+      assert_equal 'class1', result[:queue2_failed].first['payload']['class']
+    end
+
+    it 'should return all failures matching arrays of queue and class names' do
+      # matching
+      save_failure('queue1', 'class1')
+      save_failure('queue1', 'class2')
+      save_failure('queue2', 'class1')
+      save_failure('queue2', 'class2')
+
+      # not matching
+      save_failure('queue1', 'class3') # fails class name
+      save_failure('queue3', 'class1') # fails queue name
+
+      result = Resque::Failure::RedisMultiQueue.all(
+        :queue => [:queue1_failed, :queue2_failed],
+        :class_name => ['class1', 'class2']
+      )
+      assert_instance_of Hash, result
+      assert_equal 2, result.size
+      assert_equal 2, result[:queue1_failed].size
+      assert_equal 2, result[:queue2_failed].size
+    end
+
+    it 'should offset the number of failures by the given offset across all queues (single queue exists)' do
+      # not matching (fails offset)
+      save_failure('queue1', 'class1')
+
+      # matching
+      save_failure('queue1', 'class2')
+      save_failure('queue1', 'class3')
+
+      result = Resque::Failure::RedisMultiQueue.all(:offset => 1)
+      assert_instance_of Hash, result
+      assert_equal 1, result.size
+      assert_equal ['class2', 'class3'],
+        result[:queue1_failed].map { |val| val['payload']['class'] }
+    end
+
+    it 'should offset the number of failures by the given offset across all queues (multiple queues exist)' do
+      # not matching (fails offset)
+      save_failure('queue1', 'class1')
+      save_failure('queue2', 'class3')
+
+      # matching
+      save_failure('queue1', 'class2')
+      save_failure('queue2', 'class4')
+
+      result = Resque::Failure::RedisMultiQueue.all(:offset => 1)
+      assert_instance_of Hash, result
+      assert_equal 2, result.size
+      assert_equal 'class2', result[:queue1_failed].first['payload']['class']
+      assert_equal 'class4', result[:queue2_failed].first['payload']['class']
+    end
+
+    it 'should restrict the number of failures to the given limit across all queues (single queue exists)' do
+      # matching
+      save_failure('queue1', 'class1')
+      save_failure('queue1', 'class2')
+
+      # not matching (fails limit)
+      save_failure('queue1', 'class3')
+
+      result = Resque::Failure::RedisMultiQueue.all(:limit => 2)
+      assert_instance_of Hash, result
+      assert_equal 1, result.size
+      assert_equal ['class1', 'class2'],
+        result[:queue1_failed].map { |val| val['payload']['class'] }
+    end
+
+    it 'should restrict the number of failures to the given limit across all queues (multiple queues exist)' do
+      # matching
+      save_failure('queue1', 'class1')
+      save_failure('queue1', 'class2')
+      save_failure('queue2', 'class4')
+      save_failure('queue2', 'class5')
+
+      # not matching (fails limit)
+      save_failure('queue1', 'class3')
+      save_failure('queue2', 'class6')
+
+      result = Resque::Failure::RedisMultiQueue.all(:limit => 2)
+      assert_instance_of Hash, result
+      assert_equal 2, result.size
+      assert_equal ['class1', 'class2'],
+        result[:queue1_failed].map { |val| val['payload']['class'] }
+      assert_equal ['class4', 'class5'],
+        result[:queue2_failed].map { |val| val['payload']['class'] }
+    end
+
+    it 'should offset and limit results when given limit and offset options across all queues (single queue exists)' do
+      # not matching (fails offset)
+      save_failure('queue1', 'class1')
+
+      # matching
+      save_failure('queue1', 'class2')
+
+      # not matching (fails limit)
+      save_failure('queue1', 'class3')
+
+      result = Resque::Failure::RedisMultiQueue.all(:offset => 1, :limit => 1)
+      assert_instance_of Hash, result
+      assert_equal 1, result.size
+      assert_equal 1, result[:queue1_failed].size
+      assert_equal 'class2', result[:queue1_failed].first['payload']['class']
+    end
+
+    it 'should offset and limit results when given limit and offset options across all queues (multiple queues exist)' do
+      # not matching (fails offset)
+      save_failure('queue1', 'class1')
+      save_failure('queue2', 'class4')
+
+      # matching
+      save_failure('queue1', 'class2')
+      save_failure('queue2', 'class5')
+
+      # not matching (fails limit)
+      save_failure('queue1', 'class3')
+      save_failure('queue2', 'class6')
+
+      result = Resque::Failure::RedisMultiQueue.all(:offset => 1, :limit => 1)
+      assert_instance_of Hash, result
+      assert_equal 2, result.size
+      assert_equal 1, result[:queue1_failed].size
+      assert_equal 'class2', result[:queue1_failed].first['payload']['class']
+      assert_equal 1, result[:queue2_failed].size
+      assert_equal 'class5', result[:queue2_failed].first['payload']['class']
+    end
+
+    it 'should offset and limit failures from the single given queue' do
+      # not matching
+      save_failure('queue1', 'class1') # fails offset
+      save_failure('queue2', 'class1') # fails offset and queue name
+
+      # matching
+      save_failure('queue1', 'class2')
+
+      # not matching
+      save_failure('queue1', 'class3') # fails limit
+      save_failure('queue2', 'class1') # fails queue name
+
+      result = Resque::Failure::RedisMultiQueue.all(
+        :offset => 1,
+        :limit => 1,
+        :queue => :queue1_failed
+      )
+      assert_instance_of Array, result
+      assert_equal 1, result.size
+      assert_equal 'class2', result.first['payload']['class']
+    end
+
+    it 'should offset and limit failures from the array of given queues' do
+      # not matching
+      save_failure('queue1', 'class1') # fails offset
+      save_failure('queue2', 'class4') # fails offset
+      save_failure('queue3', 'class6') # fails offset and queue name
+
+      # matching
+      save_failure('queue1', 'class2')
+      save_failure('queue2', 'class5')
+
+      # not matching
+      save_failure('queue1', 'class3') # fails limit
+      save_failure('queue3', 'class7') # fails queue name
+
+      result = Resque::Failure::RedisMultiQueue.all(
+        :offset => 1,
+        :limit => 1,
+        :queue => [:queue1_failed, :queue2_failed]
+      )
+      assert_instance_of Hash, result
+      assert_equal 2, result.size
+      assert_equal 1, result[:queue1_failed].size
+      assert_equal 'class2', result[:queue1_failed].first['payload']['class']
+      assert_equal 1, result[:queue2_failed].size
+      assert_equal 'class5', result[:queue2_failed].first['payload']['class']
+    end
+
+    it 'should offset and limit failures then filter by the single given class name' do
+      # not matching (fails offset)
+      save_failure('queue1', 'class1')
+      save_failure('queue2', 'class1')
+
+      # matching
+      save_failure('queue1', 'class1', 'arg1')
+
+      # not matching (fails class_name)
+      save_failure('queue1', 'class2')
+      save_failure('queue2', 'class2')
+
+
+      result = Resque::Failure::RedisMultiQueue.all(
+        :offset => 1,
+        :limit => 2,
+        :class_name => 'class1'
+      )
+      assert_instance_of Hash, result
+      assert_equal 2, result.size
+      assert_equal 1, result[:queue1_failed].size
+      assert_equal 'arg1', result[:queue1_failed].first['payload']['args']
+      assert_equal 0, result[:queue2_failed].size
+    end
+
+    it 'should offset and limit failures then filter by the array of given class names' do
+      # not matching (fails offset)
+      save_failure('queue1', 'class1')
+      save_failure('queue2', 'class1')
+
+      # matching
+      save_failure('queue1', 'class1', 'arg1')
+      save_failure('queue1', 'class2', 'arg2')
+      save_failure('queue2', 'class1', 'arg3')
+
+      # not matching
+      save_failure('queue1', 'class1') # fails limit
+      save_failure('queue2', 'class3') # fails class_name
+
+
+      result = Resque::Failure::RedisMultiQueue.all(
+        :offset => 1,
+        :limit => 2,
+        :class_name => ['class1', 'class2']
+      )
+      assert_instance_of Hash, result
+      assert_equal 2, result.size
+      assert_equal 2, result[:queue1_failed].size
+      assert_equal 'arg1', result[:queue1_failed].first['payload']['args']
+      assert_equal 'arg2', result[:queue1_failed].last['payload']['args']
+      assert_equal 1, result[:queue2_failed].size
+      assert_equal 'arg3', result[:queue2_failed].first['payload']['args']
     end
   end
 

--- a/test/resque/failure/redis_test.rb
+++ b/test/resque/failure/redis_test.rb
@@ -19,8 +19,7 @@ describe Resque::Failure::Redis do
 
     it 'should return an empty array if there are no items in the :failed queue' do
       result = Resque::Failure::Redis.all
-      assert_instance_of Array, result
-      assert_equal 0, result.size
+      assert_equal [], result
     end
   end
 

--- a/test/resque/failure/redis_test.rb
+++ b/test/resque/failure/redis_test.rb
@@ -6,6 +6,24 @@ describe Resque::Failure::Redis do
     Resque.backend.store.flushall
   end
 
+  describe '::all' do
+    it 'should return all failures from the :failed queue' do
+      save_failure :failed, 'class1'
+      save_failure :failed, 'class2'
+
+      result = Resque::Failure::Redis.all
+      assert_equal 2, result.count
+      assert_equal ['class1', 'class2'],
+        result.map { |failure| failure['payload']['class'] }
+    end
+
+    it 'should return an empty array if there are no items in the :failed queue' do
+      result = Resque::Failure::Redis.all
+      assert_instance_of Array, result
+      assert_equal 0, result.size
+    end
+  end
+
   describe '#count' do
     it 'should count all failures' do
       save_failure
@@ -96,8 +114,8 @@ describe Resque::Failure::Redis do
       Resque::Failure::Redis.remove_queue('queue1')
 
       assert_equal 2, Resque::Failure.count
-      assert_equal 'queue2', Resque::Failure::Redis.all(0).first['queue']
-      assert_equal 'queue3', Resque::Failure::Redis.all(1).first['queue']
+      assert_equal 'queue2', Resque::Failure::Redis.slice(0).first['queue']
+      assert_equal 'queue3', Resque::Failure::Redis.slice(1).first['queue']
     end
   end
 


### PR DESCRIPTION
The former implementation of ::all was renamed to slice. ::all now
accepts an options hash consisting of :queue, :class_name, :offset or :limit.

This is intended to be an initial implementation of @tarcieri's suggestion on
how to fix the Failure interface from the Failures 2.0 wiki.