### PR TITLE
fixing multi failure queue ArgumentError , this fix: #1270

### DIFF
--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -76,8 +76,8 @@ module Resque
     end
 
     # Iterate across all failures with the given options
-    def self.each(offset = 0, limit = self.count, queue = nil, class_name = nil, order = 'desc', &block)
-      backend.each(offset, limit, queue, class_name, order, &block)
+    def self.each(offset = 0, limit = self.count, queue = nil, class_name = nil, &block)
+      backend.each(offset, limit, queue, class_name, &block)
     end
 
     # The string url of the backend's web interface, if any.

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -38,21 +38,10 @@ module Resque
         Resque.list_range(:failed, offset, limit)
       end
 
-      def self.each(offset = 0, limit = self.count, queue = :failed, class_name = nil, order = 'desc')
-        all_items = Array(all(offset, limit, queue))
-        reversed = false
-        if order.eql? 'desc'
-          all_items.reverse!
-          reversed = true
-        end
-        all_items.each_with_index do |item, i|
+      def self.each(offset = 0, limit = self.count, queue = :failed, class_name = nil)
+        Array(all(offset, limit, queue)).each_with_index do |item, i|
           if !class_name || (item['payload'] && item['payload']['class'] == class_name)
-            if reversed
-              id = (all_items.length - 1) - (offset + i)
-            else
-              id = offset + i
-            end
-            yield id, item
+            yield offset + i, item
           end
         end
       end

--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -33,21 +33,16 @@ module Resque
         end
       end
 
-      def self.all(offset = 0, limit = 1, queue = :failed, order = 'desc')
-        Resque.list_range(queue, offset, limit, order)
+      def self.all(offset = 0, limit = 1, queue = :failed)
+        Resque.list_range(queue, offset, limit)
       end
 
       def self.queues
         Array(Resque.redis.smembers(:failed_queues))
       end
 
-      def self.each(offset = 0, limit = self.count, queue = :failed, class_name = nil, order = 'desc')
-        items = all(offset, limit, queue, order)
-        items = [items] unless items.is_a? Array
-        if order.eql? 'desc'
-          items.reverse!
-        end
-        items.each_with_index do |item, i|
+      def self.each(offset = 0, limit = self.count, queue = :failed, class_name = nil)
+        Array(all(offset, limit, queue)).each_with_index do |item, i|
           if !class_name || (item['payload'] && item['payload']['class'] == class_name)
             yield offset + i, item
           end

--- a/lib/resque/server/helpers.rb
+++ b/lib/resque/server/helpers.rb
@@ -36,10 +36,6 @@ Resque::Server.helpers do
     end
   end
 
-  def failed_order
-    params[:order] || 'desc'
-  end
-
   def failed_class_counts(queue = params[:queue])
     classes = Hash.new(0)
     Resque::Failure.each(0, Resque::Failure.count(queue), queue) do |_, item|

--- a/lib/resque/server/views/failed.erb
+++ b/lib/resque/server/views/failed.erb
@@ -20,7 +20,7 @@
 
 
 <ul class='failed'>
-  <% Resque::Failure.each(failed_start_at, failed_per_page, params[:queue], params[:class], failed_order) do |id, job| %>
+  <% Resque::Failure.each(failed_start_at, failed_per_page, params[:queue] || 'failed', params[:class]) do |id, job| %>
     <%= partial :failed_job, :id => id, :job => job %>
   <% end %>
 </ul>


### PR DESCRIPTION
I've checked, actually there's a pull request for this (without commit) #1270.

First i thought that the ordering implementation must be in the Resque#list_range, since its responsability is to bring the list, ordered  would be an option. IMHO, the other methods should only rely on this behavior, and should not make any "#reverse!" and "calculate offsets" logic. If the implementation of ordering be in the #each would cause to every new failure class i would need to implement this behavior, i don't think this is ok.
And make this change have another problem: since the "ids" are the index numbers of the jobs on the queue, all the operations made with the inverse order would need some calculations to get the right id (for e.g. to make requeue and remove methods).  And i've noticed that when its filtered by class, the ids are wrong too.

I prefer to remove this 'order' stuff, and so we could think about a better solution on these all other stuff.

Currently i'm attaching the commit that removes the order, and make the 1-x-stable /failed with multi failure queue work.