### PR TITLE
Add hook when process is put into the background

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -113,6 +113,22 @@ module Resque
   # Set or retrieve the current logger object
   attr_accessor :logger
 
+  # The `after_background` hook will be run in the **parent** process
+  # only once, right after the process was put into the background and before
+  # `before_first_fork` will run. Be careful- any changes you make will be 
+  # permanent for the lifespan of the worker.
+  #
+  # Call with a block to register a hook.
+  # Call with no arguments to return all registered hooks.
+  def after_background(&block)
+    block ? register_hook(:after_background, block) : hooks(:after_background)
+  end
+
+  # Register a before_first_fork proc.
+  def after_background=(block)
+    register_hook(:after_background, block)
+  end
+
   # The `before_first_fork` hook will be run in the **parent** process
   # only once, before forking to run the first job. Be careful- any
   # changes you make will be permanent for the lifespan of the

--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -30,6 +30,7 @@ namespace :resque do
           abort "env var BACKGROUND is set, which requires ruby >= 1.9"
       end
       Process.daemon(true, true)
+      worker.run_hook :after_background
     end
 
     if ENV['PIDFILE']


### PR DESCRIPTION
When resque workers are put into the background / daemonized with BACKGROUND=yes, it might be that you get "Redis::InheritedError: Tried to use a connection from a child process without reconnecting." error in cases where the redis connection was opened before the worker is put into the background (e.g. due to loading the rails environment)

We tried to fix this issues by reconnecting to redis in `before_first_hook`, but the exception we experienced are raised before the `before_first_fork` is run, namely in `prune_dead_workers`.

It is to be discussed whether a better fix would be to run the `before_first_fork` somewhere earlier, e.g. at the beginning of `startup`, instead of adding a new `after_background` hook.

Due to unclear backwards compatibility implications we decided to add a new hook right after `Process.deamon`.
This will also make sure that reconnecting to redis is performed as early as possible so that potential new code won't connect to redis before `before_first_fork` would be run.
