### PR TITLE
Adding hooks to intercept worker timeout

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -162,6 +162,29 @@ module Resque
     register_hook(:after_fork, block)
   end
 
+  # The `after_timeout` hook will be run in the **parent** process
+  # only once, if its times out while waiting for a job. Be careful- any
+  # changes you make will be permanent for the lifespan of the
+  # worker.
+  #
+  # Call with a block to register a hook.
+  # Call with no arguments to return all registered hooks.
+  # @overload method()
+  #   Return the existing method hooks
+  #   @return (see #hooks)
+  # @overload method(&block)
+  #   @return (see #register_hook)
+  def after_timeout(&block)
+    block ? register_hook(:after_timeout, block) : hooks(:after_timeout)
+  end
+
+  # Register a after_timeout proc.
+  # @param block (see #register_hook)
+  # @return (see #register_hook)
+  def after_timeout=(block)
+    register_hook(:after_timeout, block)
+  end
+
   # The `before_pause` hook will be run in the parent process before the
   # worker has paused processing (via #pause_processing or SIGUSR2).
   def before_pause(&block)

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -203,6 +203,7 @@ module Resque
           log! "Sleeping for #{interval} seconds"
           procline paused? ? "Paused" : "Waiting for #{@queues.join(',')}"
           sleep interval
+          run_hook :after_timeout, self
         end
       end
 


### PR DESCRIPTION
While coding a gem to accelerate indexing of ElasticSearch by partitioning through resque/redis, I felt the need to trap event when resque worker timed out after configured `interval` (which defaults to 5 and can be passed as a parameter).

There is no easy way to gracefully self-terminate workers after Redis queue is empty. Of course its certainly possible to spin a `Thread` to check the Redis queue after some configured interval and invoke `worker.shutdown`. But a threaded solution does add overhead as we plan to run this across an auto-scale AWS EC2 compute nodes. `EventMachine` seems overkill.

```ruby
Resque.after_timeout do |worker|
  on_completion(worker)
end
```

Of course we can add a `after_perform` hook, but it's a JOB HOOK as opposed to worker hook, and fails to set the `@shutdown` instance variable of the `worker`. 

```ruby
def self.after_perform_check_for_empty(resource_name, from, to)
  self.on_exhausted do          
    self.shutdown rescue nil
  end
end
```