### PR TITLE
Memoize hook names in plugins.

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -508,6 +508,11 @@ module Resque
     @hooks && @hooks[name] = []
   end
 
+  # Retrieve all hooks
+  def hooks
+    @hooks || {}
+  end
+
   # Retrieve all hooks of a given name.
   def hooks(name)
     (@hooks && @hooks[name]) || []

--- a/lib/resque/plugin.rb
+++ b/lib/resque/plugin.rb
@@ -11,56 +11,68 @@ module Resque
       hooks = before_hooks(plugin) + around_hooks(plugin) + after_hooks(plugin)
 
       hooks.each do |hook|
-        if hook =~ /perform$/
+        if hook.to_s.end_with?("perform")
           raise LintError, "#{plugin}.#{hook} is not namespaced"
         end
       end
 
       failure_hooks(plugin).each do |hook|
-        if hook =~ /failure$/
+        if hook.to_s.end_with?("failure")
           raise LintError, "#{plugin}.#{hook} is not namespaced"
         end
       end
     end
 
+    @job_methods = {}
+    def job_methods(job)
+      @job_methods[job] ||= job.methods.collect{|m| m.to_s}
+    end
+
+    # Given an object, and a method prefix, returns a list of methods prefixed
+    # with that name (hook names).
+    def get_hook_names(job, hook_method_prefix)
+      methods = (job.respond_to?(:hooks) && job.hooks.keys) || job_methods(job)
+      methods.select{|m| m.start_with?(hook_method_prefix)}.sort
+    end
+
     # Given an object, returns a list `before_perform` hook names.
     def before_hooks(job)
-      job.methods.grep(/^before_perform/).sort
+      get_hook_names(job, 'before_perform')
     end
 
     # Given an object, returns a list `around_perform` hook names.
     def around_hooks(job)
-      job.methods.grep(/^around_perform/).sort
+      get_hook_names(job, 'around_perform')
     end
 
     # Given an object, returns a list `after_perform` hook names.
     def after_hooks(job)
-      job.methods.grep(/^after_perform/).sort
+      get_hook_names(job, 'after_perform')
     end
 
     # Given an object, returns a list `on_failure` hook names.
     def failure_hooks(job)
-      job.methods.grep(/^on_failure/).sort
+      get_hook_names(job, 'on_failure')
     end
 
     # Given an object, returns a list `after_enqueue` hook names.
     def after_enqueue_hooks(job)
-      job.methods.grep(/^after_enqueue/).sort
+      get_hook_names(job, 'after_enqueue')
     end
 
     # Given an object, returns a list `before_enqueue` hook names.
     def before_enqueue_hooks(job)
-      job.methods.grep(/^before_enqueue/).sort
+      get_hook_names(job, 'before_enqueue')
     end
 
     # Given an object, returns a list `after_dequeue` hook names.
     def after_dequeue_hooks(job)
-      job.methods.grep(/^after_dequeue/).sort
+      get_hook_names(job, 'after_dequeue')
     end
 
     # Given an object, returns a list `before_dequeue` hook names.
     def before_dequeue_hooks(job)
-      job.methods.grep(/^before_dequeue/).sort
+      get_hook_names(job, 'before_dequeue')
     end
   end
 end


### PR DESCRIPTION
This cherry-picks https://github.com/resque/resque/commit/62ca48d521062cf703d4daa94cece8f930a46a10 (fixes https://github.com/resque/resque/pull/508) from master into 1-x-stable. According to @dylanahsmith, doing so will allow us to get rid of https://github.com/Shopify/resque/pull/5#issuecomment-170741009 in our fork.

@steveklabnik 