### PR TITLE
fix #1293 Resque web doen't retry the correct failed job

### DIFF
--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -48,7 +48,7 @@ module Resque
         all_items.each_with_index do |item, i|
           if !class_name || (item['payload'] && item['payload']['class'] == class_name)
             if reversed
-              id = (all_items.length - 1) - (offset + i)
+              id = offset + (all_items.length - 1 - i)
             else
               id = offset + i
             end


### PR DESCRIPTION
fix #1293 Resque web doen't retry the correct failed job on the second
page of the failed jobs