### PR TITLE
Prevent a Resque::Failure from being created when re-queuing jobs

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -141,6 +141,7 @@ Modules are even better because jobs can use many of them.
       def on_failure_retry(e, *args)
         Logger.info "Performing #{self} caused an exception (#{e}). Retrying..."
         Resque.enqueue self, *args
+        raise Resque::DontFail.new # Don't add the failed job to the Resque::Failure backend
       end
     end
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -104,7 +104,8 @@ The available hooks are:
   `Resque::Failure` backend.
 
 * `on_failure`: Called with the exception and job args if any exception occurs
-  while performing the job (or hooks), this includes Resque::DirtyExit.
+  while performing the job (or hooks), this includes `Resque::DirtyExit`. If it raises `Resque::DontFail`,
+  the job will not be added to the `Resque::Failure` backend.
 
 Hooks are easily implemented with superclasses or modules. A superclass could
 look something like this.

--- a/lib/resque/errors.rb
+++ b/lib/resque/errors.rb
@@ -13,4 +13,7 @@ module Resque
 
   # Raised from a before_perform hook to abort the job.
   class DontPerform < StandardError; end
+
+  # Raised from a on_failure hook to prevent a Resque::Failure from being created
+  class DontFail < StandardError; end
 end

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -221,6 +221,7 @@ module Resque
     def fail(exception)
       Resque.logger.info "#{inspect} failed: #{exception.inspect}"
       run_failure_hooks(exception) if has_payload_class?
+      return if exception.is_a?(DontFail)
       Failure.create \
         :payload   => payload,
         :exception => exception,

--- a/test/resque/job_performer_test.rb
+++ b/test/resque/job_performer_test.rb
@@ -1,15 +1,13 @@
 require 'test_helper'
 
 describe Resque::JobPerformer do
-  before do
-    @mock          = MiniTest::Mock.new
-    @job_performer = Resque::JobPerformer.new
-    @job_args = [:foo]
-  end
+  let(:mock) { MiniTest::Mock.new }
+  let(:job_performer) { Resque::JobPerformer.new }
+  let(:job_args) { [:foo] }
 
   describe '#perform' do
-    before do
-      @options  = {
+    let(:options) {
+      {
         :before => [
           :before_one,
           :before_two
@@ -20,34 +18,40 @@ describe Resque::JobPerformer do
           :after_two
         ]
       }
-    end
+    }
 
     it 'runs the before hooks' do
-      @mock.expect :before_one, true, @job_args
-      @mock.expect :before_two, true, @job_args
-      @mock.expect :perform, true, @job_args
-      @mock.expect :after_one, true, @job_args
-      @mock.expect :after_two, true, @job_args
-      @job_performer.perform(@mock, @job_args, @options).must_equal true
-      @mock.verify
+      mock.expect :before_one, true, job_args
+      mock.expect :before_two, true, job_args
+      mock.expect :perform, true, job_args
+      mock.expect :after_one, true, job_args
+      mock.expect :after_two, true, job_args
+      job_performer.perform(mock, job_args, options).must_equal true
+      mock.verify
     end
 
-    it 'returns false when a before mock raises DontPerform' do
-      @options = {
-        :before => [:before_one],
-        :after  => [],
-        :around => []
+    describe "mock raises DontPerform" do
+      let(:options) {
+        {
+          :before => [:before_one],
+          :after  => [],
+          :around => []
+        }
       }
-      def @mock.before_one(*args)
-        raise Resque::DontPerform
+
+      it 'should return false' do
+        def mock.before_one(*args)
+          raise Resque::DontPerform
+        end
+
+        mock.expect :perform, nil, job_args
+        job_performer.perform(mock, job_args, options).must_equal false
       end
-      @mock.expect :perform, nil, @job_args
-      @job_performer.perform(@mock, @job_args, @options).must_equal false
     end
 
     describe 'when around_perform is present' do
-      before do
-        @options = {
+      let(:options) {
+        {
           :before => [],
           :around => [
             :around_one,
@@ -55,22 +59,22 @@ describe Resque::JobPerformer do
           ],
           :after => []
         }
-      end
+      }
 
       it 'runs the around hooks' do
-        @mock.expect :perform, true, @job_args
-        @mock.expect :around_two, true, @job_args
-        @mock.expect :around_one, true, @job_args
-        def @mock.around_two(*args)
+        mock.expect :perform, true, job_args
+        mock.expect :around_two, true, job_args
+        mock.expect :around_one, true, job_args
+        def mock.around_two(*args)
           method_missing(:around_two, *args)
           yield
         end
-        def @mock.around_one(*args)
+        def mock.around_one(*args)
           method_missing(:around_one, *args)
           yield
         end
-        @job_performer.perform(@mock, @job_args, @options)
-        @mock.verify
+        job_performer.perform(mock, job_args, options)
+        mock.verify
       end
     end
   end

--- a/test/resque/job_test.rb
+++ b/test/resque/job_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+module Resque
+  describe Job do
+    class ::DummyJob
+      def self.perform
+      end
+    end
+
+    subject { Resque::Job.new(:jobs, {'class' => DummyJob}) }
+
+    describe "#fail(exception)" do
+      let(:failure) { "Resque::Failure" }
+
+      def assert_created_failure(assertion, exception)
+        Failure.stub(:create, failure) do
+          assert_equal(assertion, subject.fail(exception))
+        end
+      end
+
+      describe "a Resque::DontFail exception is NOT raised" do
+        it "should create the failure" do
+          assert_created_failure(failure, DirtyExit.new)
+        end
+      end
+
+      describe "a Resque::DontFail exception is raised" do
+        it "should not create the failure" do
+          assert_created_failure(nil, DontFail.new)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I'm currently using the `on_failure_retry` hook to re-enqueue jobs like this:

```ruby
def on_failure_retry(exception, *args)
  if exception.is_a?(Resque::TermException)
    Resque.enqueue(self, *args)
  end
end
```
In these cases I don't want a new Resque::Failure to be created and shown in ResqueWeb

Borrowing from the idea for the before_hooks where you can raise a `Resque::DontPerform` exception to prevent a job from being run, it would would be nice if we could do something like this:

```ruby
def on_failure_retry(exception, *args)
  if exception.is_a?(Resque::TermException)
    Resque.enqueue(self, *args)
    raise Resque::DontFail
  end
end
```
This would prevent the code `Resque::Failure.create` from being called.

I think this approach is more flexible than automatically trying to rescue from `Resque::TermException` because the approach can be used for any job that has been requeued.

If people are happy with this solution I'll go ahead and attach a pull-request.