### PR TITLE
Reconnect to redis after daemonize.

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -30,8 +30,7 @@ namespace :resque do
           abort "env var BACKGROUND is set, which requires ruby >= 1.9"
       end
       Process.daemon(true, true)
-      Redis.current.client.reconnect
-      Resque.redis = Redis.current
+      Resque.redis.client.reconnect
     end
 
     if ENV['PIDFILE']


### PR DESCRIPTION
When we daemonize resque, pid is changed and we need to reconnect to redis to avoid InheritedError.
