### PR TITLE
Add Resque.priority_enqueue

### DIFF
--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -154,6 +154,24 @@ module Resque
       end
     end
 
+    # Creates a priority job by placing it at the front of the queue. Expects
+    # a string queue name, a string class name, and an optional array of
+    # arguments to pass to the class' `perform` method.
+    #
+    # Raises an exception if no queue or class is given.
+
+    def self.priority_create(queue, klass, *args)
+      Resque.validate(klass, queue)
+
+      if Resque.inline?
+        # Instantiating a Resque::Job and calling perform on it so callbacks run
+        # decode(encode(args)) to ensure that args are normalized in the same manner as a non-inline job
+        new(:inline, {'class' => klass, 'args' => decode(encode(args))}).perform
+      else
+        Resque.lpush(queue, :class => klass.to_s, :args => args)
+      end
+    end
+
     # Removes a job from a queue. Expects a string queue name, a
     # string class name, and, optionally, args.
     #

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -165,6 +165,14 @@ class BadJobWithSyntaxError
   end
 end
 
+class EchoJob
+  @queue = :jobs
+
+  def self.perform(message)
+    message
+  end
+end
+
 class BadFailureBackend < Resque::Failure::Base
   def save
     raise Exception.new("Failure backend error")


### PR DESCRIPTION
Adds the ability to add jobs to the front of a queue via `Resque.priority_enqueue`
and `Resque.priority_enqueue_to`. This is done by calling redis's `LPUSH` command
instead of `RPUSH`.

Addresses #1323 

Sadly due to the use of `*args` in the relevant functions, I couldn't see an easy way to extend the existing functions, so I created duplicates. If you know of a way to DRY things up, please let me know.

Also, if you have a recommendation for better method names, let me know. I realize that priority_enqueue could potentially be confused with priority queues, which should allow assignment of a specific priority level, whereas in this case, the implementation only allows you to put a job at the front of the queue. An alternative is to use the term `unshift` instead of `enqueue`.

I added a couple of tests; let me know if there are any other tests that would be helpful.