### PR TITLE
Fix error message for rake resque:work when QUEUE is not set

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -9,7 +9,12 @@ namespace :resque do
   task :work => [ :preload, :setup ] do
     require 'resque'
 
-    worker = Resque::Worker.new
+    begin
+      worker = Resque::Worker.new
+    rescue Resque::NoQueueError
+      abort "set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work"
+    end
+
     worker.log "Starting worker #{self}"
     worker.work(ENV['INTERVAL'] || 5) # interval, will block
   end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -119,20 +119,16 @@ module Resque
     def initialize(*queues)
       queues = queues.empty? ? (ENV["QUEUES"] || ENV['QUEUE']).to_s.split(',') : queues
 
-      begin
-        if ENV['LOGGING'] || ENV['VERBOSE']
-          self.verbose = ENV['LOGGING'] || ENV['VERBOSE']
-        end
-        if ENV['VVERBOSE']
-          self.very_verbose = ENV['VVERBOSE']
-        end
-        self.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
-        self.term_child = ENV['TERM_CHILD']
-        self.graceful_term = ENV['GRACEFUL_TERM']
-        self.run_at_exit_hooks = ENV['RUN_AT_EXIT_HOOKS']
-      rescue Resque::NoQueueError
-        abort "set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work"
+      if ENV['LOGGING'] || ENV['VERBOSE']
+        self.verbose = ENV['LOGGING'] || ENV['VERBOSE']
       end
+      if ENV['VVERBOSE']
+        self.very_verbose = ENV['VVERBOSE']
+      end
+      self.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
+      self.term_child = ENV['TERM_CHILD']
+      self.graceful_term = ENV['GRACEFUL_TERM']
+      self.run_at_exit_hooks = ENV['RUN_AT_EXIT_HOOKS']
 
       if ENV['BACKGROUND']
         unless Process.respond_to?('daemon')
@@ -359,7 +355,7 @@ module Resque
     # Runs all the methods needed when a worker begins its lifecycle.
     def startup
       if !term_child
-        Kernel.warn "WARNING: This way of doing signal handling is now deprecated. Please see http://hone.heroku.com/resque/2012/08/21/resque-signals.html for more info." 
+        Kernel.warn "WARNING: This way of doing signal handling is now deprecated. Please see http://hone.heroku.com/resque/2012/08/21/resque-signals.html for more info."
       end
       enable_gc_optimizations
       register_signal_handlers
@@ -410,11 +406,11 @@ module Resque
 
     def unregister_signal_handlers
       trap('TERM') do
-        trap ('TERM') do 
-          # ignore subsequent terms               
-        end  
-        raise TermException.new("SIGTERM") 
-      end 
+        trap ('TERM') do
+          # ignore subsequent terms
+        end
+        raise TermException.new("SIGTERM")
+      end
       trap('INT', 'DEFAULT')
 
       begin
@@ -530,9 +526,9 @@ module Resque
         worker_queues = worker_queues_raw.split(",")
         unless @queues.include?("*") || (worker_queues.to_set == @queues.to_set)
           # If the worker we are trying to prune does not belong to the queues
-          # we are listening to, we should not touch it. 
+          # we are listening to, we should not touch it.
           # Attempt to prune a worker from different queues may easily result in
-          # an unknown class exception, since that worker could easily be even 
+          # an unknown class exception, since that worker could easily be even
           # written in different language.
           next
         end

--- a/test/rake_test.rb
+++ b/test/rake_test.rb
@@ -12,9 +12,13 @@ context "rake" do
     Rake.application.invoke_task "resque:work"
   end
 
-  test "requires queue" do
-    assert_raises Resque::NoQueueError do
+  test "requires QUEUE environment variable" do
+    begin
       run_rake_task
+      fail 'Expected task to abort'
+    rescue Exception => e
+      assert_equal e.message, "set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work"
+      assert_equal e.class, SystemExit
     end
   end
 


### PR DESCRIPTION
Fix 1 of 2 for #1253

The previous error message of `set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work` was broken when some code was moved from the rake task to `worker.rb` (see https://github.com/resque/resque/commit/7d0b20ee00986b749b03d4407af199039b504cc2). This PR moves back the `begin...rescue` so that it properly traps the exception and presents the error message.

NOTE: I realize that I accidentally picked up a few whitespace deletions as well. Let me know if you want me to get rid of them before you merge