### PR TITLE
Remove methods which refer to non-existent object

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -51,18 +51,6 @@ module Resque
 
   extend ::Forwardable
 
-  def self.config=(options = {})
-    @config = Config.new(options)
-  end
-
-  def self.config
-    @config ||= Config.new
-  end
-
-  def self.configure
-    yield config
-  end
-
   # Accepts:
   #   1. A 'hostname:port' String
   #   2. A 'hostname:port:db' String (to select the Redis db)


### PR DESCRIPTION
Hi:

On the 1-x-stable branch, there is no Config object. The removed code ends up causing a collision with Ruby's (now deprecated) Config and produces a confusing backtrace if the `self.config` method is used.

Since the Config object doesn't exist in this branch, perhaps these methods should be removed?