### PR TITLE
Create a class between Resque classes and what they do in redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ test/stdout
 *.swp
 pkg
 Gemfiles/Gemfile.1.8.7.lock
+.ruby-version
+.ruby-gemset
+*.sw?

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -124,6 +124,8 @@ module Resque
       @data_store = Resque::DataStore.new(Redis::Namespace.new(namespace, :redis => redis))
     when Redis::Namespace
       @data_store = server
+    when Resque::DataStore
+      @data_store = server
     when Hash
       @data_store = Resque::DataStore.new(Redis::Namespace.new(:resque, :redis => Redis.new(server)))
     else

--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -1,0 +1,297 @@
+module Resque
+  # An interface between Resque's persistence and the actual
+  # implementation. 
+  class DataStore
+    extend Forwardable
+
+    def initialize(redis)
+      @redis               = redis
+      @queue_access        = QueueAccess.new(@redis)
+      @failed_queue_access = FailedQueueAccess.new(@redis)
+      @workers             = Workers.new(@redis)
+      @stats_access        = StatsAccess.new(@redis)
+    end
+
+    def_delegators :@queue_access, :push_to_queue,
+                                   :pop_from_queue,
+                                   :queue_size,
+                                   :peek_in_queue,
+                                   :queue_names,
+                                   :remove_queue,
+                                   :everything_in_queue,
+                                   :remove_from_queue,
+                                   :watch_queue,
+                                   :list_range
+
+    def_delegators :@failed_queue_access, :add_failed_queue,
+                                          :remove_failed_queue,
+                                          :num_failed,
+                                          :failed_queue_names,
+                                          :push_to_failed_queue,
+                                          :clear_failed_queue,
+                                          :update_item_in_failed_queue,
+                                          :remove_from_failed_queue
+    def_delegators :@workers, :worker_ids,
+                              :workers_map,
+                              :get_worker_payload,
+                              :worker_exists?,
+                              :register_worker,
+                              :worker_started,
+                              :unregister_worker,
+                              :set_worker_payload,
+                              :worker_start_time,
+                              :worker_done_working
+
+      def_delegators :@stats_access, :clear_stat,
+                                     :decremet_stat,
+                                     :increment_stat,
+                                     :stat
+
+    # Compatibility with any non-Resque classes that were using Resque.redis as a way to access Redis
+    def method_missing(sym,*args,&block)
+      # TODO: deprecation warning?
+      @redis.send(sym,*args,&block)
+    end
+
+    # make use respond like redis
+    def respond_to?(method,include_all=false)
+      @redis.respond_to?(method,include_all)
+    end
+
+    # Get a string identifying the underlying server.
+    # Probably should be private, but was public so must stay public
+    def identifier
+      # support 1.x versions of redis-rb
+      if @redis.respond_to?(:server)
+        @redis.server
+      elsif @redis.respond_to?(:nodes) # distributed
+        @redis.nodes.map { |n| n.id }.join(', ')
+      else
+        @redis.client.id
+      end
+    end
+
+    # Force a reconnect to Redis.  
+    def reconnect
+      @redis.client.reconnect
+    end
+
+    # Returns an array of all known Resque keys in Redis. Redis' KEYS operation
+    # is O(N) for the keyspace, so be careful - this can be slow for big databases.
+    def all_resque_keys
+      @redis.keys("*").map do |key|
+        key.sub("#{redis.namespace}:", '')
+      end
+    end
+
+    class QueueAccess
+      def initialize(redis)
+        @redis = redis
+      end
+      def push_to_queue(queue,encoded_item)
+        @redis.pipelined do
+          watch_queue(queue)
+          @redis.rpush redis_key_for_queue(queue), encoded_item
+        end
+      end
+
+      # Pop whatever is on queue
+      def pop_from_queue(queue)
+        @redis.lpop(redis_key_for_queue(queue))
+      end
+
+      # Get the number of items in the queue
+      def queue_size(queue)
+        @redis.llen(redis_key_for_queue(queue)).to_i
+      end
+
+      # Examine items in the queue.
+      #
+      # NOTE: if count is 1, you will get back an object, otherwise you will
+      #       get an Array.  I'm not making this up.
+      def peek_in_queue(queue, start = 0, count = 1)
+        list_range(redis_key_for_queue(queue), start, count)
+      end
+
+      def queue_names
+        Array(@redis.smembers(:queues))
+      end
+
+      def remove_queue(queue)
+        @redis.pipelined do
+          @redis.srem(:queues, queue.to_s)
+          @redis.del(redis_key_for_queue(queue))
+        end
+      end
+
+      def everything_in_queue(queue)
+        @redis.lrange(redis_key_for_queue(queue), 0, -1)
+      end
+
+      # Remove data from the queue, if it's there, returning the number of removed elements
+      def remove_from_queue(queue,data)
+        @redis.lrem(redis_key_for_queue(queue), 0, data)
+      end
+
+      # Private: do not call
+      def watch_queue(queue)
+        @redis.sadd(:queues, queue.to_s)
+      end
+
+      # Private: do not call
+      def list_range(key, start = 0, count = 1)
+        if count == 1
+          @redis.lindex(key, start)
+        else
+          Array(@redis.lrange(key, start, start+count-1))
+        end
+      end
+
+    private
+
+      def redis_key_for_queue(queue)
+        "queue:#{queue}"
+      end
+
+    end
+
+    class FailedQueueAccess 
+      def initialize(redis)
+        @redis = redis
+      end
+
+      def add_failed_queue(failed_queue_name)
+        @redis.sadd(:failed_queues, failed_queue_name)
+      end
+
+      def remove_failed_queue(failed_queue_name=:failed)
+        @redis.del(failed_queue_name)
+      end
+
+      def num_failed(failed_queue_name=:failed)
+        @redis.llen(failed_queue_name).to_i
+      end
+
+      def failed_queue_names(find_queue_names_in_key=nil)
+        if find_queue_names_in_key.nil?
+          [:failed]
+        else
+          Array(@redis.smembers(find_queue_names_in_key))
+        end
+      end
+
+      def push_to_failed_queue(data,failed_queue_name=:failed)
+        @redis.rpush(failed_queue_name,data)
+      end
+
+      def clear_failed_queue(failed_queue_name=:failed)
+        @redis.del(failed_queue_name)
+      end
+
+      def update_item_in_failed_queue(index_in_failed_queue,new_item_data,failed_queue_name=:failed)
+        @redis.lset(failed_queue_name, index_in_failed_queue, new_item_data)
+      end
+
+      def remove_from_failed_queue(index_in_failed_queue,failed_queue_name=:failed)
+        hopefully_unique_value_we_can_use_to_delete_job = ""
+        @redis.lset(failed_queue_name, index_in_failed_queue, hopefully_unique_value_we_can_use_to_delete_job)
+        @redis.lrem(failed_queue_name, 1,                     hopefully_unique_value_we_can_use_to_delete_job)
+      end
+    end
+
+    class Workers
+      def initialize(redis)
+        @redis = redis
+      end
+
+      def worker_ids
+        Array(@redis.smembers(:workers))
+      end
+
+      # Given a list of worker ids, returns a map of those ids to the worker's value 
+      # in redis, even if that value maps to nil
+      def workers_map(worker_ids)
+        redis_keys = worker_ids.map { |id| "worker:#{id}" }
+        @redis.mapped_mget(*redis_keys)
+      end
+
+      # return the worker's payload i.e. job
+      def get_worker_payload(worker_id)
+        @redis.get("worker:#{worker_id}")
+      end
+
+      def worker_exists?(worker_id)
+        @redis.sismember(:workers, worker_id)
+      end
+
+      def register_worker(worker)
+        @redis.pipelined do
+          @redis.sadd(:workers, worker)
+          worker_started(worker)
+        end
+      end
+
+      def worker_started(worker)
+        @redis.set(redis_key_for_worker_start_time(worker), Time.now.to_s)
+      end
+
+      def unregister_worker(worker,&block)
+        @redis.pipelined do
+          @redis.srem(:workers, worker)
+          @redis.del(redis_key_for_worker(worker))
+          @redis.del(redis_key_for_worker_start_time(worker))
+          @redis.hdel(Resque::Worker::WORKER_HEARTBEAT_KEY, self.to_s)
+
+          block.call
+        end
+      end
+
+      def set_worker_payload(worker,data)
+        @redis.set(redis_key_for_worker(worker), data)
+      end
+
+      def worker_start_time(worker)
+        @redis.get(redis_key_for_worker_start_time(worker))
+      end
+
+      def worker_done_working(worker,&block)
+        @redis.pipelined do
+          @redis.del(redis_key_for_worker(worker))
+          block.call
+        end
+      end
+
+    private
+      
+      def redis_key_for_worker(worker)
+        "worker:#{worker}"
+      end
+
+      def redis_key_for_worker_start_time(worker)
+        "#{redis_key_for_worker(worker)}:started"
+      end
+
+    end
+
+    class StatsAccess
+      def initialize(redis)
+        @redis = redis
+      end
+      def stat(stat)
+        @redis.get("stat:#{stat}").to_i
+      end
+
+      def increment_stat(stat, by = 1)
+        @redis.incrby("stat:#{stat}", by)
+      end
+
+      def decremet_stat(stat, by = 1)
+        @redis.decrby("stat:#{stat}", by)
+      end
+
+      def clear_stat(stat)
+        @redis.del("stat:#{stat}")
+      end
+    end
+  end
+end

--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -1,6 +1,6 @@
 module Resque
   # An interface between Resque's persistence and the actual
-  # implementation. 
+  # implementation.
   class DataStore
     extend Forwardable
 
@@ -71,7 +71,7 @@ module Resque
       end
     end
 
-    # Force a reconnect to Redis.  
+    # Force a reconnect to Redis.
     def reconnect
       @redis.client.reconnect
     end
@@ -80,7 +80,7 @@ module Resque
     # is O(N) for the keyspace, so be careful - this can be slow for big databases.
     def all_resque_keys
       @redis.keys("*").map do |key|
-        key.sub("#{redis.namespace}:", '')
+        key.sub("#{Resque.redis.namespace}:", '')
       end
     end
 
@@ -155,7 +155,7 @@ module Resque
 
     end
 
-    class FailedQueueAccess 
+    class FailedQueueAccess
       def initialize(redis)
         @redis = redis
       end
@@ -192,7 +192,8 @@ module Resque
         @redis.lset(failed_queue_name, index_in_failed_queue, new_item_data)
       end
 
-      def remove_from_failed_queue(index_in_failed_queue,failed_queue_name=:failed)
+      def remove_from_failed_queue(index_in_failed_queue,failed_queue_name=nil)
+        failed_queue_name ||= :failed
         hopefully_unique_value_we_can_use_to_delete_job = ""
         @redis.lset(failed_queue_name, index_in_failed_queue, hopefully_unique_value_we_can_use_to_delete_job)
         @redis.lrem(failed_queue_name, 1,                     hopefully_unique_value_we_can_use_to_delete_job)
@@ -208,7 +209,7 @@ module Resque
         Array(@redis.smembers(:workers))
       end
 
-      # Given a list of worker ids, returns a map of those ids to the worker's value 
+      # Given a list of worker ids, returns a map of those ids to the worker's value
       # in redis, even if that value maps to nil
       def workers_map(worker_ids)
         redis_keys = worker_ids.map { |id| "worker:#{id}" }
@@ -262,7 +263,7 @@ module Resque
       end
 
     private
-      
+
       def redis_key_for_worker(worker)
         "worker:#{worker}"
       end

--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -48,7 +48,7 @@ module Resque
     # Obtain the failure queue name for a given job queue
     def self.failure_queue_name(job_queue_name)
       name = "#{job_queue_name}_failed"
-      Resque.redis.sadd(:failed_queues, name)
+      Resque.data_store.add_failed_queue(name)
       name
     end
 

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -3,6 +3,15 @@ module Resque
     # A Failure backend that stores exceptions in Redis. Very simple but
     # works out of the box, along with support in the Resque web app.
     class Redis < Base
+
+      def data_store
+        Resque.data_store
+      end
+
+      def self.data_store
+        Resque.data_store
+      end
+
       def save
         data = {
           :failed_at => UTF8Util.clean(Time.now.strftime("%Y/%m/%d %H:%M:%S %Z")),
@@ -14,7 +23,7 @@ module Resque
           :queue     => queue
         }
         data = Resque.encode(data)
-        Resque.redis.rpush(:failed, data)
+        data_store.push_to_failed_queue(data)
       end
 
       def self.count(queue = nil, class_name = nil)
@@ -25,12 +34,12 @@ module Resque
           each(0, count(queue), queue, class_name) { n += 1 } 
           n
         else
-          Resque.redis.llen(:failed).to_i
+          data_store.num_failed
         end
       end
 
       def self.queues
-        [:failed]
+        data_store.failed_queue_names
       end
 
       def self.all(offset = 0, limit = 1, queue = nil)
@@ -63,22 +72,20 @@ module Resque
 
       def self.clear(queue = nil)
         check_queue(queue)
-        Resque.redis.del(:failed)
+        data_store.clear_failed_queue
       end
 
       def self.requeue(id, queue = nil)
         check_queue(queue)
         item = all(id)
         item['retried_at'] = Time.now.strftime("%Y/%m/%d %H:%M:%S")
-        Resque.redis.lset(:failed, id, Resque.encode(item))
+        data_store.update_item_in_failed_queue(id,Resque.encode(item))
         Job.create(item['queue'], item['payload']['class'], *item['payload']['args'])
       end
 
       def self.remove(id, queue = nil)
         check_queue(queue)
-        sentinel = ""
-        Resque.redis.lset(:failed, id, sentinel)
-        Resque.redis.lrem(:failed, 1,  sentinel)
+        data_store.remove_from_failed_queue(id, queue)
       end
 
       def self.requeue_queue(queue)

--- a/lib/resque/stat.rb
+++ b/lib/resque/stat.rb
@@ -12,10 +12,11 @@ module Resque
     def redis
       Resque.redis
     end
+    alias :data_store :redis
 
     # Returns the int value of a stat, given a string stat name.
     def get(stat)
-      redis.get("stat:#{stat}").to_i
+      data_store.stat(stat)
     end
 
     # Alias of `get`
@@ -28,7 +29,7 @@ module Resque
     # Can optionally accept a second int parameter. The stat is then
     # incremented by that amount.
     def incr(stat, by = 1)
-      redis.incrby("stat:#{stat}", by)
+      data_store.increment_stat(stat,by)
     end
 
     # Increments a stat by one.
@@ -41,7 +42,7 @@ module Resque
     # Can optionally accept a second int parameter. The stat is then
     # decremented by that amount.
     def decr(stat, by = 1)
-      redis.decrby("stat:#{stat}", by)
+      data_store.decremet_stat(stat,by)
     end
 
     # Decrements a stat by one.
@@ -51,7 +52,7 @@ module Resque
 
     # Removes a stat from Redis, effectively setting it to 0.
     def clear(stat)
-      redis.del("stat:#{stat}")
+      data_store.clear_stat(stat)
     end
   end
 end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -19,9 +19,14 @@ module Resque
     def redis
       Resque.redis
     end
+    alias :data_store :redis
 
     def self.redis
       Resque.redis
+    end
+
+    def self.data_store
+      self.redis
     end
 
     # Given a Ruby object, returns a string suitable for storage in a
@@ -53,7 +58,7 @@ module Resque
 
     # Returns an array of all worker objects.
     def self.all
-      Array(redis.smembers(:workers)).map { |id| find(id, :skip_exists => true) }.compact
+      data_store.worker_ids.map { |id| find(id, :skip_exists => true) }.compact
     end
 
     # Returns an array of all worker objects currently processing
@@ -62,17 +67,15 @@ module Resque
       names = all
       return [] unless names.any?
 
-      names.map! { |name| "worker:#{name}" }
-
       reportedly_working = {}
 
       begin
-        reportedly_working = redis.mapped_mget(*names).reject do |key, value|
+        reportedly_working = data_store.workers_map(names).reject do |key, value|
           value.nil? || value.empty?
         end
       rescue Redis::Distributed::CannotDistribute
         names.each do |name|
-          value = redis.get name
+          value = data_store.get_worker_payload(name)
           reportedly_working[name] = value unless value.nil? || value.empty?
         end
       end
@@ -108,7 +111,7 @@ module Resque
     # Given a string worker id, return a boolean indicating whether the
     # worker exists
     def self.exists?(worker_id)
-      redis.sismember(:workers, worker_id)
+      data_store.worker_exists?(worker_id)
     end
 
     # Workers should be initialized with an array of string queue
@@ -321,7 +324,7 @@ module Resque
     def reconnect
       tries = 0
       begin
-        redis.client.reconnect
+        data_store.reconnect
       rescue Redis::BaseConnectionError
         if (tries += 1) <= 3
           log_with_severity :error, "Error reconnecting to Redis; retrying"
@@ -605,10 +608,7 @@ module Resque
     # Registers ourself as a worker. Useful when entering the worker
     # lifecycle on startup.
     def register_worker
-      redis.pipelined do
-        redis.sadd(:workers, self)
-        started!
-      end
+      data_store.register_worker(self)
     end
 
     # Runs a named hook, passing along any arguments.
@@ -647,12 +647,7 @@ module Resque
 
       kill_background_threads
 
-      redis.pipelined do
-        redis.srem(:workers, self)
-        redis.del("worker:#{self}")
-        redis.del("worker:#{self}:started")
-        redis.hdel(WORKER_HEARTBEAT_KEY, self.to_s)
-
+      data_store.unregister_worker(self) do
         Stat.clear("processed:#{self}")
         Stat.clear("failed:#{self}")
       end
@@ -674,15 +669,14 @@ module Resque
         :queue   => job.queue,
         :run_at  => Time.now.utc.iso8601,
         :payload => job.payload
-      redis.set("worker:#{self}", data)
+      data_store.set_worker_payload(self,data)
     end
 
     # Called when we are done working - clears our `working_on` state
     # and tells Redis we processed a job.
     def done_working
-      redis.pipelined do
+      data_store.worker_done_working(self) do
         processed!
-        redis.del("worker:#{self}")
       end
     end
 
@@ -710,18 +704,18 @@ module Resque
 
     # What time did this worker start? Returns an instance of `Time`
     def started
-      redis.get "worker:#{self}:started"
+      data_store.worker_start_time(self)
     end
 
     # Tell Redis we've started
     def started!
-      redis.set("worker:#{self}:started", Time.now.to_s)
+      data_store.worker_started(self)
     end
 
     # Returns a hash explaining the Job we're currently processing, if any.
     def job(reload = true)
       @job = nil if reload
-      @job ||= decode(redis.get("worker:#{self}")) || {}
+      @job ||= decode(data_store.get_worker_payload(self)) || {}
     end
     attr_writer :job
     alias_method :processing, :job
@@ -747,7 +741,7 @@ module Resque
     # Returns a symbol representing the current worker state,
     # which can be either :working or :idle
     def state
-      redis.exists("worker:#{self}") ? :working : :idle
+      data_store.get_worker_payload(self) ? :working : :idle
     end
 
     # Is this worker the same as another worker?

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -155,7 +155,7 @@ describe "Resque::Worker" do
   it "does not mask exception when timeout getting job metadata" do
     job = Resque::Job.new(:jobs, {'class' => 'GoodJob', 'args' => "blah"})
     @worker.working_on(job)
-    Resque.redis.stubs(:get).raises(Redis::CannotConnectError)
+    Resque.data_store.redis.stubs(:get).raises(Redis::CannotConnectError)
 
     error_message = "Something bad happened"
     exception_caught = assert_raises Redis::CannotConnectError do


### PR DESCRIPTION
## Problem

I want to write code to access information about what's going on in Resque, but the code needs to work for multiple Resque instances in the same Ruby VM.  Because `Resque.redis` is global, it is very difficult (impossible in some cases) to use the Resque API directly.

## Solution

Provide an API that does not rely on a global variable that encapsulates all the ways in which Resque interacts with Redis, namely the names of keys and what sort of data structure is expected in those keys.

Consider a call like this:

```ruby
decode redis.lpop("queue:#{queue}")
```

This should mean "decode the job on queue `queue`", but it actually means "decode whatever is in redis under the key `"queue:#{queue}"` which just so happens to be how we store queues, but don't worry about that right now, just go in Redis and do it".

With this PR, it turns into this:

```ruby
decode(@data_store.pop_from_queue(queue))
```
which is saying "get me the job in queue `queue`, however that's done, and decode it.

Which means that someone _else_ can do this without knowing how to construct the redis key for queue.

And because that knowledge is now centralized in one class (`DataStore`) instead of littered throughout the codebase, one could perform these operations on multiple resque queues from the same Ruby VM, e.g. for monitoring:

```ruby
resques = {
    www: '10.0.3.4:2345',
  admin: '10.1.4.5:8765',
    ops: '10.1.4.5:8766',
}

data_stores = Hash[resques.map { |name,location|
  [name,Resque::DataStore.new(Redis.new(location))]
}]

data_stores[:www].num_failed # => how many are failed in www's Resque
data_stores[:admin].num_failed # => what about admin?
stuck_workers = data_stores[:ops].workers.select { |worker|
  data_stores[:ops].worker_start_time(worker) > 1.hour.ago
}
```
And so forth.

This is not an ideal design, but it solves the problem without breaking backwards compatibility and is better than what exists now, since it at least centralizes how Resque's data structures are stored in Redis.  It could also, in theory, allow a different backing store than Redis.

I hacked a `concerning` concept to demonstrate which calls were relevant to what—this could be split into further classes.  It's also possible that versions of the major objects (`Resque`, `Worker`, and `Job`) could be created to not use a global for `redis`, but that is for another day.