### PR TITLE
Pass Hash as :payload_args instead of Stirng

### DIFF
--- a/lib/resque/failure/airbrake.rb
+++ b/lib/resque/failure/airbrake.rb
@@ -24,7 +24,7 @@ module Resque
         ::Airbrake.notify_or_ignore(exception,
           :parameters => {
             :payload_class => payload['class'].to_s,
-            :payload_args => payload['args'].inspect
+            :payload_args => payload['args']
           },
           :component => 'resque',
           :action => action


### PR DESCRIPTION
If `String` is passed and contains any kind of confidential data, Airbrake does not filter them out. When `Hash` or even `Array` is passed, everything works correctly, Airbrake filters them out and no confidential data are revealed.
