### PR TITLE
Fix child reuse of Redis process

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -100,6 +100,7 @@ module Resque
     # @yieldreturn (see #work_loop)
     # @return [void]
     def work(&block)
+      reconnect unless Process.pid == @pid && @pid == redis.client.instance_variable_get(:@pid)
       startup
       work_loop(&block)
       worker_registry.unregister


### PR DESCRIPTION
The error `#<Redis::InheritedError: Tried to use a connection from a child process without reconnecting. You need to reconnect to Redis after forking.>` arises during `prune_dead_workers`, which invokes Redis and occurs before the `before_fork` hook could let a user reconnect.

Because the worker has a new pid, it conflicts with the pid of the redis client (which is based on the calling process, eg rake), which causes `Redis::Client#ensure_connected` to raise an error.

This patch simply checks whether all the pids are aligned (as they're supposed to be), and if not, reconnects to redis.
