### PR TITLE
work vs. perform?

### DIFF
--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -163,7 +163,7 @@ module Resque
         :around => around_hooks,
         :after => after_hooks
       }
-      JobPerformer.new.perform(payload_class, args, hooks)
+      JobPerformer.new.perform(payload_class.new, args, hooks)
     # If an exception occurs during the job execution, look for an
     # on_failure hook then re-raise.
     rescue Object => e

--- a/lib/resque/legacy_job_adapter.rb
+++ b/lib/resque/legacy_job_adapter.rb
@@ -1,0 +1,7 @@
+module Resque
+  module LegacyJobAdapter
+    def perform *args
+      self.class.perform *args
+    end
+  end
+end


### PR DESCRIPTION
I've noticed the readme for 2.0 says the required method is `work` although the code is still `self.perform`. Is there a reason we want to change it to the instance method `work` and if so is there anything stopping us from doing so?
