### PR TITLE
Implement prefixing of RESQUE_PROCLINE_PREFIX environment variable to procline.

### DIFF
--- a/lib/resque/child_process.rb
+++ b/lib/resque/child_process.rb
@@ -121,14 +121,14 @@ module Resque
 
     # Given a string, sets the procline ($0) and logs.
     # Procline is always in the format of:
-    #   resque-VERSION: STRING
+    #   RESQUE_PROCLINE_PREFIXresque-VERSION: STRING
     #
     # TODO: This is a duplication of Rescue::Worker#procline
     # which is a protected method. Can we DRY this up?
     # @param string [String]
     # @return [void]
     def procline(string)
-      $0 = "resque-#{Resque::Version}: #{string}"
+      $0 = "#{ENV['RESQUE_PROCLINE_PREFIX']}resque-#{Resque::Version}: #{string}"
       logger.debug $0
     end
 

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -404,11 +404,11 @@ module Resque
 
     # Given a string, sets the procline ($0) and logs.
     # Procline is always in the format of:
-    #   resque-VERSION: STRING
+    #   RESQUE_PROCLINE_PREFIXresque-VERSION: STRING
     # @param string [String]
     # @return [void]
     def procline(string)
-      $0 = "resque-#{Resque::Version}: #{string}"
+      $0 = "#{ENV['RESQUE_PROCLINE_PREFIX']}resque-#{Resque::Version}: #{string}"
       logger.debug $0
     end
 

--- a/test/legacy/worker_test.rb
+++ b/test/legacy/worker_test.rb
@@ -496,8 +496,9 @@ describe "Resque::Worker" do
   it "sets $0 while working" do
     stub_to_fork(worker, false) do
       worker.work do
+        prefix = ENV['RESQUE_PROCLINE_PREFIX']
         ver = Resque::Version
-        assert_equal "resque-#{ver}: Processing jobs since #{Time.now.iso8601} [SomeJob]", $0
+        assert_equal "#{prefix}resque-#{ver}: Processing jobs since #{Time.now.iso8601} [SomeJob]", $0
       end
     end
   end

--- a/test/resque/worker_test.rb
+++ b/test/resque/worker_test.rb
@@ -151,4 +151,44 @@ describe Resque::Worker do
     end
 
   end
+
+  describe "#procline" do
+    it "supports arbitrary suffixes" do
+      prefix = ENV['RESQUE_PROCLINE_PREFIX']
+      suffix = 'worker-test-suffix'
+      ver = Resque::Version
+      worker = Resque::Worker.new [:foo, :bar], :client => client, :logger => MonoLogger.new("/dev/null")
+
+      old_procline = $0
+
+      worker.send(:procline, suffix)
+      assert_equal "#{prefix}resque-#{ver}: #{suffix}", $0
+
+      $0 = old_procline
+    end
+
+    it "supports arbitrary prefixes" do
+      prefix = 'WORKER-TEST-PREFIX/'
+      ver = Resque::Version
+      worker = Resque::Worker.new [:foo, :bar], :client => client, :logger => MonoLogger.new("/dev/null")
+
+      old_prefix = ENV['RESQUE_PROCLINE_PREFIX']
+      ENV.delete('RESQUE_PROCLINE_PREFIX')
+      old_procline = $0
+
+      worker.send(:procline, '')
+      assert_equal "resque-#{ver}: ", $0
+
+      ENV['RESQUE_PROCLINE_PREFIX'] = prefix
+      worker.send(:procline, '')
+      assert_equal "#{prefix}resque-#{ver}: ", $0
+
+      $0 = old_procline
+      if old_prefix.nil?
+        ENV.delete('RESQUE_PROCLINE_PREFIX')
+      else
+        ENV['RESQUE_PROCLINE_PREFIX'] = old_prefix
+      end
+    end
+  end
 end


### PR DESCRIPTION
@yaauie here is the new pull request with correct tests for the procline handling and the variable renamed from PROCLINE_PREFIX to RESQUE_PROCLINE_PREFIX.

This replaces #1116.
