### PR TITLE
Math tweaks for failures

### DIFF
--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -48,7 +48,7 @@ module Resque
         all_items.each_with_index do |item, i|
           if !class_name || (item['payload'] && item['payload']['class'] == class_name)
             if reversed
-              id = (all_items.length - 1) - (offset + i)
+              id = (all_items.length - 1) + (offset - i)
             else
               id = offset + i
             end

--- a/lib/resque/server/helpers.rb
+++ b/lib/resque/server/helpers.rb
@@ -32,7 +32,7 @@ Resque::Server.helpers do
     if failed_start_at + failed_per_page > failed_size
       failed_size
     else
-      failed_start_at  + failed_per_page
+      failed_start_at  + failed_per_page - 1
     end
   end
 


### PR DESCRIPTION
Fix id on paginated failures pages (resque-web.domain.tld/failed?start=1960), items would be displayed with negative ids (resque-web.domain.tld/failed/requeue/-1941), preventing retry/remove.

Fix numbering - helper would display "Showing 1960 to 1980" for items 1960-1979.