### PR TITLE
In resque.god, include comment about SIGQUIT

### DIFF
--- a/examples/god/resque.god
+++ b/examples/god/resque.god
@@ -15,6 +15,10 @@ num_workers.times do |num|
 
     w.uid = 'deploy'
     w.gid = 'deploy'
+    
+    # By default, god stops a process by sending SIGTERM, and waits 10 seconds before sending a SIGKILL.
+    # Sending a SIGQUIT allows the process to finish its job before exiting.
+    # w.stop_signal = 'QUIT'
 
     # restart if memory gets too high
     w.transition(:up, :restart) do |on|


### PR DESCRIPTION
I've updated the resque.god file to include a comment about sending SIGQUIT when stopping the resque process. My current use case benefits from using SIGQUIT, and it actually took me a while to realize that this option existed. I thought it would be helpful to include this information in the resque.god file for others.