### PR TITLE
Interrupted system call - hostname (Errno::EINTR)

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -647,7 +647,7 @@ module Resque
 
     # chomp'd hostname of this machine
     def hostname
-      @hostname ||= `hostname`.chomp
+      Socket.gethostname
     end
 
     # Returns Integer PID of running worker


### PR DESCRIPTION
When create many resque workers simultaneously, it may raise 'Interrupted system call' on mac os x. This is fixed in 2.0 release, but not in 1.x
