### PR TITLE
Moved yard gem under common group development and documentation in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,15 +5,17 @@ gem "redis-namespace", :git => "https://github.com/resque/redis-namespace.git"
 
 group :development do
   gem 'rake'
-  gem 'yard'
 end
 
 group :documentation do
   gem 'rdoc'
-  gem 'yard'
   gem 'yard-thor', '~>0.2', :github => 'lsegal/yard-thor'
   gem 'kramdown'
   gem 'coveralls', :require => false
+end
+
+group :development, :documentation do
+  gem 'yard'
 end
 
 group :test do


### PR DESCRIPTION
- While running 'bundle' with bundler version 1.5.1 command following message was observed
  
  Your Gemfile lists the gem yard (>= 0) more than once.
  You should probably keep only one of them.
  While it's not a problem now, it could cause errors if you change the version of just one of them later.
- This commit adds 'yard' gem to common group of development and
  documentation to remove that message
