### PR TITLE
Alternate for #1120: queueless worker silently fails new worker when being pruned

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -493,8 +493,8 @@ module Resque
       known_workers = worker_pids unless all_workers.empty?
       all_workers.each do |worker|
         host, pid, worker_queues_raw = worker.id.split(':')
-        worker_queues = worker_queues_raw.split(",")
-        unless @queues.include?("*") || (worker_queues.to_set == @queues.to_set)
+        worker_queues = (worker_queues_raw ? worker_queues_raw.split(",") : [])
+        unless @queues.include?("*") || worker_queues.empty? || (worker_queues.to_set == @queues.to_set)
           # If the worker we are trying to prune does not belong to the queues
           # we are listening to, we should not touch it. 
           # Attempt to prune a worker from different queues may easily result in

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -470,7 +470,12 @@ context "Resque::Worker" do
     workerB.instance_variable_set(:@to_s, "#{`hostname`.chomp}-foo:4:high")
     workerB.register_worker
 
-    assert_equal 4, Resque.workers.size
+    # 5: no queues; gets pruned.
+    workerA = Resque::Worker.new(:jobs)
+    workerA.instance_variable_set(:@to_s, "#{`hostname`.chomp}:5:")
+    workerA.register_worker
+
+    assert_equal 5, Resque.workers.size
 
     # then we prune them
     @worker.work(0)
@@ -481,6 +486,7 @@ context "Resque::Worker" do
 
     # pruned
     assert !worker_strings.include?("#{`hostname`.chomp}:1:jobs")
+    assert !worker_strings.include?("#{`hostname`.chomp}:5:")
 
     # not pruned
     assert worker_strings.include?("#{`hostname`.chomp}-foo:2:jobs")


### PR DESCRIPTION
If a worker is all of:

1. registered
2. not listening on any queues
3. on our host
4. no longer running (via pid check)

It should get pruned.

See #1120 (cc: @dsabanin)