### PR TITLE
(Another) Fix for Redis::InheritedError

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -343,8 +343,8 @@ module Resque
       Kernel.warn "WARNING: This way of doing signal handling is now deprecated. Please see http://hone.heroku.com/resque/2012/08/21/resque-signals.html for more info." unless term_child or $TESTING
       enable_gc_optimizations
       register_signal_handlers
-      prune_dead_workers
       run_hook :before_first_fork
+      prune_dead_workers
       register_worker
 
       # Fix buffering so we can `rake resque:work > resque.log` and


### PR DESCRIPTION
Today I stumpled over the Redis::InheritedError while starting a worker into the background.

> Redis::InheritedError: Tried to use a connection from a child process without reconnecting. You need to reconnect to Redis after forking

There are already _many_ fixes out there, but none of them worked for me.
My favorited solution was to add 

```
Resque.before_first_fork do
  Resque.redis.client.reconnect
end
```

(or using #before_fork callback) to my initializer.
However, the error still occurred everytime and after some debugging I found that in #prune_dead_workers (within #startup) Resque already tried to call Workers.all which leads to Resque.redis/@redis.
But because there was no reconnect yet, the error popped in.
After the small change the workaround mentioned above worked.
Any comments on this, e.g. if there was a reason why the hook was called below prune_dead_workers and not before?
