### PR TITLE
1-x-stable ruby 2.2 compatibility: add test dependency on test-unit.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - rbx-19mode
   - 2.0
   - 2.1
+  - 2.2
 matrix:
   allow_failures:
     - rvm: jruby-18mode

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ group :test do
   gem "i18n"
   gem "minitest", "4.7.0"
   gem "json"
+  gem "test-unit", "~> 3.0"
 end


### PR DESCRIPTION
Ruby 2.2 moves this library out of stdlib into a gem.

This may fix #1295, though I was unable to produce that particular failure.

Running the command in question there, with a slight modification (adding `envrionment`), is currently working fine for me with this branch and ruby 2.2.2:

```
bundle exec rake environment resque:work RAILS_ENV="development" QUEUE=* VERBOSE="1" BACKGROUND="no" --trace; echo $?
```

Also @yaauie: all tests seem to pass fine with test-unit ~> 2.0 as well, so we could relax that dependency if you think it would make sense.