### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ them later.
   - [![Code Climate](https://img.shields.io/codeclimate/github/resque/resque.svg)](https://codeclimate.com/github/resque/resque)
   - [![Build Status](https://img.shields.io/travis/resque/resque/master.svg)](https://travis-ci.org/resque/resque)
   - [![Coverage Status](https://img.shields.io/coveralls/resque/resque/master.svg)](https://coveralls.io/r/resque/resque)
-  - [![Inline docs](http://inch-pages.github.io/github/resque/resque.svg)](http://inch-pages.github.io/github/resque/resque)
+  - [![Inline docs](http://inch-ci.org/github/resque/resque.svg)](http://inch-ci.org/github/resque/resque)
 
 ### A note about branches
 


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-pages.github.io/github/resque/resque.png)](http://inch-pages.github.io/github/resque/resque) (I added the SVG version in this PR since your README contained all the other badges in SVG as well)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-pages.github.io/github/resque/resque/

Inch Pages is still a young project, but already used by projects like [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [ROM](https://github.com/rom-rb/rom).

What do you think?
