### PR TITLE
1 x stable fix ruby2.1.x specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 test/dump.rdb
 test/dump-cluster.rdb
+test/stdout

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - jruby-18mode
   - jruby-19mode
   - rbx-18mode
   - rbx-19mode
+  - 2.0
+  - 2.1
 matrix:
   allow_failures:
     - rvm: jruby-18mode
     - rvm: jruby-19mode
     - rvm: rbx-18mode
     - rvm: rbx-19mode
+  include:
+    - rvm: 1.8.7
+      gemfile: Gemfiles/Gemfile.1.8.7
+    - rvm: 1.9.2
+      gemfile: Gemfiles/Gemfile.1.9.2

--- a/Gemfiles/Gemfile.1.8.7
+++ b/Gemfiles/Gemfile.1.8.7
@@ -1,0 +1,15 @@
+source "https://rubygems.org"
+
+group :test do
+  gem "rake"
+  gem "rack-test", "~> 0.5"
+  gem "mocha", :require => false
+  gem "airbrake"
+  gem "activesupport", "~> 3.0"
+  gem "i18n", "~> 0.6.0"
+  gem "minitest", "4.7.0"
+  gem "json"
+  gem 'redis', '~> 3.0.0', '< 3.0.7'
+end
+
+gemspec :path => "../"

--- a/Gemfiles/Gemfile.1.9.2
+++ b/Gemfiles/Gemfile.1.9.2
@@ -1,0 +1,14 @@
+source "https://rubygems.org"
+
+group :test do
+  gem "rake"
+  gem "rack-test", "~> 0.5"
+  gem "mocha", :require => false
+  gem "airbrake"
+  gem "activesupport", "~> 3.0"
+  gem "i18n", "~> 0.6.0"
+  gem "minitest", "4.7.0"
+  gem "json"
+end
+
+gemspec :path => "../"

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -489,6 +489,7 @@ context "Resque::Worker" do
   end
 
   test "worker_pids returns pids" do
+    @worker.work(0)
     known_workers = @worker.worker_pids
     assert !known_workers.empty?
   end


### PR DESCRIPTION
This test should never have passed, though for some reason it passes with ruby 1.9.3. I wasn't able to isolate the reason, but it had to do with silent dependencies on other tests, and the fact that test order
is not randomized (if you remove all other tests from this file, and run it on 1.9.3, this test will fail).

Tests now pass on 1.9.3, 2.0.x, and 2.1.x, as far as I can tell.