### PR TITLE
reconnect only once for a worker

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -277,18 +277,22 @@ module Resque
 
     # Reconnect to Redis to avoid sharing a connection with the parent,
     # retry up to 3 times with increasing delay before giving up.
+    # For a worker processes multi jobs, just reconnect once
     def reconnect
-      tries = 0
-      begin
-        redis.client.reconnect
-      rescue Redis::BaseConnectionError
-        if (tries += 1) <= 3
-          log "Error reconnecting to Redis; retrying"
-          sleep(tries)
-          retry
-        else
-          log "Error reconnecting to Redis; quitting"
-          raise
+      if @reconnected.nil?
+        tries = 0
+        begin
+          redis.client.reconnect
+          @reconnected = true
+        rescue Redis::BaseConnectionError
+          if (tries += 1) <= 3
+            log "Error reconnecting to Redis; retrying"
+            sleep(tries)
+            retry
+          else
+            log "Error reconnecting to Redis; quitting"
+            raise
+          end
         end
       end
     end


### PR DESCRIPTION
We use resque-multi-job-forks to have a worker processing multiple jobs. In this case, reconnecting redis for every job isn't needed.
For a system that reconnecting occurs thousands times per second, the patch will do some help. In our case, prevented 900 reconnection per second resulted about 5% down of CPU usage for a cache.m1.large aws instance.
