### PR TITLE
Remove repeated constantize and classify method implementations

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -50,6 +50,53 @@ module Resque
     end
   end
 
+  # Given a word with dashes, returns a camel cased version of it.
+  #
+  # classify('job-name') # => 'JobName'
+  def classify(dashed_word)
+    dashed_word.split('-').each { |part| part[0] = part[0].chr.upcase }.join
+  end
+
+  # Tries to find a constant with the name specified in the argument string:
+  #
+  # constantize("Module") # => Module
+  # constantize("Test::Unit") # => Test::Unit
+  #
+  # The name is assumed to be the one of a top-level constant, no matter
+  # whether it starts with "::" or not. No lexical context is taken into
+  # account:
+  #
+  # C = 'outside'
+  # module M
+  #   C = 'inside'
+  #   C # => 'inside'
+  #   constantize("C") # => 'outside', same as ::C
+  # end
+  #
+  # NameError is raised when the constant is unknown.
+  def constantize(camel_cased_word)
+    camel_cased_word = camel_cased_word.to_s
+
+    if camel_cased_word.include?('-')
+      camel_cased_word = classify(camel_cased_word)
+    end
+
+    names = camel_cased_word.split('::')
+    names.shift if names.empty? || names.first.empty?
+
+    constant = Object
+    names.each do |name|
+      args = Module.method(:const_get).arity != 1 ? [false] : []
+
+      if constant.const_defined?(name, *args)
+        constant = constant.const_get(name)
+      else
+        constant = constant.const_missing(name)
+      end
+    end
+    constant
+  end
+
   extend ::Forwardable
 
   # Accepts:

--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -44,50 +44,13 @@ module Resque
     end
 
     # Given a word with dashes, returns a camel cased version of it.
-    #
-    # classify('job-name') # => 'JobName'
     def classify(dashed_word)
-      dashed_word.split('-').each { |part| part[0] = part[0].chr.upcase }.join
+      Resque.classify(dashed_word)
     end
 
-    # Tries to find a constant with the name specified in the argument string:
-    #
-    # constantize("Module") # => Module
-    # constantize("Test::Unit") # => Test::Unit
-    #
-    # The name is assumed to be the one of a top-level constant, no matter
-    # whether it starts with "::" or not. No lexical context is taken into
-    # account:
-    #
-    # C = 'outside'
-    # module M
-    #   C = 'inside'
-    #   C # => 'inside'
-    #   constantize("C") # => 'outside', same as ::C
-    # end
-    #
-    # NameError is raised when the constant is unknown.
+    # Tries to find a constant with the name specified in the argument string
     def constantize(camel_cased_word)
-      camel_cased_word = camel_cased_word.to_s
-
-      if camel_cased_word.include?('-')
-        camel_cased_word = classify(camel_cased_word)
-      end
-
-      names = camel_cased_word.split('::')
-      names.shift if names.empty? || names.first.empty?
-
-      constant = Object
-      names.each do |name|
-        args = Module.method(:const_get).arity != 1 ? [false] : []
-
-        if constant.const_defined?(name, *args)
-          constant = constant.const_get(name)
-        else
-          constant = constant.const_missing(name)
-        end
-      end
-      constant
+      Resque.constantize(camel_cased_word)
     end
   end
 end

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -45,50 +45,13 @@ module Resque
     end
     
     # Given a word with dashes, returns a camel cased version of it.
-    #
-    # classify('job-name') # => 'JobName'
     def classify(dashed_word)
-      dashed_word.split('-').each { |part| part[0] = part[0].chr.upcase }.join
+      Resque.classify(dashed_word)
     end
-    
-    # Tries to find a constant with the name specified in the argument string:
-    #
-    # constantize("Module") # => Module
-    # constantize("Test::Unit") # => Test::Unit
-    #
-    # The name is assumed to be the one of a top-level constant, no matter
-    # whether it starts with "::" or not. No lexical context is taken into
-    # account:
-    #
-    # C = 'outside'
-    # module M
-    #   C = 'inside'
-    #   C # => 'inside'
-    #   constantize("C") # => 'outside', same as ::C
-    # end
-    #
-    # NameError is raised when the constant is unknown.
+
+    # Tries to find a constant with the name specified in the argument string
     def constantize(camel_cased_word)
-      camel_cased_word = camel_cased_word.to_s
-
-      if camel_cased_word.include?('-')
-        camel_cased_word = classify(camel_cased_word)
-      end
-
-      names = camel_cased_word.split('::')
-      names.shift if names.empty? || names.first.empty?
-
-      constant = Object
-      names.each do |name|
-        args = Module.method(:const_get).arity != 1 ? [false] : []
-
-        if constant.const_defined?(name, *args)
-          constant = constant.const_get(name)
-        else
-          constant = constant.const_missing(name)
-        end
-      end
-      constant
+      Resque.constantize(camel_cased_word)
     end
 
     # Raise Resque::Job::DontPerform from a before_perform hook to


### PR DESCRIPTION
The constantize and classify method implementations are repeated. This PR moves the one true implementation of these to the Resque module and retains wrapper methods in the Helpers module and Job class for backwards compatibility.