### PR TITLE
Allow Resque::Failure::Multiple and Resque::Failure::Base to receive #requeue_queue.

### DIFF
--- a/lib/resque/failure/base.rb
+++ b/lib/resque/failure/base.rb
@@ -87,6 +87,11 @@ module Resque
       # @param index [Integer]
       def self.remove(index)
       end
+
+      # @overload self.requeue_queue(queue)
+      # @param queue [Integer, Symbol]
+      def self.requeue_queue(queue)
+      end
     end
   end
 end

--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -84,6 +84,13 @@ module Resque
       def self.remove(index)
         classes.each { |klass| klass.remove(index) }
       end
+
+      # @override (see Resque::Failure::Base::requeue_queue)
+      # @param (see Resque::Failure::Base::requeue_queue)
+      # @return (see Resque::Failure::Base::requeue_queue)
+      def self.requeue_queue(queue)
+        classes.each { |klass| klass.requeue_queue(queue) }
+      end
     end
   end
 end

--- a/test/resque/failure/multiple_test.rb
+++ b/test/resque/failure/multiple_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require 'resque/failure/multiple'
+require 'resque/failure/redis'
+require 'resque/failure/base'
+
+describe Resque::Failure::Multiple do
+  after do
+    Resque::Failure::Multiple.classes = []
+  end
+
+  describe '.requeue_queue' do
+    let(:backends) { [Minitest::Mock.new, Minitest::Mock.new] }
+
+    it 'calls .requeue_queue for the classes' do
+      Resque::Failure::Multiple.classes = backends
+
+      backends[0].expect :requeue_queue, nil, ['foo']
+      backends[1].expect :requeue_queue, nil, ['foo']
+
+      Resque::Failure::Multiple.requeue_queue('foo')
+    end
+  end
+end


### PR DESCRIPTION
This fix the problem when you are using Resque::Failure::Multiple, for example with Redis and Rollbar, but in certain moment you want to requeue a queue.