### PR TITLE
Make sure the filicide is justified

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -170,7 +170,7 @@ module Resque
     # @return (see Resque::ChildProcess#kill)
     def shutdown!
       shutdown
-      @child.kill
+      @child.kill if @child
     end
 
     # Should this worker shutdown as soon as current job is finished?


### PR DESCRIPTION
Using `^C` before a child is forked leads to a stack trace:

```
martin@mbp[master]$ bundle exec resque work
D, [2013-09-23T08:31:28.888182 #7529] DEBUG -- : resque-2.0.0.pre.1: Starting
D, [2013-09-23T08:31:28.888305 #7529] DEBUG -- : Registered signals
I, [2013-09-23T08:31:28.890092 #7529]  INFO -- : Running before_first_fork hooks with [#<Worker mbp.local:7529:default>]
^CI, [2013-09-23T08:31:32.827525 #7529]  INFO -- : Exiting...
/Users/martin/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/bundler/gems/resque-9274eff13859/lib/resque/worker.rb:173:in `shutdown!': undefined method `kill' for nil:NilClass (NoMethodError)
```
