### PR TITLE
Remove repeated encode and decode method implementations

### DIFF
--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -35,26 +35,12 @@ module Resque
     # Given a Ruby object, returns a string suitable for storage in a
     # queue.
     def encode(object)
-      if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
-        MultiJson.dump object
-      else
-        MultiJson.encode object
-      end
+      Resque.encode(object)
     end
 
     # Given a string, returns a Ruby object.
     def decode(object)
-      return unless object
-
-      begin
-        if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
-          MultiJson.load object
-        else
-          MultiJson.decode object
-        end
-      rescue ::MultiJson::DecodeError => e
-        raise DecodeException, e.message, e.backtrace
-      end
+      Resque.decode(object)
     end
 
     # Given a word with dashes, returns a camel cased version of it.

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -23,51 +23,23 @@ module Resque
     # Given a Ruby object, returns a string suitable for storage in a
     # queue.
     def encode(object)
-      if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
-        MultiJson.dump object
-      else
-        MultiJson.encode object
-      end
+      Resque.encode(object)
     end
 
     # Given a string, returns a Ruby object.
     def decode(object)
-      return unless object
-
-      begin
-        if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
-          MultiJson.load object
-        else
-          MultiJson.decode object
-        end
-      rescue ::MultiJson::DecodeError => e
-        raise DecodeException, e.message, e.backtrace
-      end
+      Resque.decode(object)
     end
 
     # Given a Ruby object, returns a string suitable for storage in a
     # queue.
     def self.encode(object)
-      if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
-        MultiJson.dump object
-      else
-        MultiJson.encode object
-      end
+      Resque.encode(object)
     end
 
     # Given a string, returns a Ruby object.
     def self.decode(object)
-      return unless object
-
-      begin
-        if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
-          MultiJson.load object
-        else
-          MultiJson.decode object
-        end
-      rescue ::MultiJson::DecodeError => e
-        raise DecodeException, e.message, e.backtrace
-      end
+      Resque.decode(object)
     end
     
     # Given a word with dashes, returns a camel cased version of it.

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -23,26 +23,12 @@ module Resque
     # Given a Ruby object, returns a string suitable for storage in a
     # queue.
     def encode(object)
-      if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
-        MultiJson.dump object
-      else
-        MultiJson.encode object
-      end
+      Resque.encode(object)
     end
 
     # Given a string, returns a Ruby object.
     def decode(object)
-      return unless object
-
-      begin
-        if MultiJson.respond_to?(:dump) && MultiJson.respond_to?(:load)
-          MultiJson.load object
-        else
-          MultiJson.decode object
-        end
-      rescue ::MultiJson::DecodeError => e
-        raise DecodeException, e.message, e.backtrace
-      end
+      Resque.decode(object)
     end
 
     attr_accessor :term_timeout


### PR DESCRIPTION
The encode and decode method implementations are repeated (and exactly the same) within the Resque module, Helpers module, Worker class, and Job class. Much easier to maintain with one true source of implementation (in the top-level Resque module).

Also, encode and decode wrapper methods left in the Helpers module, Worker class, and Job class for backwards compatibility (in case anyone's explicitly utilizing these methods off instances of the classes or the modules).