### PR TITLE
Set the default to all queues

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -8,7 +8,7 @@ namespace :resque do
   task :work => [ :preload, :setup ] do
     require 'resque'
 
-    queues = (ENV['QUEUES'] || ENV['QUEUE']).to_s.split(',')
+    queues = (ENV['QUEUES'] || ENV['QUEUE'] || '*').to_s.split(',')
 
     begin
       worker = Resque::Worker.new(*queues)


### PR DESCRIPTION
This changes the rake task to use all queues if a default queue is not
present.
