### PR TITLE
Use human readable date in process names

### DIFF
--- a/lib/resque/child_process.rb
+++ b/lib/resque/child_process.rb
@@ -1,5 +1,6 @@
 require 'resque/worker_hooks'
 require 'resque/signal_trapper'
+require 'time' # Time#iso8601
 
 module Resque
   # A child process processes a single job. It is created by a Resque Worker.
@@ -110,7 +111,7 @@ module Resque
     # @return [nil] on SystemCallError failure
     def wait
       srand # Reseeding
-      procline "Forked #{pid} at #{Time.now.to_i}"
+      procline "Forked #{pid} at #{Time.now.iso8601}"
       begin
         Process.waitpid(pid)
       rescue SystemCallError

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -291,7 +291,7 @@ module Resque
     # @yieldreturn [void]
     # @return [void]
     def perform(job)
-      procline "Processing #{job.queue} since #{Time.now.to_i} [#{job.payload_class_name}]"
+      procline "Processing #{job.queue} since #{Time.now.iso8601} [#{job.payload_class_name}]"
       worker_hooks.run_hook :before_perform, job
       job.perform
       worker_hooks.run_hook :after_perform, job

--- a/test/legacy/worker_test.rb
+++ b/test/legacy/worker_test.rb
@@ -497,7 +497,7 @@ describe "Resque::Worker" do
     stub_to_fork(worker, false) do
       worker.work do
         ver = Resque::Version
-        assert_equal "resque-#{ver}: Processing jobs since #{Time.now.to_i} [SomeJob]", $0
+        assert_equal "resque-#{ver}: Processing jobs since #{Time.now.iso8601} [SomeJob]", $0
       end
     end
   end


### PR DESCRIPTION
Resque workers process line displaying unix timestamp is pretty useless, especially when viewing the process list. It's impossible to tell if a job is taking too long from unix timestamp. 

In case of shell scripts, it's possible to get process run time using other means, i.e.:

``` bash
PID=<resque_worker_pid>
SECONDS_RUNNING=`expr $(awk -F. '{print $1}' /proc/uptime) - $(expr $(awk '{print $22}' /proc/${PID}/stat) / 100)`
```

This is a proposal to print human readable date in procline.
