### PR TITLE
Don't reconnect to redis when we aren't forking for jobs.

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -206,7 +206,7 @@ module Resque
             unregister_signal_handlers if will_fork? && term_child
             begin
 
-              reconnect
+              reconnect if will_fork?
               perform(job, &block)
 
             rescue Exception => exception

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -213,6 +213,21 @@ ensure
   $stderr = orig_stderr
 end
 
+def capture_io_with_pipe
+  orig_stdout, orig_stderr = $stdout, $stderr
+  stdout_rd, $stdout = IO.pipe
+  stderr_rd, $stderr = IO.pipe
+
+  yield
+
+  $stdout.close
+  $stderr.close
+  return stdout_rd.read, stderr_rd.read
+ensure
+  $stdout = orig_stdout
+  $stderr = orig_stderr
+end
+
 # Log to log/test.log
 def reset_logger
   $test_logger ||= MonoLogger.new(File.open(File.expand_path("../../log/test.log", __FILE__), "w"))


### PR DESCRIPTION
## Problem

When running with `ENV["FORK_PER_JOB"] = 'false'` resque 1.x will reconnect to redis after popping a job from the redis queue.  This doesn't make sense, because we already have a valid connection to redis, since that is how it reserved the job.  This only makes sense after forking.

## Solution

Make reconnect conditional with `if will_fork?`

Most of the code changes are to test reconnecting to redis with forking rather than without forking, where I used a pipe to collect information from the child process.