### PR TITLE
tests: use assert_raises

### DIFF
--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -316,7 +316,7 @@ context "Resque::Worker" do
   end
 
   test "complains if no queues are given" do
-    assert_raise Resque::NoQueueError do
+    assert_raises Resque::NoQueueError do
       Resque::Worker.new
     end
   end


### PR DESCRIPTION
`assert_raise` was a Test::Unit function that is not available in Minitest. Switch to the newer Minitest syntax, `assert_raises`.

This matches all the other `assert_raises` calls within the test suite.
