### PR TITLE
Implemented pre_term_timeout including test

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -427,6 +427,23 @@ If you want to stop processing jobs, but want to leave the worker running
 (for example, to temporarily alleviate load), use `USR2` to stop processing,
 then `CONT` to start it again.
 
+#### Signals on Heroku
+
+When shutting down processes, Heroku sends every process a TERM 
+signal at the same time. By default this causes an immediate 
+shutdown of any running job leading to frequent 
+`Resque::TermException` errors.  For short running jobs, a simple
+solution is to give a small amount of time for the job to finish
+before killing it.
+
+To accomplish this set the following environment variables:
+
+* `RESQUE_PRE_SHUTDOWN_TIMEOUT` - The time between the parent receiving a shutdown signal (TERM by default) and it sending that signal on to the child process. Designed to give the child process
+time to complete before being forced to die.
+
+* `RESQUE_SHUTDOWN_SIGNAL` - The signal sent to the child process
+when the parent receives any exit signal.
+
 ### Mysql::Error: MySQL server has gone away
 
 If your workers remain idle for too long they may lose their MySQL

--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -19,8 +19,8 @@ namespace :resque do
         worker.very_verbose = ENV['VVERBOSE']
       end
       worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
-      worker.pre_term_timeout = ENV['RESQUE_PRE_TERM_TIMEOUT'] || 0.0
-      worker.term_child_signal = (ENV['TERM_CHILD_SIGNAL'] || 'TERM').upcase
+      worker.pre_shutdown_timeout = ENV['RESQUE_PRE_SHUTDOWN_TIMEOUT'] || 0.0
+      worker.shutdown_signal = (ENV['RESQUE_SHUTDOWN_SIGNAL'] || 'TERM').upcase
       worker.term_child = ENV['TERM_CHILD']
       worker.run_at_exit_hooks = ENV['RUN_AT_EXIT_HOOKS']
     rescue Resque::NoQueueError

--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -20,6 +20,7 @@ namespace :resque do
       end
       worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
       worker.pre_term_timeout = ENV['RESQUE_PRE_TERM_TIMEOUT'] || 0.0
+      worker.term_child_signal = (ENV['TERM_CHILD_SIGNAL'] || 'TERM').upcase
       worker.term_child = ENV['TERM_CHILD']
       worker.run_at_exit_hooks = ENV['RUN_AT_EXIT_HOOKS']
     rescue Resque::NoQueueError

--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -19,6 +19,7 @@ namespace :resque do
         worker.very_verbose = ENV['VVERBOSE']
       end
       worker.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
+      worker.pre_term_timeout = ENV['RESQUE_PRE_TERM_TIMEOUT'] || 0.0
       worker.term_child = ENV['TERM_CHILD']
       worker.run_at_exit_hooks = ENV['RUN_AT_EXIT_HOOKS']
     rescue Resque::NoQueueError

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -1081,6 +1081,80 @@ context "Resque::Worker" do
       end
     end
 
+    if !defined?(RUBY_ENGINE) || defined?(RUBY_ENGINE) && RUBY_ENGINE != "jruby"
+      {
+        'job finishes in allotted time' => 0.5,
+        'job takes too long' => 1.1
+      }.each do |scenario, run_time|
+        test "gives time to finish before sending term if pre_term_timeout is set: when #{scenario}" do
+          begin
+            class LongRunningJob
+              @queue = :long_running_job
+
+              def self.perform(run_time)
+                Resque.redis.client.reconnect # get its own connection
+                Resque.redis.rpush('pre-term-timeout-test:start', Process.pid)
+                sleep run_time
+                Resque.redis.rpush('pre-term-timeout-test:result', 'Finished Normally')
+              rescue Resque::TermException => e
+                Resque.redis.rpush('pre-term-timeout-test:result', %Q(Caught TermException: #{e.inspect}))
+              ensure
+                Resque.redis.rpush('pre-term-timeout-test:final', 'exiting.')
+              end
+            end
+
+            pre_term_timeout = 1
+            Resque.enqueue(LongRunningJob, run_time)
+
+            worker_pid = Kernel.fork do
+              # reconnect to redis
+              Resque.redis.client.reconnect
+
+              # ensure we fork (in worker)
+              $TESTING = false
+
+              worker = Resque::Worker.new(:long_running_job)
+              worker.pre_term_timeout = pre_term_timeout
+              worker.term_timeout = 2
+              worker.term_child = 1
+
+              worker.work(0)
+              exit!
+            end
+
+            # ensure the worker is started
+            start_status = Resque.redis.blpop('pre-term-timeout-test:start', 5)
+            assert_not_nil start_status
+            child_pid = start_status[1].to_i
+            assert_operator child_pid, :>, 0
+
+            # send signal to abort the worker
+            Process.kill('TERM', worker_pid)
+            Process.waitpid(worker_pid)
+
+            # wait to see how it all came down
+            result = Resque.redis.blpop('pre-term-timeout-test:result', 5)
+            assert_not_nil result
+
+            if run_time >= pre_term_timeout
+              assert !result[1].start_with?('Finished Normally'), 'Job finished normally when running over pre term timeout'
+              assert result[1].start_with?('Caught TermException'), 'TermException not raised in child.'
+            else
+              assert result[1].start_with?('Finished Normally'), 'Job did not finish normally. Pre term timeout too short?'
+              assert !result[1].start_with?('Caught TermException'), 'TermException raised in child.'
+            end
+
+            # ensure that the child pid is no longer running
+            child_still_running = !(`ps -p #{child_pid.to_s} -o pid=`).empty?
+            assert !child_still_running
+          ensure
+            remaining_keys = Resque.redis.keys('pre-term-timeout-test:*') || []
+            Resque.redis.del(*remaining_keys) unless remaining_keys.empty?
+          end
+        end
+      end
+    end
+
     test "displays warning when not using term_child" do
       begin
         $TESTING = false


### PR DESCRIPTION
Implements the same functionality but includes a test of the signal handling to make sure things are working properly.

See https://github.com/resque/resque/pull/1136 for a description of the use case for this code.