### PR TITLE
Issue 1230/multi failuire backend regression

### DIFF
--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -104,10 +104,16 @@ module Resque
       backend.requeue_queue(queue)
     end
 
+    # Requeues all failed jobs
+    def self.requeue_all
+      backend.requeue_all
+    end
+
     # Removes all failed jobs in a specific queue.
     # Queue name should be a string.
     def self.remove_queue(queue)
       backend.remove_queue(queue)
     end
+
   end
 end

--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -90,14 +90,14 @@ module Resque
       backend.clear(queue)
     end
 
-    def self.requeue(id)
-      backend.requeue(id)
+    def self.requeue(id, queue = nil)
+      backend.requeue(id, queue)
     end
 
-    def self.remove(id)
-      backend.remove(id)
+    def self.remove(id, queue = nil)
+      backend.remove(id, queue)
     end
-    
+
     # Requeues all failed jobs in a specific queue.
     # Queue name should be a string.
     def self.requeue_queue(queue)

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -85,6 +85,12 @@ module Resque
         end
       end
 
+      def self.requeue_all
+        count.times do |num|
+          requeue(num)
+        end
+      end
+
       def self.remove_queue(queue)
         i = 0
         while job = all(i)
@@ -105,6 +111,7 @@ module Resque
         index = backtrace.index { |item| item.include?('/lib/resque/job.rb') }
         backtrace.first(index.to_i)
       end
+
     end
   end
 end

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -62,14 +62,16 @@ module Resque
         Resque.redis.del(:failed)
       end
 
-      def self.requeue(id)
+      def self.requeue(id, queue = nil)
+        check_queue(queue)
         item = all(id)
         item['retried_at'] = Time.now.strftime("%Y/%m/%d %H:%M:%S")
         Resque.redis.lset(:failed, id, Resque.encode(item))
         Job.create(item['queue'], item['payload']['class'], *item['payload']['args'])
       end
 
-      def self.remove(id)
+      def self.remove(id, queue = nil)
+        check_queue(queue)
         sentinel = ""
         Resque.redis.lset(:failed, id, sentinel)
         Resque.redis.lrem(:failed, 1,  sentinel)

--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -57,8 +57,9 @@ module Resque
         end
       end
 
-      def self.clear(queue = :failed)
-        Resque.redis.del(queue)
+      def self.clear(queue = nil)
+        queues = queue ? Array(queue) : self.queues
+        queues.each { |queue| Resque.redis.del(queue) }
       end
 
       def self.requeue(id, queue = :failed)

--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -79,6 +79,10 @@ module Resque
         each(0, count(failure_queue), failure_queue) { |id, _| requeue(id, failure_queue) }
       end
 
+      def self.requeue_all
+        queues.each { |queue| requeue_queue(Resque::Failure.job_queue_name(queue)) }
+      end
+
       def self.remove_queue(queue)
         Resque.redis.del(Resque::Failure.failure_queue_name(queue))
       end

--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -44,12 +44,15 @@ module Resque
       def self.each(offset = 0, limit = self.count, queue = :failed, class_name = nil, order = 'desc')
         items = all(offset, limit, queue)
         items = [items] unless items.is_a? Array
+        reversed = false
         if order.eql? 'desc'
           items.reverse!
+          reversed = true
         end
         items.each_with_index do |item, i|
           if !class_name || (item['payload'] && item['payload']['class'] == class_name)
-            yield offset + i, item
+            id = reversed ? (items.length - 1) - (offset + i) : offset + i
+            yield id, item
           end
         end
       end

--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -205,9 +205,7 @@ module Resque
     end
 
     post "/failed/requeue/all" do
-      Resque::Failure.count.times do |num|
-        Resque::Failure.requeue(num)
-      end
+      Resque::Failure.requeue_all
       redirect u('failed')
     end
 

--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -225,9 +225,23 @@ module Resque
       end
     end
 
+    get "/failed/:queue/requeue/:index/?" do
+      Resque::Failure.requeue(params[:index], params[:queue])
+      if request.xhr?
+        return Resque::Failure.all(params[:index],1,params[:queue])['retried_at']
+      else
+        redirect url_path("/failed/#{params[:queue]}")
+      end
+    end
+
     get "/failed/remove/:index/?" do
       Resque::Failure.remove(params[:index])
       redirect u('failed')
+    end
+
+    get "/failed/:queue/remove/:index/?" do
+      Resque::Failure.remove(params[:index], params[:queue])
+      redirect url_path("/failed/#{params[:queue]}")
     end
 
     get "/stats/?" do

--- a/lib/resque/server/views/failed.erb
+++ b/lib/resque/server/views/failed.erb
@@ -21,7 +21,7 @@
 
 <ul class='failed'>
   <% Resque::Failure.each(failed_start_at, failed_per_page, params[:queue], params[:class], failed_order) do |id, job| %>
-    <%= partial :failed_job, :id => id, :job => job %>
+    <%= partial :failed_job, :id => id, :job => job, :queue => "failed#{'/' + params[:queue] if params[:queue]}" %>
   <% end %>
 </ul>
 

--- a/lib/resque/server/views/failed_job.erb
+++ b/lib/resque/server/views/failed_job.erb
@@ -10,13 +10,13 @@
       <% if job['retried_at'] %>
         <div class='retried'>
           Retried <b><span class="time"><%= Time.parse(job['retried_at']).strftime(failed_date_format) %></span></b>
-          <a href="<%= u "failed/remove/#{id}" %>" class="remove" rel="remove">Remove</a>
+          <a href="<%= u "#{queue}/remove/#{id}" %>" class="remove" rel="remove">Remove</a>
         </div>
       <% else %>
         <div class='controls'>
-          <a href="<%= u "failed/requeue/#{id}" %>" rel="retry">Retry</a>
+          <a href="<%= u "#{queue}/requeue/#{id}" %>" rel="retry">Retry</a>
           or
-          <a href="<%= u "failed/remove/#{id}" %>" rel="remove">Remove</a>
+          <a href="<%= u "#{queue}/remove/#{id}" %>" rel="remove">Remove</a>
         </div>
       <% end %>
     </dd>

--- a/lib/resque/server/views/failed_queues_overview.erb
+++ b/lib/resque/server/views/failed_queues_overview.erb
@@ -7,14 +7,14 @@
 
   <% Resque::Failure.queues.sort.each do |queue| %>
 	  <tr>
-	    <th><b class="queue-tag"><a href="/failed/<%= queue %>"><%= queue %></a></b></th>
+	    <th><b class="queue-tag"><a href="<%= u "/failed/#{queue}" %>"><%= queue %></a></b></th>
 	    <th style="width:75px;" class="center"><%= Resque::Failure.count(queue) %></th>
 	  </tr>
 
     <% failed_class_counts(queue).sort_by { |name,_| name }.each do |k, v| %>
     <tr id="<%= k %>">
       <td>
-        <a href="/failed/<%= "#{queue}?class=#{k}" %>"><span class="failed failed_class"><%= k %></span></a>
+        <a href="<%= u "/failed/#{queue}?class=#{k}" %>"><span class="failed failed_class"><%= k %></span></a>
       </td>
       <td style="text-align: center;" class="failed<%= (v.to_i > 1000) ? '_many' : '' %>"><%= v %></td>
     </tr>


### PR DESCRIPTION
Fixes a few bugs around multi failure queue functionality:

Re-queueing/deleting a failed job uses the wrong index and wrong queue.
Failure overview page queue links broken.
Re-queueing/clearing all failed jobs doesn't work for all failure queues, only the failed queue.

