### PR TITLE
encoding should be done outside of pipeline block

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -251,9 +251,10 @@ module Resque
   #
   # Returns nothing
   def push(queue, item)
+    encoded = encode(item)
     redis.pipelined do
       watch_queue(queue)
-      redis.rpush "queue:#{queue}", encode(item)
+      redis.rpush "queue:#{queue}", encoded
     end
   end
 

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -9,6 +9,13 @@ describe "Resque" do
     Resque.redis = @original_redis
   end
 
+  it "can push an item that depends on redis for encoding" do
+    Resque.redis.set("count", 1)
+    # No error should be raised
+    Resque.push(:test, JsonObject.new)
+    Resque.redis.del("count")
+  end
+
   it "can set a namespace through a url-like string" do
     assert Resque.redis
     assert_equal :resque, Resque.redis.namespace

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -117,6 +117,13 @@ class SomeJob
   end
 end
 
+class JsonObject
+  def to_json(opts = {})
+    val = Resque.redis.get("count")
+    { "val" => val }.to_json
+  end
+end
+
 class SomeIvarJob < SomeJob
   @queue = :ivar
 end


### PR DESCRIPTION
(reopen of https://github.com/resque/resque/pull/1243)

Redis 3.0 makes a change to return a future for some commands run inside pipeline or multi. This change allows serialization (like to_json) to read from redis and get a value, not a future.

I'm not sure how best to test this. The test I included may not even be a test at all... any ideas?

@steveklabnik 