### PR TITLE
Fix NoMethodError on `working` server view

### DIFF
--- a/lib/resque/server/views/working.erb
+++ b/lib/resque/server/views/working.erb
@@ -1,4 +1,4 @@
-<% if params[:id] && (worker = Resque::Worker.find(params[:id])) && worker.job %>
+<% if params[:id] && (worker = Resque::Worker.find(params[:id])) && (data = worker.job) %>
   <h1><%= worker %>'s job</h1>
 
   <table>
@@ -14,14 +14,13 @@
         <td><img src="<%=u 'working.png' %>" alt="working" title="working"></td>
         <% host, pid, _ = worker.to_s.split(':') %>
         <td><a href="<%=u "/workers/#{worker}" %>"><%= host %>:<%= pid %></a></td>
-        <% data = worker.job %>
         <% queue = data['queue'] %>
         <td><a class="queue" href="<%=u "/queues/#{queue}" %>"><%= queue %></a></td>
         <td><span class="time"><%= data['run_at'] %></span></td>
         <td>
-          <code><%= data['payload']['class'] %></code>
+          <code><%= data['payload'].to_h['class'] %></code>
         </td>
-        <td><%=h data['payload']['args'].inspect %></td>
+        <td><%=h data['payload'].to_h['args'].inspect %></td>
       </tr>
   </table>
 


### PR DESCRIPTION
In our application, we discovered a race in the `working` view.
Worker#job is called twice, which means on its second invocation
it could actually be nil, or have a different payload.  This fix
protects against a race during page rendering, and makes nested
hash lookups safer.

Thanks for great work on an amazing product!