### PR TITLE
Ensure Resque travis builds have latest version of bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+before_install:
+  - gem update --system
+  - gem update bundler
 matrix:
   allow_failures:
     - rvm: jruby-18mode

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test do
   gem "rake"
   gem "rack-test", "~> 0.5"
   gem "mocha", :require => false
-  gem "airbrake"
+  gem "airbrake", "4.3.4"
   gem "activesupport", "~> 3.0"
   gem "i18n"
   gem "minitest", "4.7.0"


### PR DESCRIPTION
- Prevents following error: `NoMethodError: undefined method 'spec' for nil:NilClass`