### PR TITLE
Don't run before_fork hooks if we aren't going to fork

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -319,7 +319,7 @@ module Resque
     # Not every platform supports fork. Here we do our magic to
     # determine if yours does.
     def fork(job)
-      return if @cant_fork
+      return unless will_fork?
 
       # Only run before_fork hooks if we're actually going to fork
       # (after checking @cant_fork)
@@ -328,7 +328,7 @@ module Resque
       begin
         # IronRuby doesn't support `Kernel.fork` yet
         if Kernel.respond_to?(:fork)
-          Kernel.fork if will_fork?
+          Kernel.fork
         else
           raise NotImplementedError
         end
@@ -632,7 +632,7 @@ module Resque
     end
 
     def will_fork?
-      !@cant_fork && !$TESTING && fork_per_job?
+      !@cant_fork && fork_per_job?
     end
 
     def fork_per_job?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -226,3 +226,13 @@ def suppress_warnings
 ensure
   $VERBOSE = old_verbose
 end
+
+def without_forking
+  orig_fork_per_job = ENV['FORK_PER_JOB']
+  begin
+    ENV['FORK_PER_JOB'] = 'false'
+    yield
+  ensure
+    ENV['FORK_PER_JOB'] = orig_fork_per_job
+  end
+end


### PR DESCRIPTION
**Note**: This change addresses the same issue as https://github.com/resque/resque/pull/1173, but I've taken @yaauie's suggestion of eliminating the `$TESTING` check from `will_fork?` and fixing the tests that were relying on it to instead explicitly use a new `without_forking` test helper to set `FORK_PER_JOB=false`.

I'm happy to adjust the approach to dealing with these tests if there's something else you had in mind, I just really want to get this fixed so that `FORK_PER_JOB` is usable.

When FORK_PER_JOB=false is set in the environment, Resque will not actually fork
for each job. Unfortunately, before_fork hooks will still run (although
after_fork hooks will not). This can lead to problems when the after_fork hook
has dependencies on the before_fork hook.

This change makes it so that before_fork hooks will no longer run when
FORK_PER_JOB=false.

I've also adjusted the conditions for the Worker#will_fork? method to ignore the
$TESTING global. Many of the worker tests were implicitly relying upon the fact
that forking would not happen during tests in order to work correctly, so those
tests have been changed to set FORK_PER_JOB=false in the environment instead,
via a new test helper, called without_forking.
