### PR TITLE
Backport add klass name to no queue error

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -391,7 +391,7 @@ module Resque
     queue ||= queue_from_class(klass)
 
     if !queue
-      raise NoQueueError.new("Jobs must be placed onto a queue.")
+      raise NoQueueError.new("Jobs must be placed onto a queue. No queue could be inferred for class #{klass}")
     end
 
     if klass.to_s.empty?

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -153,9 +153,10 @@ context "Resque" do
   end
 
   test "validates job for queue presence" do
-    assert_raises Resque::NoQueueError do
+    err = assert_raises Resque::NoQueueError do
       Resque.validate(SomeJob)
     end
+    assert err.message =~ /SomeJob/
   end
 
   test "can put items on a queue" do


### PR DESCRIPTION
(Backported pull request)

Ensure NoQueueError reports the klass name when failing to infer the queue name

This makes it easier to pinpoint hard to debug issues where configuration is incorrect.

For example see: resque/resque-scheduler#169
