### PR TITLE
Avoid masking exceptions that cause unregistering

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -581,6 +581,15 @@ module Resque
         Stat.clear("processed:#{self}")
         Stat.clear("failed:#{self}")
       end
+    rescue Exception => exception_while_unregistering
+      message = exception_while_unregistering.message
+      if exception
+        message << "\nOriginal Exception (#{exception.class}): #{exception.message}\n"
+        message << "  #{exception.backtrace.join("  \n")}"
+      end
+      fail(exception_while_unregistering.class,
+           message,
+           exception_while_unregistering.backtrace)
     end
 
     # Given a job, tells Redis we're working on it. Useful for seeing

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -584,8 +584,8 @@ module Resque
     rescue Exception => exception_while_unregistering
       message = exception_while_unregistering.message
       if exception
-        message << "\nOriginal Exception (#{exception.class}): #{exception.message}\n"
-        message << "  #{exception.backtrace.join("  \n")}"
+        message = message + "\nOriginal Exception (#{exception.class}): #{exception.message}\n" + 
+                            "  #{exception.backtrace.join("  \n")}"
       end
       fail(exception_while_unregistering.class,
            message,

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -135,7 +135,7 @@ describe "Resque::Worker" do
     assert_equal('StandardError', Resque::Failure.all['exception'])
   end
 
-  test "does not mask exception when timeout getting job metadata" do
+  it "does not mask exception when timeout getting job metadata" do
     job = Resque::Job.new(:jobs, {'class' => 'GoodJob', 'args' => "blah"})
     @worker.working_on(job)
     Resque.redis.stubs(:get).raises(Redis::CannotConnectError)


### PR DESCRIPTION
When unregistering a worker, there are various calls to Redis to try to fail the job that's in progress, however if said job is failing due to an unhandled exception but we then get an exception accessing Redis itself, the original exception is raised, making it impossible to figure out what else might've gone wrong and how to fix it.

FWIW, I see this very frequently and the log message "Failed to start worker {ex.message}" is never rendered.

To show how masking the real exception is a problem, consider the following situation:

1. Queue worker to charge someone $50
2. Will contacting the gateway, we loose the network
3. Job fails with "Connection Timed Out"
4. Exception bubbles up and Resque unregisters the worker, with the timeout exception as the value `exception` passed to `unregister_worker`.
5. When checking to see if still processing a job, timeout to Redis (which you could imagine might happen if Redis is cloud-hosted and the network issue were on the network where workers were running)

In the current implementation, we don't see the timeout to our credit card processor, and we don't see what job was even running, so we can't event see that there was a problem charging someone $50

The change below would favor the original exception to be raised, instead of the Redis Timeout, in this case.

Let me know if there is a better way to do this.