### PR TITLE
Refactor Resque::Worker#prune_dead_workers

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -233,7 +233,7 @@ module Resque
     def dead_worker?(worker)
       host, pid, workers_queues = worker.info.values_at(:host, :pid, :queues)
 
-      (worker_queues.all_queues? || (workers_queues.to_set == worker_queues.to_set)) &&
+      (worker_queues.all_queues? || (workers_queues.to_set == worker_queues.to_set) || workers_queues.empty?) &&
         host == hostname && !known_workers.include?(pid)
     end
 

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -213,56 +213,6 @@ module Resque
       end
     end
 
-    # Given a worker, if it's defined as prunable it gets unregistered
-    # from the WorkerRegistry
-    # @return [void]
-    def prune_worker_if_dead(worker)
-      if dead_worker?(worker)
-        logger.debug "Pruning dead worker: #{worker}"
-        WorkerRegistry.new(worker).unregister
-      end
-    end
-
-    # Checks to see if another worker is able to be pruned
-    # @return [Boolean]
-    def dead_worker?(worker)
-      shares_queues?(worker) && shares_host?(worker) && unknown_worker?(worker)
-    end
-
-    # If the worker we are trying to prune does not belong to the queues
-    # we are listening to, we should not touch it.
-    #
-    # Attempt to prune a worker from different queues may easily result in
-    # an unknown class exception, since that worker could easily be even
-    # written in different language.
-    # @return [Boolean]
-    def shares_queues?(worker)
-      workers_queues = worker.info[:queues]
-      worker_queues.all_queues? ||
-        (workers_queues.to_set == worker_queues.to_set) ||
-        workers_queues.empty?
-    end
-
-    # Checks to see if a different worker shares a host with this worker
-    # @return [Boolean]
-    def shares_host?(worker)
-      host = worker.info[:host]
-      host == hostname
-    end
-
-    # Checks to see if the WorkerRegistry knows about this worker
-    # @return [Boolean]
-    def unknown_worker?(worker)
-      pid = worker.info[:pid]
-      !known_workers.include?(pid)
-    end
-
-    # Helper to get an array of worker pids from the ProcessCoordinator
-    # @return [Array<String>]
-    def known_workers
-      ProcessCoordinator.new.worker_pids unless WorkerRegistry.all.empty?
-    end
-
     # Returns some basic information about this worker in hash format
     # {
     #   :host   => String,
@@ -525,6 +475,57 @@ module Resque
     # @return [Boolean]
     def graceful_term?
       options[:graceful_term]
+    end
+
+    private
+    # Given a worker, if it's defined as prunable it gets unregistered
+    # from the WorkerRegistry
+    # @return [void]
+    def prune_worker_if_dead(worker)
+      if dead_worker?(worker)
+        logger.debug "Pruning dead worker: #{worker}"
+        WorkerRegistry.new(worker).unregister
+      end
+    end
+
+    # Checks to see if another worker is able to be pruned
+    # @return [Boolean]
+    def dead_worker?(worker)
+      shares_queues?(worker) && shares_host?(worker) && unknown_worker?(worker)
+    end
+
+    # If the worker we are trying to prune does not belong to the queues
+    # we are listening to, we should not touch it.
+    #
+    # Attempt to prune a worker from different queues may easily result in
+    # an unknown class exception, since that worker could easily be even
+    # written in different language.
+    # @return [Boolean]
+    def shares_queues?(worker)
+      workers_queues = worker.info[:queues]
+      worker_queues.all_queues? ||
+        (workers_queues.to_set == worker_queues.to_set) ||
+        workers_queues.empty?
+    end
+
+    # Checks to see if a different worker shares a host with this worker
+    # @return [Boolean]
+    def shares_host?(worker)
+      host = worker.info[:host]
+      host == hostname
+    end
+
+    # Checks to see if the WorkerRegistry knows about this worker
+    # @return [Boolean]
+    def unknown_worker?(worker)
+      pid = worker.info[:pid]
+      !known_workers.include?(pid)
+    end
+
+    # Helper to get an array of worker pids from the ProcessCoordinator
+    # @return [Array<String>]
+    def known_workers
+      ProcessCoordinator.new.worker_pids unless WorkerRegistry.all.empty?
     end
   end
 end

--- a/test/resque/process_coordinator_test.rb
+++ b/test/resque/process_coordinator_test.rb
@@ -19,19 +19,19 @@ CMD
     it "should return worker pids for each OS" do
       Resque::ProcessCoordinator.stub_const(:RUBY_PLATFORM, "solaris") do
         process_coordinator.stub :`, SOLARIS_RESPONSE do
-          assert_equal process_coordinator.worker_pids, ["11111"]
+          assert_equal ["11111"], process_coordinator.worker_pids
         end
       end
 
       Resque::ProcessCoordinator.stub_const(:RUBY_PLATFORM, "mingw32") do
         process_coordinator.stub :`, WINDOWS_RESPONSE do
-          assert_equal process_coordinator.worker_pids, ["5244"]
+          assert_equal ["5244"], process_coordinator.worker_pids
         end
       end
 
       Resque::ProcessCoordinator.stub_const(:RUBY_PLATFORM, "linux") do
         process_coordinator.stub :`, LINUX_RESPONSE do
-          assert_equal process_coordinator.worker_pids, ["22222"]
+          assert_equal ["22222"], process_coordinator.worker_pids
         end
       end
     end

--- a/test/resque/worker_test.rb
+++ b/test/resque/worker_test.rb
@@ -152,7 +152,7 @@ describe Resque::Worker do
 
   end
 
-  describe "#prune" do
+  describe "#prune_dead_workers" do
     it "removes workers from Redis that aren't running" do
       redis = Resque.backend.store
 


### PR DESCRIPTION
I was looking through CodeClimate for bad methods and found this one so
I decided I could refactor it.

Testing it was the hardest part.

I moved a lot of what was in #prune_dead_workers into some helper
methods to split up responsibility.

I also the order of the arguments passed to `assert_equal` in the
ProcessCoordinator test because the error output was confusing.

I tried my best to adhere to the style of the code I saw, but I'm more than happy to make any changes.