### PR TITLE
Set pidfile so god monitors the correct process

### DIFF
--- a/examples/god/resque.god
+++ b/examples/god/resque.god
@@ -4,12 +4,14 @@ num_workers = rails_env == 'production' ? 5 : 2
 
 num_workers.times do |num|
   God.watch do |w|
+    pid_file   = "#{rails_root}/tmp/pids/resque-#{num}.pid"
     w.dir      = "#{rails_root}"
     w.name     = "resque-#{num}"
     w.group    = 'resque'
     w.interval = 30.seconds
-    w.env      = {"QUEUE"=>"critical,high,low", "RAILS_ENV"=>rails_env}
+    w.env      = {"QUEUE"=>"critical,high,low", "RAILS_ENV"=>rails_env, "PIDFILE"=>pid_file}
     w.start    = "/usr/bin/rake -f #{rails_root}/Rakefile environment resque:work"
+    w.pid_file = pid_file
 
     w.uid = 'deploy'
     w.gid = 'deploy'


### PR DESCRIPTION
The current example causes the resque worker launched to flap because the pid that god is monitoring is the pid for the rake process launching the resque worker. A more robust solution is to have god monitor the pid of the pid file created by resque when the worker is fully up and running. 

This solution stopped my worker from flapping. It may only be the case for when workers take a while to start since our app has a slow startup time, but in general I believe this will work in all cases, where the current example has the flapping issue I experienced. 
