### PR TITLE
speed up test suite

### DIFF
--- a/lib/resque/backend.rb
+++ b/lib/resque/backend.rb
@@ -94,7 +94,7 @@ module Resque
       tries ||= 0
       if (tries += 1) < MAX_RECONNECT_ATTEMPTS
         logger.info "Error reconnecting to Redis; retrying"
-        sleep(tries)
+        Kernel.sleep(tries)
         retry
       else
         logger.info "Error reconnecting to Redis; quitting"

--- a/test/resque/backend_test.rb
+++ b/test/resque/backend_test.rb
@@ -61,7 +61,6 @@ describe Resque::Backend do
 
       client = Resque::Backend.new(redis, logger)
 
-      # not actually stubbing right now?
       Kernel.stub(:sleep, nil) do
         rescued = false
 


### PR DESCRIPTION
- sleep was not actually being stubbed in Resque::Backend#reconnect test since Kernel
  was not the explicit receiver. The suite should be ~3 seconds faster.
