### PR TITLE
fix Resque::Failure::Redis#each id assign when reversed order

### DIFF
--- a/test/resque_failure_redis_test.rb
+++ b/test/resque_failure_redis_test.rb
@@ -17,3 +17,36 @@ context "Resque::Failure::Redis" do
     Resque::Failure::Redis.all # should not raise an error
   end
 end
+
+describe ".each" do
+
+  context 'order ASC' do
+    setup do
+      exception      = StandardError.exception("error")
+      worker         = Resque::Worker.new(:test)
+      queue          = "queue"
+      payload        = { "class" => Object, "args" => 3 }
+      5.times do
+        Resque::Failure::Redis.new(exception, worker, queue, payload).save
+      end
+    end
+
+    test "should iterate over the failed tasks with ids in order" do
+      ids = []
+      Resque::Failure::Redis.each(0, 3, :failed, nil, 'asc') do |id, _|
+        ids << id
+      end
+      assert_equal([0,1,2], ids)
+    end
+  end
+
+  context 'order desc' do
+    test "should iterate over the failed tasks with ids in reverse order" do
+      ids = []
+      Resque::Failure::Redis.each(2, 3, :failed, nil, 'desc') do |id, _|
+        ids << id
+      end
+      assert_equal([4,3,2], ids)
+    end
+  end
+end


### PR DESCRIPTION
`resque-web` on the failure tab the job ids in the queue where miscalculated and the jobs where not correctly paged 
`Resque v1.25.2`

This fix issue #1172