### PR TITLE
Make Failure::Multiple work with Failure::RedisMultiQueue back port to 1.x

### DIFF
--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -27,6 +27,11 @@ module Resque
         classes.first.count(*args)
       end
 
+      # Returns an array of all available failure queues
+      def self.queues
+        classes.first.queues
+      end
+
       # Returns a paginated array of failure objects.
       def self.all(*args)
         classes.first.all(*args)


### PR DESCRIPTION
This is a back port of #1241