### PR TITLE
Only allow before_first_fork hook to run once in worker parent

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -149,6 +149,7 @@ module Resque
       @queues = queues.map { |queue| queue.to_s.strip }
       @shutdown = nil
       @paused = nil
+      @before_first_fork_hook_ran = false
       validate_queues
     end
 
@@ -554,12 +555,14 @@ module Resque
     # Runs a named hook, passing along any arguments.
     def run_hook(name, *args)
       return unless hooks = Resque.send(name)
+      return if name == :before_first_fork && @before_first_fork_hook_ran
       msg = "Running #{name} hooks"
       msg << " with #{args.inspect}" if args.any?
       log msg
 
       hooks.each do |hook|
         args.any? ? hook.call(*args) : hook.call
+        @before_first_fork_hook_ran = true if name == :before_first_fork
       end
     end
 

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -573,9 +573,9 @@ context "Resque::Worker" do
     workerA.work(0)
     assert_equal 1, $BEFORE_FORK_CALLED
 
-    # TODO: Verify it's only run once. Not easy.
-#     workerA.work(0)
-#     assert_equal 1, $BEFORE_FORK_CALLED
+    #Verify it's only run once.
+    workerA.work(0)
+    assert_equal 1, $BEFORE_FORK_CALLED
   end
 
   test "Will call a before_pause hook before pausing" do


### PR DESCRIPTION
Implements the behavior for a TODO in the worker test.

It doesn't seem that currently we actually force the parent worker to call the `before_first_fork` hook only once. This hook is executed during the `startup` method which is called each time `worker.work` is called. If `work` is called multiple times on a worker, `the before_first_fork` hook is ran multiple times.