### PR TITLE
Fix backport of before_pause & after_pause hooks

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -168,8 +168,10 @@ module Resque
     block ? register_hook(:before_pause, block) : hooks(:before_pause)
   end
 
-  # Set the after_pause proc.
-  attr_writer :before_pause
+  # Register a before_pause proc.
+  def before_pause=(block)
+    register_hook(:before_pause, block)
+  end
 
   # The `after_pause` hook will be run in the parent process after the
   # worker has paused (via SIGCONT).
@@ -177,8 +179,10 @@ module Resque
     block ? register_hook(:after_pause, block) : hooks(:after_pause)
   end
 
-  # Set the after_continue proc.
-  attr_writer :after_pause
+  # Register an after_pause proc.
+  def after_pause=(block)
+    register_hook(:after_pause, block)
+  end
 
   def to_s
     "Resque Client connected to #{redis_id}"

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -507,6 +507,7 @@ module Resque
     # currently running one).
     def pause_processing
       log "USR2 received; pausing job processing"
+      run_hook :before_pause, self
       @paused = true
     end
 
@@ -514,6 +515,7 @@ module Resque
     def unpause_processing
       log "CONT received; resuming job processing"
       @paused = false
+      run_hook :after_pause, self
     end
 
     # Looks for any workers which should be running on this server

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -578,6 +578,32 @@ context "Resque::Worker" do
 #     assert_equal 1, $BEFORE_FORK_CALLED
   end
 
+  test "Will call a before_pause hook before pausing" do
+    Resque.redis.flushall
+    $BEFORE_PAUSE_CALLED = 0
+    $WORKER_NAME = nil
+    Resque.before_pause = Proc.new { |w| $BEFORE_PAUSE_CALLED += 1; $WORKER_NAME = w.to_s; }
+    workerA = Resque::Worker.new(:jobs)
+
+    assert_equal 0, $BEFORE_PAUSE_CALLED
+    workerA.pause_processing
+    assert_equal 1, $BEFORE_PAUSE_CALLED
+    assert_equal workerA.to_s, $WORKER_NAME
+  end
+
+  test "Will call a after_pause hook after pausing" do
+    Resque.redis.flushall
+    $AFTER_PAUSE_CALLED = 0
+    $WORKER_NAME = nil
+    Resque.after_pause = Proc.new { |w| $AFTER_PAUSE_CALLED += 1; $WORKER_NAME = w.to_s; }
+    workerA = Resque::Worker.new(:jobs)
+
+    assert_equal 0, $AFTER_PAUSE_CALLED
+    workerA.unpause_processing
+    assert_equal 1, $AFTER_PAUSE_CALLED
+    assert_equal workerA.to_s, $WORKER_NAME
+  end
+
   test "Will call a before_fork hook before forking" do
     Resque.redis.flushall
     $BEFORE_FORK_CALLED = false

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -815,8 +815,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "will call before_pause before it is paused" do
-    before_pause_called = false
+  test "tries to reconnect three times before giving up" do
     captured_worker = nil
     begin
       class Redis::Client


### PR DESCRIPTION
Heya awesome folks! Thank you for all awesome work that goes into resque :tada: 

I ran into a small issue today, in the `1-x-stable` version (`v1.25.2`), where `before_pause` and `after_pause` hooks would never get called. Workers are still paused correctly, they just don't fire their associated hooks.

After a bit of digging, I think there was just a small mixup in #831 when the hooks got backported to `1-x-stable` (which is awesome by the way, :heart: for the backport).

I've added in the `run_hook` calls to the `pause_processing` and `unpause_processing` methods respectively, and added specs to cover the change.

Cheers! Please let me know if there's anything else I can do!