### PR TITLE
add :log_file configuration option and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ interval: 1
 daemon: true
 timeout: 5
 graceful_term: false
+log_file: '/var/log/resque.log'
 ```
 
 Then pass the configuration to the resque CLI: `bin/resque work -c='./.resque'`.

--- a/lib/resque/cli.rb
+++ b/lib/resque/cli.rb
@@ -17,6 +17,7 @@ module Resque
       end
 
       Resque.redis = options[:redis] || "localhost:6379/resque"
+      Resque.logger = MonoLogger.new(options[:log_file]) if options[:log_file]
     end
 
     desc "work", "Start processing jobs."


### PR DESCRIPTION
The default logging to STDOUT is rather verbose, especially when running with other services (such as with foreman). This adds a log_file configuration option for CLI config files but defaults to the same behavior.