### PR TITLE
Support for adding reverse proxy friendly url prefixes

### DIFF
--- a/bin/resque-web
+++ b/bin/resque-web
@@ -24,4 +24,8 @@ Vegas::Runner.new(Resque::Server, 'resque-web', {
     runner.logger.info "Using Redis connection '#{redis_conf}'"
     Resque.redis = redis_conf
   }
+  opts.on('-a url-prefix', "--append url-prefix", "set reverse_proxy friendly prefix to links") {|url_prefix|
+    runner.logger.info "Using URL Prefix '#{url_prefix}'"
+    Resque::Server.url_prefix = url_prefix
+  }
 end

--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -38,9 +38,13 @@ module Resque
       end
 
       def url_path(*path_parts)
-        [ path_prefix, path_parts ].join("/").squeeze('/')
+        [ url_prefix, path_prefix, path_parts ].join("/").squeeze('/')
       end
       alias_method :u, :url_path
+
+      def redirect_url_path(*path_parts)
+        [ path_prefix, path_parts ].join("/").squeeze('/')
+      end
 
       def path_prefix
         request.env['SCRIPT_NAME']
@@ -58,6 +62,10 @@ module Resque
 
       def tabs
         Resque::Server.tabs
+      end
+
+      def url_prefix
+        Resque::Server.url_prefix
       end
 
       def redis_get_size(key)
@@ -150,7 +158,7 @@ module Resque
 
     # to make things easier on ourselves
     get "/?" do
-      redirect url_path(:overview)
+      redirect redirect_url_path(:overview)
     end
 
     %w( overview workers ).each do |page|
@@ -213,7 +221,7 @@ module Resque
 
     post "/failed/:queue/requeue/all" do
       Resque::Failure.requeue_queue Resque::Failure.job_queue_name(params[:queue])
-      redirect url_path("/failed/#{params[:queue]}")
+      redirect redirect_url_path("/failed/#{params[:queue]}")
     end
 
     get "/failed/requeue/:index/?" do
@@ -231,7 +239,7 @@ module Resque
     end
 
     get "/stats/?" do
-      redirect url_path("/stats/resque")
+      redirect redirect_url_path("/stats/resque")
     end
 
     get "/stats/:id/?" do
@@ -266,6 +274,14 @@ module Resque
 
     def self.tabs
       @tabs ||= ["Overview", "Working", "Failed", "Queues", "Workers", "Stats"]
+    end
+
+    def self.url_prefix=(url_prefix)
+      @url_prefix = url_prefix
+    end
+
+    def self.url_prefix
+      (@url_prefix.nil? || @url_prefix.empty?) ? '' : @url_prefix + '/'
     end
   end
 end

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -19,6 +19,16 @@ context "on GET to /overview" do
   end
 end
 
+context "With append-prefix option on GET to /overview" do
+  reverse_proxy_prefix = 'proxy_site/resque'
+  Resque::Server.url_prefix = reverse_proxy_prefix
+  setup { get "/overview" }
+
+  test "should contain reverse proxy prefix for asset urls and links" do
+    assert last_response.body.include?(reverse_proxy_prefix)
+  end
+end
+
 # Working jobs
 context "on GET to /working" do
   setup { get "/working" }


### PR DESCRIPTION
Summary
-
In order for resque-web to be put behind a reverse-proxy path
that is not root, resque-web must serve templates with asset and
url links with the reverse proxy url prefix.

The url prefix can be added using '-a' option. e.g:
`./resque-web -F -L -s thin -p 5678 -e development -a '/proxy_sites/resque'`

Tests Ran:
-
Existing tests with additional url_prefix use case