### PR TITLE
Ensure NoQueueError reports the klass name when failing to infer the queue name

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -424,7 +424,7 @@ module Resque
     queue ||= queue_from_class(klass)
 
     unless queue
-      raise NoQueueError.new("Jobs must be placed onto a queue.")
+      raise NoQueueError.new("Jobs must be placed onto a queue. No queue could be inferred for class #{klass}")
     end
 
     if klass.to_s.empty?

--- a/test/legacy/resque_test.rb
+++ b/test/legacy/resque_test.rb
@@ -155,9 +155,10 @@ describe "Resque" do
   end
 
   it "validates job for queue presence" do
-    assert_raises Resque::NoQueueError do
+    err = assert_raises Resque::NoQueueError do
       Resque.validate(JobNotAmI)
     end
+    err.message.must_match /JobNotAmI/
   end
 
   it "can put jobs on a queue inferred from class name ending in 'Worker'" do


### PR DESCRIPTION
Ensure NoQueueError reports the klass name when failing to infer the queue name

This makes it easier to pinpoint hard to debug issues where configuration is incorrect.

For example see: https://github.com/resque/resque-scheduler/issues/169
