### PR TITLE
encoding should be done outside of pipeline block to accomodate redis

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -211,9 +211,10 @@ module Resque
   #
   # Returns nothing
   def push(queue, item)
+    encoded = encode(item)
     redis.pipelined do
       watch_queue(queue)
-      redis.rpush "queue:#{queue}", encode(item)
+      redis.rpush "queue:#{queue}", encoded
     end
   end
 

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -14,6 +14,14 @@ context "Resque" do
     Resque.redis = @original_redis
   end
 
+  test "can push an item that depends on redis for encoding" do
+    Resque.redis.set("count", 1)
+    assert_nothing_raised do
+      Resque.push(:test, JsonObject.new)
+    end
+    Resque.redis.del("count")
+  end
+
   test "can set a namespace through a url-like string" do
     assert Resque.redis
     assert_equal :resque, Resque.redis.namespace

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -128,6 +128,13 @@ class SomeJob
   end
 end
 
+class JsonObject
+  def to_json(opts = {})
+    val = Resque.redis.get("count")
+    { "val" => val }.to_json
+  end
+end
+
 class SomeIvarJob < SomeJob
   @queue = :ivar
 end


### PR DESCRIPTION
Redis 3.0 makes a change to return a future for some commands run inside pipeline or multi.  This change allows serialization (like `to_json`) to read from redis and get a value, not a future.

I'm not sure how best to test this.  The test I included may not even be a test at all... any ideas?