### PR TITLE
Fail rake rescue:workers if COUNT is not set

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -23,6 +23,10 @@ namespace :resque do
   task :workers do
     threads = []
 
+    if ENV['COUNT'].to_i < 1
+      abort "set COUNT env var, e.g. $ COUNT=2 rake resque:workers"
+    end
+
     ENV['COUNT'].to_i.times do
       threads << Thread.new do
         system "rake resque:work"

--- a/test/rake_test.rb
+++ b/test/rake_test.rb
@@ -2,34 +2,39 @@ require "rake"
 require "test_helper"
 require "mocha"
 
-context "rake" do
-  setup do
+describe "rake tasks" do
+  before do
     Rake.application.rake_require "tasks/resque"
   end
 
-  def run_rake_task
-    Rake::Task["resque:work"].reenable
-    Rake.application.invoke_task "resque:work"
+  describe 'resque:work' do
+
+    it "requires QUEUE environment variable" do
+      begin
+        run_rake_task("resque:work")
+        fail 'Expected task to abort'
+      rescue Exception => e
+        assert_equal e.message, "set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work"
+        assert_equal e.class, SystemExit
+      end
+    end
+
+    it "works when multiple queues specified" do
+      begin
+        old_queues = ENV["QUEUES"]
+        ENV["QUEUES"] = "high,low"
+        Resque::Worker.any_instance.expects(:work)
+        run_rake_task("resque:work")
+      ensure
+        ENV["QUEUES"] = old_queues
+      end
+    end
+
   end
 
-  test "requires QUEUE environment variable" do
-    begin
-      run_rake_task
-      fail 'Expected task to abort'
-    rescue Exception => e
-      assert_equal e.message, "set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work"
-      assert_equal e.class, SystemExit
-    end
+  def run_rake_task(name)
+    Rake::Task[name].reenable
+    Rake.application.invoke_task(name)
   end
 
-  test "works when multiple queues specified" do
-    begin
-      old_queues = ENV["QUEUES"]
-      ENV["QUEUES"] = "high,low"
-      Resque::Worker.any_instance.expects(:work)
-      run_rake_task
-    ensure
-      ENV["QUEUES"] = old_queues
-    end
-  end
 end

--- a/test/rake_test.rb
+++ b/test/rake_test.rb
@@ -10,12 +10,8 @@ describe "rake tasks" do
   describe 'resque:work' do
 
     it "requires QUEUE environment variable" do
-      begin
+      assert_system_exit("set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work") do
         run_rake_task("resque:work")
-        fail 'Expected task to abort'
-      rescue Exception => e
-        assert_equal e.message, "set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work"
-        assert_equal e.class, SystemExit
       end
     end
 
@@ -32,9 +28,41 @@ describe "rake tasks" do
 
   end
 
+  describe 'resque:workers' do
+
+    it 'requires COUNT environment variable' do
+      assert_system_exit("set COUNT env var, e.g. $ COUNT=2 rake resque:workers") do
+        run_rake_task("resque:workers")
+      end
+    end
+
+  end
+
   def run_rake_task(name)
     Rake::Task[name].reenable
     Rake.application.invoke_task(name)
+  end
+
+  def assert_system_exit(expected_message)
+    begin
+      silence_stream(STDERR) { yield }
+      fail 'Expected task to abort'
+    rescue Exception => e
+      assert_equal e.message, expected_message
+      assert_equal e.class, SystemExit
+    end
+  end
+
+  # Borrowed from Rails ActiveSupport
+  # https://github.com/rails/rails/blob/7f18ea14c893cb5c9f04d4fda9661126758332b5/activesupport/lib/active_support/testing/stream.rb#L6-L14
+  def silence_stream(stream)
+    old_stream = stream.dup
+    stream.reopen(IO::NULL)
+    stream.sync = true
+    yield
+  ensure
+    stream.reopen(old_stream)
+    old_stream.close
   end
 
 end

--- a/test/rake_test.rb
+++ b/test/rake_test.rb
@@ -45,24 +45,12 @@ describe "rake tasks" do
 
   def assert_system_exit(expected_message)
     begin
-      silence_stream(STDERR) { yield }
+      capture_io { yield }
       fail 'Expected task to abort'
     rescue Exception => e
       assert_equal e.message, expected_message
       assert_equal e.class, SystemExit
     end
-  end
-
-  # Borrowed from Rails ActiveSupport
-  # https://github.com/rails/rails/blob/7f18ea14c893cb5c9f04d4fda9661126758332b5/activesupport/lib/active_support/testing/stream.rb#L6-L14
-  def silence_stream(stream)
-    old_stream = stream.dup
-    stream.reopen(IO::NULL)
-    stream.sync = true
-    yield
-  ensure
-    stream.reopen(old_stream)
-    old_stream.close
   end
 
 end


### PR DESCRIPTION
2nd of 2 PRs to address #1253 

Added a check that the COUNT environment variable is set to a number greater than 0 with an appropriate error message.

Refactored the test file a bit in order to support testing multiple rake tasks, and also switched it to using the `describe` syntax of minitest. Finally borrowed some code from Rails to silence stderr messages so as to not pollute the test output.