### PR TITLE
caching hook names

### DIFF
--- a/lib/resque/plugin.rb
+++ b/lib/resque/plugin.rb
@@ -32,22 +32,26 @@ module Resque
 
     # A cache for object method names (see #job_methods)
     @job_methods = {}
-
     # Caches the object's method names
     # @param job [Object]
     # @return [Array<String>] - an array of method names
     def job_methods(job)
-      @job_methods[job] ||= job.methods.collect{|m| m.to_s}
+      @job_methods[job] ||= (job.methods - Object.methods).collect{|m| m.to_s}
     end
 
+    # A cache for hook names :job => before_after_hook
+    @hook_names = {}
     # Given an object, and a method prefix, returns a list of methods prefixed
     # with that name (hook names).
     # @param job [Object]
     # @param hook_method_prefix [String]
     # @return [Array<String>]
     def get_hook_names(job, hook_method_prefix)
-      methods = (job.respond_to?(:hooks) && job.hooks.keys) || job_methods(job)
-      methods.select{|m| m.start_with?(hook_method_prefix)}.sort
+      (@hook_names[job] ||= {})[hook_method_prefix] ||=
+        begin
+          methods = (job.respond_to?(:hooks) && job.hooks.keys) || job_methods(job)
+          methods.select{|m| m.start_with?(hook_method_prefix)}.sort
+        end
     end
 
     # Given an object, returns a list `before_perform` hook names.


### PR DESCRIPTION
In order to schedule jobs more fast, it caches the hook method names instead of search every time.

It improves a little the current job_methods looking only for non-object methods.

Using the following benchmark:

```ruby
require 'benchmark/ips'  # gem install benchmark-ips
require 'yajl/json_gem'
require 'redis'
require 'pry'

$LOAD_PATH.unshift File.dirname(File.expand_path(__FILE__)) + '/lib'
require 'resque'

Resque.redis = Redis.new

class JobWithHooks
  def self.hooks
    { 'before_or_after' => "do_something" }
  end

  def self.before_or_after
  end

  def perform
  end

  def do_something
  end
end

class JobWithoutHooks
  def perform
  end
end

Benchmark.ips do |x|
  x.time = 10
  x.warmup = 3

  x.report("Resque.enqueue_to with hooks") do
    Resque.enqueue_to("nurturing_steps", JobWithHooks, {"parameter"=> "value"})
  end

  x.report("Resque.enqueue_to without hooks") do
    Resque.enqueue_to("nurturing_steps", JobWithoutHooks, {"parameter"=> "value"})
  end

  x.compare!
end
```

## Benchmarking on master

```
Calculating -------------------------------------
Resque.enqueue_to with hooks
                       710.000  i/100ms
Resque.enqueue_to without hooks
                       545.000  i/100ms
-------------------------------------------------
Resque.enqueue_to with hooks
                          6.995k (± 6.4%) i/s -     70.290k
Resque.enqueue_to without hooks
                          5.664k (± 6.7%) i/s -     56.680k

Comparison:
Resque.enqueue_to with hooks:     6995.2 i/s
Resque.enqueue_to without hooks:     5664.3 i/s - 1.23x slower
```

## Benchmarking after cache the names

```
Calculating -------------------------------------
Resque.enqueue_to with hooks
                       622.000  i/100ms
Resque.enqueue_to without hooks
                       565.000  i/100ms
-------------------------------------------------
Resque.enqueue_to with hooks
                          7.027k (± 6.8%) i/s -     70.286k
Resque.enqueue_to without hooks
                          7.122k (± 5.9%) i/s -     71.190k

Comparison:
Resque.enqueue_to without hooks:     7121.9 i/s
Resque.enqueue_to with hooks:     7027.1 i/s - 1.01x slower
```

It improves a little bit.

