### PR TITLE
Remove helper deprecation warnings

### DIFF
--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -11,14 +11,6 @@ end
 module Resque
   # Methods used by various classes in Resque.
   module Helpers
-    def self.extended(parent_class)
-      warn("Resque::Helpers will be gone with no replacement in Resque 2.0.0.")
-    end
-
-    def self.included(parent_class)
-      warn("Resque::Helpers will be gone with no replacement in Resque 2.0.0.")
-    end
-
     class DecodeException < StandardError; end
 
     # Direct access to the Redis instance.


### PR DESCRIPTION
The helper deprecation warnings were added here: https://github.com/resque/resque/commit/30f9310a4241e8026727cd049010ee74908d295d

Since there is no longer a 2.0 deprecation plan, I propose that we remove the warnings (which currently show up when you run `rake resque:work` on `1-x-stable`