### PR TITLE
Switch all tests to describe/it Minitest syntax

### DIFF
--- a/test/airbrake_test.rb
+++ b/test/airbrake_test.rb
@@ -9,8 +9,8 @@ end
 
 if defined? Airbrake
   require 'resque/failure/airbrake'
-  context "Airbrake" do
-    test "should be notified of an error" do
+  describe "Airbrake" do
+    it "should be notified of an error" do
       exception = StandardError.new("BOOM")
       worker = Resque::Worker.new(:test)
       queue = "test"

--- a/test/child_killing_test.rb
+++ b/test/child_killing_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'tmpdir'
 require 'fixtures/long_running_job'
 
-context "Resque::Worker" do
+describe "Resque::Worker" do
   def start_worker(rescue_time, term_child)
     Resque.enqueue( LongRunningJob, 3, rescue_time )
 
@@ -22,7 +22,7 @@ context "Resque::Worker" do
 
     # ensure the worker is started
     start_status = Resque.redis.blpop( 'sigterm-test:start', 5 )
-    assert_not_nil start_status
+    refute_nil start_status
     child_pid = start_status[1].to_i
     assert child_pid > 0, "worker child process not created"
 
@@ -33,7 +33,7 @@ context "Resque::Worker" do
   end
 
   def assert_exception_caught(result)
-    assert_not_nil result
+    refute_nil result
     assert !result[1].start_with?('Finished Normally'), 'Job Finished normally.  (sleep parameter to LongRunningJob not long enough?)'
     assert result[1].start_with?("Caught TermException"), 'TermException exception not raised in child.'
   end
@@ -44,19 +44,19 @@ context "Resque::Worker" do
     assert !child_still_running
   end
 
-  teardown do
+  before do
     remaining_keys = Resque.redis.keys('sigterm-test:*') || []
     Resque.redis.del(*remaining_keys) unless remaining_keys.empty?
   end
 
   if !defined?(RUBY_ENGINE) || RUBY_ENGINE != "jruby"
-    test "old signal handling just kills off the child" do
+    it "old signal handling just kills off the child" do
       worker_pid, child_pid, result = start_worker(0, false)
       assert_nil result
       assert_child_not_running child_pid
     end
 
-    test "SIGTERM and cleanup occurs in allotted time" do
+    it "SIGTERM and cleanup occurs in allotted time" do
       worker_pid, child_pid, result = start_worker(0, true)
       assert_exception_caught result
       assert_child_not_running child_pid
@@ -66,7 +66,7 @@ context "Resque::Worker" do
       assert post_cleanup_occurred, 'post cleanup did not occur. SIGKILL sent too early?'
     end
 
-    test "SIGTERM and cleanup does not occur in allotted time" do
+    it "SIGTERM and cleanup does not occur in allotted time" do
       worker_pid, child_pid, result = start_worker(5, true)
       assert_exception_caught result
       assert_child_not_running child_pid
@@ -77,7 +77,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "exits with Resque::TermException when using TERM_CHILD and not forking" do
+  it "exits with Resque::TermException when using TERM_CHILD and not forking" do
     begin
       ENV['FORK_PER_JOB'] = 'false'
       worker_pid, child_pid, result = start_worker(5, true)
@@ -88,14 +88,14 @@ context "Resque::Worker" do
     end
   end
 
-  test "displays warning when not using term_child" do
+  it "displays warning when not using term_child" do
     worker = Resque::Worker.new(:jobs)
     worker.term_child = nil
     _, stderr = capture_io { worker.work(0) }
     assert stderr.match(/^WARNING:/)
   end
 
-  test "it does not display warning when using term_child" do
+  it "it does not display warning when using term_child" do
     worker = Resque::Worker.new(:jobs)
     worker.term_child = "1"
     _, stderr = capture_io { worker.work(0) }

--- a/test/job_hooks_test.rb
+++ b/test/job_hooks_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-context "Resque::Job before_perform" do
+describe "Resque::Job before_perform" do
   include PerformJob
 
   class ::BeforePerformJob
@@ -13,7 +13,7 @@ context "Resque::Job before_perform" do
     end
   end
 
-  test "it runs before_perform before perform" do
+  it "it runs before_perform before perform" do
     result = perform_job(BeforePerformJob, history=[])
     assert_equal true, result, "perform returned true"
     assert_equal history, [:before_perform, :perform]
@@ -29,7 +29,7 @@ context "Resque::Job before_perform" do
     end
   end
 
-  test "raises an error and does not perform if before_perform fails" do
+  it "raises an error and does not perform if before_perform fails" do
     history = []
     assert_raises StandardError do
       perform_job(BeforePerformJobFails, history)
@@ -47,14 +47,14 @@ context "Resque::Job before_perform" do
     end
   end
 
-  test "does not perform if before_perform raises Resque::Job::DontPerform" do
+  it "does not perform if before_perform raises Resque::Job::DontPerform" do
     result = perform_job(BeforePerformJobAborts, history=[])
     assert_equal false, result, "perform returned false"
     assert_equal history, [:before_perform], "Only before_perform was run"
   end
 end
 
-context "Resque::Job after_perform" do
+describe "Resque::Job after_perform" do
   include PerformJob
 
   class ::AfterPerformJob
@@ -66,7 +66,7 @@ context "Resque::Job after_perform" do
     end
   end
 
-  test "it runs after_perform after perform" do
+  it "it runs after_perform after perform" do
     result = perform_job(AfterPerformJob, history=[])
     assert_equal true, result, "perform returned true"
     assert_equal history, [:perform, :after_perform]
@@ -82,7 +82,7 @@ context "Resque::Job after_perform" do
     end
   end
 
-  test "raises an error but has already performed if after_perform fails" do
+  it "raises an error but has already performed if after_perform fails" do
     history = []
     assert_raises StandardError do
       perform_job(AfterPerformJobFails, history)
@@ -91,7 +91,7 @@ context "Resque::Job after_perform" do
   end
 end
 
-context "Resque::Job around_perform" do
+describe "Resque::Job around_perform" do
   include PerformJob
 
   class ::AroundPerformJob
@@ -105,7 +105,7 @@ context "Resque::Job around_perform" do
     end
   end
 
-  test "it runs around_perform then yields in order to perform" do
+  it "it runs around_perform then yields in order to perform" do
     result = perform_job(AroundPerformJob, history=[])
     assert_equal true, result, "perform returned true"
     assert_equal history, [:start_around_perform, :perform, :finish_around_perform]
@@ -123,7 +123,7 @@ context "Resque::Job around_perform" do
     end
   end
 
-  test "raises an error and does not perform if around_perform fails before yielding" do
+  it "raises an error and does not perform if around_perform fails before yielding" do
     history = []
     assert_raises StandardError do
       perform_job(AroundPerformJobFailsBeforePerforming, history)
@@ -147,7 +147,7 @@ context "Resque::Job around_perform" do
     end
   end
 
-  test "raises an error but may handle exceptions if perform fails" do
+  it "raises an error but may handle exceptions if perform fails" do
     history = []
     assert_raises StandardError do
       perform_job(AroundPerformJobFailsWhilePerforming, history)
@@ -165,7 +165,7 @@ context "Resque::Job around_perform" do
     end
   end
 
-  test "around_perform is not required to yield" do
+  it "around_perform is not required to yield" do
     history = []
     result = perform_job(AroundPerformJobDoesNotHaveToYield, history)
     assert_equal false, result, "perform returns false"
@@ -173,7 +173,7 @@ context "Resque::Job around_perform" do
   end
 end
 
-context "Resque::Job on_failure" do
+describe "Resque::Job on_failure" do
   include PerformJob
 
   class ::FailureJobThatDoesNotFail
@@ -185,7 +185,7 @@ context "Resque::Job on_failure" do
     end
   end
 
-  test "it does not call on_failure if no failures occur" do
+  it "it does not call on_failure if no failures occur" do
     result = perform_job(FailureJobThatDoesNotFail, history=[])
     assert_equal true, result, "perform returned true"
     assert_equal history, [:perform]
@@ -201,7 +201,7 @@ context "Resque::Job on_failure" do
     end
   end
 
-  test "it calls on_failure with the exception and then re-raises the exception" do
+  it "it calls on_failure with the exception and then re-raises the exception" do
     history = []
     assert_raises StandardError do
       perform_job(FailureJobThatFails, history)
@@ -219,7 +219,7 @@ context "Resque::Job on_failure" do
     end
   end
 
-  test "it calls on_failure even with bad exceptions" do
+  it "it calls on_failure even with bad exceptions" do
     history = []
     assert_raises SyntaxError do
       perform_job(FailureJobThatFailsBadly, history)
@@ -228,7 +228,7 @@ context "Resque::Job on_failure" do
   end
 end
 
-context "Resque::Job after_enqueue" do
+describe "Resque::Job after_enqueue" do
   include PerformJob
 
   class ::AfterEnqueueJob
@@ -241,7 +241,7 @@ context "Resque::Job after_enqueue" do
     end
   end
 
-  test "the after enqueue hook should run" do
+  it "the after enqueue hook should run" do
     history = []
     @worker = Resque::Worker.new(:jobs)
     Resque.enqueue(AfterEnqueueJob, history)
@@ -251,7 +251,7 @@ context "Resque::Job after_enqueue" do
 end
 
 
-context "Resque::Job before_enqueue" do
+describe "Resque::Job before_enqueue" do
   include PerformJob
 
   class ::BeforeEnqueueJob
@@ -274,7 +274,7 @@ context "Resque::Job before_enqueue" do
     end
   end
 
-  test "the before enqueue hook should run" do
+  it "the before enqueue hook should run" do
     history = []
     @worker = Resque::Worker.new(:jobs)
     assert Resque.enqueue(BeforeEnqueueJob, history)
@@ -282,7 +282,7 @@ context "Resque::Job before_enqueue" do
     assert_equal history, [:before_enqueue], "before_enqueue was not run"
   end
 
-  test "a before enqueue hook that returns false should prevent the job from getting queued" do
+  it "a before enqueue hook that returns false should prevent the job from getting queued" do
     Resque.remove_queue(:jobs)
     history = []
     @worker = Resque::Worker.new(:jobs)
@@ -291,7 +291,7 @@ context "Resque::Job before_enqueue" do
   end
 end
 
-context "Resque::Job after_dequeue" do
+describe "Resque::Job after_dequeue" do
   include PerformJob
 
   class ::AfterDequeueJob
@@ -304,7 +304,7 @@ context "Resque::Job after_dequeue" do
     end
   end
 
-  test "the after dequeue hook should run" do
+  it "the after dequeue hook should run" do
     history = []
     @worker = Resque::Worker.new(:jobs)
     Resque.dequeue(AfterDequeueJob, history)
@@ -314,7 +314,7 @@ context "Resque::Job after_dequeue" do
 end
 
 
-context "Resque::Job before_dequeue" do
+describe "Resque::Job before_dequeue" do
   include PerformJob
 
   class ::BeforeDequeueJob
@@ -337,7 +337,7 @@ context "Resque::Job before_dequeue" do
     end
   end
 
-  test "the before dequeue hook should run" do
+  it "the before dequeue hook should run" do
     history = []
     @worker = Resque::Worker.new(:jobs)
     Resque.dequeue(BeforeDequeueJob, history)
@@ -345,13 +345,13 @@ context "Resque::Job before_dequeue" do
     assert_equal history, [:before_dequeue], "before_dequeue was not run"
   end
 
-  test "a before dequeue hook that returns false should prevent the job from getting dequeued" do
+  it "a before dequeue hook that returns false should prevent the job from getting dequeued" do
     history = []
     assert_equal nil, Resque.dequeue(BeforeDequeueJobAbort, history)
   end
 end
 
-context "Resque::Job all hooks" do
+describe "Resque::Job all hooks" do
   include PerformJob
 
   class ::VeryHookyJob
@@ -374,7 +374,7 @@ context "Resque::Job all hooks" do
     end
   end
 
-  test "the complete hook order" do
+  it "the complete hook order" do
     result = perform_job(VeryHookyJob, history=[])
     assert_equal true, result, "perform returned true"
     assert_equal history, [
@@ -407,7 +407,7 @@ context "Resque::Job all hooks" do
     end
   end
 
-  test "the complete hook order with a failure at the last minute" do
+  it "the complete hook order with a failure at the last minute" do
     history = []
     assert_raises StandardError do
       perform_job(VeryHookyJobThatFails, history)
@@ -450,7 +450,7 @@ context "Resque::Job all hooks" do
     end
   end
 
-  test "it runs callbacks when inline is true" do
+  it "it runs callbacks when inline is true" do
     begin
       Resque.inline = true
       # Sending down two parameters that can be passed and updated by reference

--- a/test/job_plugins_test.rb
+++ b/test/job_plugins_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-context "Multiple plugins with multiple hooks" do
+describe "Multiple plugins with multiple hooks" do
   include PerformJob
 
   module Plugin1
@@ -29,14 +29,14 @@ context "Multiple plugins with multiple hooks" do
     end
   end
 
-  test "hooks of each type are executed in alphabetical order" do
+  it "hooks of each type are executed in alphabetical order" do
     result = perform_job(ManyBeforesJob, history=[])
     assert_equal true, result, "perform returned true"
     assert_equal [:before1, :before2, :perform, :after1, :after2], history
   end
 end
 
-context "Resque::Plugin ordering before_perform" do
+describe "Resque::Plugin ordering before_perform" do
   include PerformJob
 
   module BeforePerformPlugin
@@ -55,14 +55,14 @@ context "Resque::Plugin ordering before_perform" do
     end
   end
 
-  test "before_perform hooks are executed in order" do
+  it "before_perform hooks are executed in order" do
     result = perform_job(JobPluginsTestBeforePerformJob, history=[])
     assert_equal true, result, "perform returned true"
     assert_equal [:before_perform, :before_perform1, :perform], history
   end
 end
 
-context "Resque::Plugin ordering after_perform" do
+describe "Resque::Plugin ordering after_perform" do
   include PerformJob
 
   module AfterPerformPlugin
@@ -81,14 +81,14 @@ context "Resque::Plugin ordering after_perform" do
     end
   end
 
-  test "after_perform hooks are executed in order" do
+  it "after_perform hooks are executed in order" do
     result = perform_job(JobPluginsTestAfterPerformJob, history=[])
     assert_equal true, result, "perform returned true"
     assert_equal [:perform, :after_perform, :after_perform1], history
   end
 end
 
-context "Resque::Plugin ordering around_perform" do
+describe "Resque::Plugin ordering around_perform" do
   include PerformJob
 
   module AroundPerformPlugin1
@@ -105,7 +105,7 @@ context "Resque::Plugin ordering around_perform" do
     end
   end
 
-  test "around_perform hooks are executed before the job" do
+  it "around_perform hooks are executed before the job" do
     result = perform_job(AroundPerformJustPerformsJob, history=[])
     assert_equal true, result, "perform returned true"
     assert_equal [:around_perform_plugin1, :perform], history
@@ -122,7 +122,7 @@ context "Resque::Plugin ordering around_perform" do
     end
   end
 
-  test "around_perform hooks are executed in order" do
+  it "around_perform hooks are executed in order" do
     result = perform_job(JobPluginsTestAroundPerformJob, history=[])
     assert_equal true, result, "perform returned true"
     assert_equal [:around_perform, :around_perform_plugin1, :perform], history
@@ -147,7 +147,7 @@ context "Resque::Plugin ordering around_perform" do
     end
   end
 
-  test "many around_perform are executed in order" do
+  it "many around_perform are executed in order" do
     result = perform_job(AroundPerformJob2, history=[])
     assert_equal true, result, "perform returned true"
     assert_equal [:around_perform, :around_perform_plugin1, :around_perform_plugin2, :perform], history
@@ -172,7 +172,7 @@ context "Resque::Plugin ordering around_perform" do
     end
   end
 
-  test "the job is aborted if an around_perform hook does not yield" do
+  it "the job is aborted if an around_perform hook does not yield" do
     result = perform_job(AroundPerformJob3, history=[])
     assert_equal false, result, "perform returned false"
     assert_equal [:around_perform, :around_perform0], history
@@ -193,14 +193,14 @@ context "Resque::Plugin ordering around_perform" do
     extend AroundPerformGetsJobResult
   end
 
-  test "the job is not aborted if an around_perform hook does yield" do
+  it "the job is not aborted if an around_perform hook does yield" do
     result = perform_job(AroundPerformJobWithReturnValue, 'Bob')
     assert_equal true, result, "perform returned true"
     assert_equal 'Good job, Bob', AroundPerformJobWithReturnValue.last_job_result
   end
 end
 
-context "Resque::Plugin ordering on_failure" do
+describe "Resque::Plugin ordering on_failure" do
   include PerformJob
 
   module OnFailurePlugin
@@ -220,7 +220,7 @@ context "Resque::Plugin ordering on_failure" do
     end
   end
 
-  test "on_failure hooks are executed in order" do
+  it "on_failure hooks are executed in order" do
     history = []
     assert_raises StandardError do
       perform_job(FailureJob, history)

--- a/test/logging_test.rb
+++ b/test/logging_test.rb
@@ -1,17 +1,16 @@
 require 'test_helper'
 require 'minitest/mock'
 
-context "Resque::Logging" do
-  teardown { reset_logger }
+describe "Resque::Logging" do
 
-  test "sets and receives the active logger" do
+  it "sets and receives the active logger" do
     my_logger = Object.new
     Resque.logger = my_logger
     assert_equal my_logger, Resque.logger
   end
 
   %w(debug info error fatal).each do |severity|
-    test "logs #{severity} messages" do
+    it "logs #{severity} messages" do
       message       = "test message"
       mock_logger   = MiniTest::Mock.new
       mock_logger.expect severity.to_sym, nil, [message]

--- a/test/plugin_test.rb
+++ b/test/plugin_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-context "Resque::Plugin finding hooks" do
+describe "Resque::Plugin finding hooks" do
   module SimplePlugin
     extend self
     def before_perform1; end
@@ -18,24 +18,24 @@ context "Resque::Plugin finding hooks" do
     def on_failure2; end
   end
 
-  test "before_perform hooks are found and sorted" do
+  it "before_perform hooks are found and sorted" do
     assert_equal ["before_perform", "before_perform1", "before_perform2"], Resque::Plugin.before_hooks(SimplePlugin).map {|m| m.to_s}
   end
 
-  test "after_perform hooks are found and sorted" do
+  it "after_perform hooks are found and sorted" do
     assert_equal ["after_perform", "after_perform1", "after_perform2"], Resque::Plugin.after_hooks(SimplePlugin).map {|m| m.to_s}
   end
 
-  test "around_perform hooks are found and sorted" do
+  it "around_perform hooks are found and sorted" do
     assert_equal ["around_perform", "around_perform1", "around_perform2"], Resque::Plugin.around_hooks(SimplePlugin).map {|m| m.to_s}
   end
 
-  test "on_failure hooks are found and sorted" do
+  it "on_failure hooks are found and sorted" do
     assert_equal ["on_failure", "on_failure1", "on_failure2"], Resque::Plugin.failure_hooks(SimplePlugin).map {|m| m.to_s}
   end
 end
 
-context "Resque::Plugin linting" do
+describe "Resque::Plugin linting" do
   module ::BadBefore
     def self.before_perform; end
   end
@@ -49,7 +49,7 @@ context "Resque::Plugin linting" do
     def self.on_failure; end
   end
 
-  test "before_perform must be namespaced" do
+  it "before_perform must be namespaced" do
     begin
       Resque::Plugin.lint(BadBefore)
       assert false, "should have failed"
@@ -58,7 +58,7 @@ context "Resque::Plugin linting" do
     end
   end
 
-  test "after_perform must be namespaced" do
+  it "after_perform must be namespaced" do
     begin
       Resque::Plugin.lint(BadAfter)
       assert false, "should have failed"
@@ -67,7 +67,7 @@ context "Resque::Plugin linting" do
     end
   end
 
-  test "around_perform must be namespaced" do
+  it "around_perform must be namespaced" do
     begin
       Resque::Plugin.lint(BadAround)
       assert false, "should have failed"
@@ -76,7 +76,7 @@ context "Resque::Plugin linting" do
     end
   end
 
-  test "on_failure must be namespaced" do
+  it "on_failure must be namespaced" do
     begin
       Resque::Plugin.lint(BadFailure)
       assert false, "should have failed"
@@ -98,19 +98,19 @@ context "Resque::Plugin linting" do
     def self.on_failure1; end
   end
 
-  test "before_perform1 is an ok name" do
+  it "before_perform1 is an ok name" do
     Resque::Plugin.lint(GoodBefore)
   end
 
-  test "after_perform1 is an ok name" do
+  it "after_perform1 is an ok name" do
     Resque::Plugin.lint(GoodAfter)
   end
 
-  test "around_perform1 is an ok name" do
+  it "around_perform1 is an ok name" do
     Resque::Plugin.lint(GoodAround)
   end
 
-  test "on_failure1 is an ok name" do
+  it "on_failure1 is an ok name" do
     Resque::Plugin.lint(GoodFailure)
   end
 end

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -1,69 +1,91 @@
 require 'test_helper'
-require 'resque/server/test_helper'
- 
-# Root path test
-context "on GET to /" do
-  setup { get "/" }
+require 'rack/test'
+require 'resque/server'
 
-  test "redirect to overview" do
-    follow_redirect!
+describe "Resque web" do
+  include Rack::Test::Methods
+
+  def app
+    Resque::Server.new
   end
-end
 
-# Global overview
-context "on GET to /overview" do
-  setup { get "/overview" }
+  # Root path test
+  describe "on GET to /" do
+    before { get "/" }
 
-  test "should at least display 'queues'" do
-    assert last_response.body.include?('Queues')
+    it "redirect to overview" do
+      follow_redirect!
+    end
   end
-end
 
-context "With append-prefix option on GET to /overview" do
-  reverse_proxy_prefix = 'proxy_site/resque'
-  Resque::Server.url_prefix = reverse_proxy_prefix
-  setup { get "/overview" }
+  # Global overview
+  describe "on GET to /overview" do
+    before { get "/overview" }
 
-  test "should contain reverse proxy prefix for asset urls and links" do
-    assert last_response.body.include?(reverse_proxy_prefix)
+    it "should at least display 'queues'" do
+      assert last_response.body.include?('Queues')
+    end
   end
-end
 
-# Working jobs
-context "on GET to /working" do
-  setup { get "/working" }
+  describe "With append-prefix option on GET to /overview" do
+    reverse_proxy_prefix = 'proxy_site/resque'
+    Resque::Server.url_prefix = reverse_proxy_prefix
+    before { get "/overview" }
 
-  should_respond_with_success
-end
+    it "should contain reverse proxy prefix for asset urls and links" do
+      assert last_response.body.include?(reverse_proxy_prefix)
+    end
+  end
 
-# Failed
-context "on GET to /failed" do
-  setup { get "/failed" }
+  # Working jobs
+  describe "on GET to /working" do
+    before { get "/working" }
 
-  should_respond_with_success
-end
+    it "should respond with success" do
+      assert last_response.ok?, last_response.errors
+    end
+  end
 
-# Stats 
-context "on GET to /stats/resque" do
-  setup { get "/stats/resque" }
+  # Failed
+  describe "on GET to /failed" do
+    before { get "/failed" }
 
-  should_respond_with_success
-end
+    it "should respond with success" do
+      assert last_response.ok?, last_response.errors
+    end
+  end
 
-context "on GET to /stats/redis" do
-  setup { get "/stats/redis" }
+  # Stats
+  describe "on GET to /stats/resque" do
+    before { get "/stats/resque" }
 
-  should_respond_with_success
-end
+    it "should respond with success" do
+      assert last_response.ok?, last_response.errors
+    end
+  end
 
-context "on GET to /stats/resque" do
-  setup { get "/stats/keys" }
+  describe "on GET to /stats/redis" do
+    before { get "/stats/redis" }
 
-  should_respond_with_success
-end
+    it "should respond with success" do
+      assert last_response.ok?, last_response.errors
+    end
+  end
 
-context "also works with slash at the end" do
-  setup { get "/working/" }
+  describe "on GET to /stats/resque" do
+    before { get "/stats/keys" }
 
-  should_respond_with_success
+    it "should respond with success" do
+      assert last_response.ok?, last_response.errors
+    end
+  end
+
+  describe "also works with slash at the end" do
+    before { get "/working/" }
+
+    it "should respond with success" do
+      assert last_response.ok?, last_response.errors
+    end
+  end
+
 end

--- a/test/resque_failure_redis_test.rb
+++ b/test/resque_failure_redis_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 require 'resque/failure/redis'
 
-context "Resque::Failure::Redis" do
-  setup do
+describe "Resque::Failure::Redis" do
+  before do
     Resque::Failure::Redis.clear
     @bad_string    = [39, 52, 127, 86, 93, 95, 39].map { |c| c.chr }.join
     exception      = StandardError.exception(@bad_string)
@@ -12,20 +12,20 @@ context "Resque::Failure::Redis" do
     @redis_backend = Resque::Failure::Redis.new(exception, worker, queue, payload)
   end
 
-  test 'cleans up bad strings before saving the failure, in order to prevent errors on the resque UI' do
+  it 'cleans up bad strings before saving the failure, in order to prevent errors on the resque UI' do
     # test assumption: the bad string should not be able to round trip though JSON
     @redis_backend.save
     Resque::Failure::Redis.all # should not raise an error
   end
 
-  test '.each iterates correctly (does nothing) for no failures' do
+  it '.each iterates correctly (does nothing) for no failures' do
     assert_equal 0, Resque::Failure::Redis.count
     Resque::Failure::Redis.each do |id, item|
       raise "Should not get here"
     end
   end
 
-  test '.each iterates thru a single hash if there is a single failure' do
+  it '.each iterates thru a single hash if there is a single failure' do
     @redis_backend.save
     assert_equal 1, Resque::Failure::Redis.count
     num_iterations = 0
@@ -36,7 +36,7 @@ context "Resque::Failure::Redis" do
     assert_equal 1, num_iterations
   end
 
-  test '.each iterates thru hashes if there is are multiple failures' do
+  it '.each iterates thru hashes if there is are multiple failures' do
     @redis_backend.save
     @redis_backend.save
     num_iterations = 0
@@ -46,6 +46,6 @@ context "Resque::Failure::Redis" do
       assert_equal Hash, item.class
     end
     assert_equal 2, num_iterations
-  end 
+  end
 
 end

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
-context "Resque" do
-  setup do
+describe "Resque" do
+  before do
     Resque.redis.flushall
 
     Resque.push(:people, { 'name' => 'chris' })
@@ -10,18 +10,18 @@ context "Resque" do
     @original_redis = Resque.redis
   end
 
-  teardown do
+  after do
     Resque.redis = @original_redis
   end
 
-  test "can set a namespace through a url-like string" do
+  it "can set a namespace through a url-like string" do
     assert Resque.redis
     assert_equal :resque, Resque.redis.namespace
     Resque.redis = 'localhost:9736/namespace'
     assert_equal 'namespace', Resque.redis.namespace
   end
 
-  test "redis= works correctly with a Redis::Namespace param" do
+  it "redis= works correctly with a Redis::Namespace param" do
     new_redis = Redis.new(:host => "localhost", :port => 9736)
     new_namespace = Redis::Namespace.new("namespace", :redis => new_redis)
     Resque.redis = new_namespace
@@ -30,12 +30,12 @@ context "Resque" do
     Resque.redis = 'localhost:9736/namespace'
   end
 
-  test "can put jobs on a queue" do
+  it "can put jobs on a queue" do
     assert Resque::Job.create(:jobs, 'SomeJob', 20, '/tmp')
     assert Resque::Job.create(:jobs, 'SomeJob', 20, '/tmp')
   end
 
-  test "can grab jobs off a queue" do
+  it "can grab jobs off a queue" do
     Resque::Job.create(:jobs, 'some-job', 20, '/tmp')
 
     job = Resque.reserve(:jobs)
@@ -46,7 +46,7 @@ context "Resque" do
     assert_equal '/tmp', job.args[1]
   end
 
-  test "can re-queue jobs" do
+  it "can re-queue jobs" do
     Resque::Job.create(:jobs, 'some-job', 20, '/tmp')
 
     job = Resque.reserve(:jobs)
@@ -55,7 +55,7 @@ context "Resque" do
     assert_equal job, Resque.reserve(:jobs)
   end
 
-  test "can put jobs on a queue by way of an ivar" do
+  it "can put jobs on a queue by way of an ivar" do
     assert_equal 0, Resque.size(:ivar)
     assert Resque.enqueue(SomeIvarJob, 20, '/tmp')
     assert Resque.enqueue(SomeIvarJob, 20, '/tmp')
@@ -71,7 +71,7 @@ context "Resque" do
     assert_equal nil, Resque.reserve(:ivar)
   end
 
-  test "can remove jobs from a queue by way of an ivar" do
+  it "can remove jobs from a queue by way of an ivar" do
     assert_equal 0, Resque.size(:ivar)
     assert Resque.enqueue(SomeIvarJob, 20, '/tmp')
     assert Resque.enqueue(SomeIvarJob, 30, '/tmp')
@@ -86,13 +86,13 @@ context "Resque" do
     assert_equal 1, Resque.size(:ivar)
   end
 
-  test "jobs have a nice #inspect" do
+  it "jobs have a nice #inspect" do
     assert Resque::Job.create(:jobs, 'SomeJob', 20, '/tmp')
     job = Resque.reserve(:jobs)
     assert_equal '(Job{jobs} | SomeJob | [20, "/tmp"])', job.inspect
   end
 
-  test "jobs can be destroyed" do
+  it "jobs can be destroyed" do
     assert Resque::Job.create(:jobs, 'SomeJob', 20, '/tmp')
     assert Resque::Job.create(:jobs, 'BadJob', 20, '/tmp')
     assert Resque::Job.create(:jobs, 'SomeJob', 20, '/tmp')
@@ -106,21 +106,21 @@ context "Resque" do
     assert_equal 2, Resque.size(:jobs)
   end
 
-  test "jobs can test for equality" do
+  it "jobs can it for equality" do
     assert Resque::Job.create(:jobs, 'SomeJob', 20, '/tmp')
     assert Resque::Job.create(:jobs, 'some-job', 20, '/tmp')
     assert_equal Resque.reserve(:jobs), Resque.reserve(:jobs)
 
     assert Resque::Job.create(:jobs, 'SomeMethodJob', 20, '/tmp')
     assert Resque::Job.create(:jobs, 'SomeJob', 20, '/tmp')
-    assert_not_equal Resque.reserve(:jobs), Resque.reserve(:jobs)
+    refute_equal Resque.reserve(:jobs), Resque.reserve(:jobs)
 
     assert Resque::Job.create(:jobs, 'SomeJob', 20, '/tmp')
     assert Resque::Job.create(:jobs, 'SomeJob', 30, '/tmp')
-    assert_not_equal Resque.reserve(:jobs), Resque.reserve(:jobs)
+    refute_equal Resque.reserve(:jobs), Resque.reserve(:jobs)
   end
 
-  test "can put jobs on a queue by way of a method" do
+  it "can put jobs on a queue by way of a method" do
     assert_equal 0, Resque.size(:method)
     assert Resque.enqueue(SomeMethodJob, 20, '/tmp')
     assert Resque.enqueue(SomeMethodJob, 20, '/tmp')
@@ -136,7 +136,7 @@ context "Resque" do
     assert_equal nil, Resque.reserve(:method)
   end
 
-  test "can define a queue for jobs by way of a method" do
+  it "can define a queue for jobs by way of a method" do
     assert_equal 0, Resque.size(:method)
     assert Resque.enqueue_to(:new_queue, SomeMethodJob, 20, '/tmp')
 
@@ -146,31 +146,31 @@ context "Resque" do
     assert_equal '/tmp', job.args[1]
   end
 
-  test "needs to infer a queue with enqueue" do
+  it "needs to infer a queue with enqueue" do
     assert_raises Resque::NoQueueError do
       Resque.enqueue(SomeJob, 20, '/tmp')
     end
   end
 
-  test "validates job for queue presence" do
+  it "validates job for queue presence" do
     err = assert_raises Resque::NoQueueError do
       Resque.validate(SomeJob)
     end
     assert_match(/SomeJob/, err.message)
   end
 
-  test "can put items on a queue" do
+  it "can put items on a queue" do
     assert Resque.push(:people, { 'name' => 'jon' })
   end
 
-  test "can pull items off a queue" do
+  it "can pull items off a queue" do
     assert_equal({ 'name' => 'chris' }, Resque.pop(:people))
     assert_equal({ 'name' => 'bob' }, Resque.pop(:people))
     assert_equal({ 'name' => 'mark' }, Resque.pop(:people))
     assert_equal nil, Resque.pop(:people)
   end
 
-  test "knows how big a queue is" do
+  it "knows how big a queue is" do
     assert_equal 3, Resque.size(:people)
 
     assert_equal({ 'name' => 'chris' }, Resque.pop(:people))
@@ -181,12 +181,12 @@ context "Resque" do
     assert_equal 0, Resque.size(:people)
   end
 
-  test "can peek at a queue" do
+  it "can peek at a queue" do
     assert_equal({ 'name' => 'chris' }, Resque.peek(:people))
     assert_equal 3, Resque.size(:people)
   end
 
-  test "can peek multiple items on a queue" do
+  it "can peek multiple items on a queue" do
     assert_equal({ 'name' => 'bob' }, Resque.peek(:people, 1, 1))
 
     assert_equal([{ 'name' => 'bob' }, { 'name' => 'mark' }], Resque.peek(:people, 1, 2))
@@ -197,18 +197,18 @@ context "Resque" do
     assert_equal [], Resque.peek(:people, 3, 2)
   end
 
-  test "knows what queues it is managing" do
+  it "knows what queues it is managing" do
     assert_equal %w( people ), Resque.queues
     Resque.push(:cars, { 'make' => 'bmw' })
     assert_equal %w( cars people ).sort, Resque.queues.sort
   end
 
-  test "queues are always a list" do
+  it "queues are always a list" do
     Resque.redis.flushall
     assert_equal [], Resque.queues
   end
 
-  test "can delete a queue" do
+  it "can delete a queue" do
     Resque.push(:cars, { 'make' => 'bmw' })
     assert_equal %w( cars people ).sort, Resque.queues.sort
     Resque.remove_queue(:people)
@@ -216,17 +216,17 @@ context "Resque" do
     assert_equal nil, Resque.pop(:people)
   end
 
-  test "keeps track of resque keys" do
+  it "keeps track of resque keys" do
     assert_equal ["queue:people", "queues"].sort, Resque.keys.sort
   end
 
-  test "badly wants a class name, too" do
+  it "badly wants a class name, too" do
     assert_raises Resque::NoClassError do
       Resque::Job.create(:jobs, nil)
     end
   end
 
-  test "keeps stats" do
+  it "keeps stats" do
     Resque::Job.create(:jobs, SomeJob, 20, '/tmp')
     Resque::Job.create(:jobs, BadJob)
     Resque::Job.create(:jobs, GoodJob)
@@ -261,13 +261,13 @@ context "Resque" do
     end
   end
 
-  test "decode bad json" do
+  it "decode bad json" do
     assert_raises Resque::Helpers::DecodeException do
       Resque.decode("{\"error\":\"Module not found \\u002\"}")
     end
   end
 
-  test "inlining jobs" do
+  it "inlining jobs" do
     begin
       Resque.inline = true
       Resque.enqueue(SomeIvarJob, 20, '/tmp')
@@ -277,12 +277,12 @@ context "Resque" do
     end
   end
 
-  context "stats" do
-    setup do
+  describe "stats" do
+    before do
       Resque.redis.flushall
     end
 
-    test "queue_sizes with one queue" do
+    it "queue_sizes with one queue" do
       Resque.enqueue_to(:queue1, SomeJob)
 
       queue_sizes = Resque.queue_sizes
@@ -290,7 +290,7 @@ context "Resque" do
       assert_equal({ "queue1" => 1 }, queue_sizes)
     end
 
-    test "queue_sizes with two queue" do
+    it "queue_sizes with two queue" do
       Resque.enqueue_to(:queue1, SomeJob)
       Resque.enqueue_to(:queue2, SomeJob)
 
@@ -299,7 +299,7 @@ context "Resque" do
       assert_equal({ "queue1" => 1, "queue2" => 1, }, queue_sizes)
     end
 
-    test "queue_sizes with two queue with multiple jobs" do
+    it "queue_sizes with two queue with multiple jobs" do
       5.times { Resque.enqueue_to(:queue1, SomeJob) }
       9.times { Resque.enqueue_to(:queue2, SomeJob) }
 
@@ -308,7 +308,7 @@ context "Resque" do
       assert_equal({ "queue1" => 5, "queue2" => 9 }, queue_sizes)
     end
 
-    test "sample_queues with simple job with no args" do
+    it "sample_queues with simple job with no args" do
       Resque.enqueue_to(:queue1, SomeJob)
       queues = Resque.sample_queues
 
@@ -322,7 +322,7 @@ context "Resque" do
       assert_equal([], samples[0]['args'])
     end
 
-    test "sample_queues with simple job with args" do
+    it "sample_queues with simple job with args" do
       Resque.enqueue_to(:queue1, SomeJob, :arg1 => '1')
 
       queues = Resque.sample_queues
@@ -334,7 +334,7 @@ context "Resque" do
       assert_equal([{'arg1' => '1'}], samples[0]['args'])
     end
 
-    test "sample_queues with simple jobs" do
+    it "sample_queues with simple jobs" do
       Resque.enqueue_to(:queue1, SomeJob, :arg1 => '1')
       Resque.enqueue_to(:queue1, SomeJob, :arg1 => '2')
 
@@ -347,7 +347,7 @@ context "Resque" do
       assert_equal([{'arg1' => '2'}], samples[1]['args'])
     end
 
-    test "sample_queues with more jobs only returns sample size number of jobs" do
+    it "sample_queues with more jobs only returns sample size number of jobs" do
       11.times { Resque.enqueue_to(:queue1, SomeJob) }
 
       queues = Resque.sample_queues(10)

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 require 'tmpdir'
 
-context "Resque::Worker" do
-  setup do
+describe "Resque::Worker" do
+  before do
     Resque.redis.flushall
 
     Resque.before_first_fork = nil
@@ -13,34 +13,34 @@ context "Resque::Worker" do
     Resque::Job.create(:jobs, SomeJob, 20, '/tmp')
   end
 
-  test "can fail jobs" do
+  it "can fail jobs" do
     Resque::Job.create(:jobs, BadJob)
     @worker.work(0)
     assert_equal 1, Resque::Failure.count
   end
 
-  test "failed jobs report exception and message" do
+  it "failed jobs report exception and message" do
     Resque::Job.create(:jobs, BadJobWithSyntaxError)
     @worker.work(0)
     assert_equal('SyntaxError', Resque::Failure.all['exception'])
     assert_equal('Extra Bad job!', Resque::Failure.all['error'])
   end
 
-  test "does not allow exceptions from failure backend to escape" do
+  it "does not allow exceptions from failure backend to escape" do
     job = Resque::Job.new(:jobs, {})
     with_failure_backend BadFailureBackend do
       @worker.perform job
     end
   end
 
-  test "does not raise exception for completed jobs" do
+  it "does not raise exception for completed jobs" do
     without_forking do
       @worker.work(0)
     end
     assert_equal 0, Resque::Failure.count
   end
 
-  test "executes at_exit hooks when configured with run_at_exit_hooks" do
+  it "executes at_exit hooks when configured with run_at_exit_hooks" do
     tmpfile = File.join(Dir.tmpdir, "resque_at_exit_test_file")
     FileUtils.rm_f tmpfile
 
@@ -73,7 +73,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "should not treat SystemExit as an exception in the child with run_at_exit_hooks == true" do
+  it "should not treat SystemExit as an exception in the child with run_at_exit_hooks == true" do
 
     if worker_pid = Kernel.fork
       Process.waitpid(worker_pid)
@@ -92,7 +92,7 @@ context "Resque::Worker" do
   end
 
 
-  test "does not execute at_exit hooks by default" do
+  it "does not execute at_exit hooks by default" do
     tmpfile = File.join(Dir.tmpdir, "resque_at_exit_test_file")
     FileUtils.rm_f tmpfile
 
@@ -112,20 +112,20 @@ context "Resque::Worker" do
 
   end
 
-  test "does report failure for jobs with invalid payload" do
+  it "does report failure for jobs with invalid payload" do
     job = Resque::Job.new(:jobs, { 'class' => 'NotAValidJobClass', 'args' => '' })
     @worker.perform job
     assert_equal 1, Resque::Failure.count, 'failure not reported'
   end
 
-  test "register 'run_at' time on UTC timezone in ISO8601 format" do
+  it "register 'run_at' time on UTC timezone in ISO8601 format" do
     job = Resque::Job.new(:jobs, {'class' => 'GoodJob', 'args' => "blah"})
     now = Time.now.utc.iso8601
     @worker.working_on(job)
     assert_equal now, @worker.processing['run_at']
   end
 
-  test "fails uncompleted jobs with DirtyExit by default on exit" do
+  it "fails uncompleted jobs with DirtyExit by default on exit" do
     job = Resque::Job.new(:jobs, {'class' => 'GoodJob', 'args' => "blah"})
     @worker.working_on(job)
     @worker.unregister_worker
@@ -133,7 +133,7 @@ context "Resque::Worker" do
     assert_equal('Resque::DirtyExit', Resque::Failure.all['exception'])
   end
 
-  test "fails uncompleted jobs with worker exception on exit" do
+  it "fails uncompleted jobs with worker exception on exit" do
     job = Resque::Job.new(:jobs, {'class' => 'GoodJob', 'args' => "blah"})
     @worker.working_on(job)
     @worker.unregister_worker(StandardError.new)
@@ -151,7 +151,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "fails uncompleted jobs on exit, and calls failure hook" do
+  it "fails uncompleted jobs on exit, and calls failure hook" do
     job = Resque::Job.new(:jobs, {'class' => 'SimpleJobWithFailureHandling', 'args' => ""})
     @worker.working_on(job)
     @worker.unregister_worker
@@ -175,14 +175,14 @@ context "Resque::Worker" do
     end
   end
 
-  test "only calls failure hook once on exception" do
+  it "only calls failure hook once on exception" do
     job = Resque::Job.new(:jobs, {'class' => 'SimpleFailingJob', 'args' => ""})
     @worker.perform(job)
     assert_equal 1, Resque::Failure.count
     assert_equal 1, SimpleFailingJob.exception_count
   end
 
-  test "can peek at failed jobs" do
+  it "can peek at failed jobs" do
     10.times { Resque::Job.create(:jobs, BadJob) }
     @worker.work(0)
     assert_equal 10, Resque::Failure.count
@@ -190,7 +190,7 @@ context "Resque::Worker" do
     assert_equal 10, Resque::Failure.all(0, 20).size
   end
 
-  test "can clear failed jobs" do
+  it "can clear failed jobs" do
     Resque::Job.create(:jobs, BadJob)
     @worker.work(0)
     assert_equal 1, Resque::Failure.count
@@ -198,7 +198,7 @@ context "Resque::Worker" do
     assert_equal 0, Resque::Failure.count
   end
 
-  test "catches exceptional jobs" do
+  it "catches exceptional jobs" do
     Resque::Job.create(:jobs, BadJob)
     Resque::Job.create(:jobs, BadJob)
     @worker.process
@@ -207,7 +207,7 @@ context "Resque::Worker" do
     assert_equal 2, Resque::Failure.count
   end
 
-  test "supports setting the procline to have arbitrary prefixes and suffixes" do
+  it "supports setting the procline to have arbitrary prefixes and suffixes" do
     prefix = 'WORKER-TEST-PREFIX/'
     suffix = 'worker-test-suffix'
     ver = Resque::Version
@@ -231,13 +231,13 @@ context "Resque::Worker" do
     end
   end
 
-  test "strips whitespace from queue names" do
+  it "strips whitespace from queue names" do
     queues = "critical, high, low".split(',')
     worker = Resque::Worker.new(*queues)
     assert_equal %w( critical high low ), worker.queues
   end
 
-  test "can work on multiple queues" do
+  it "can work on multiple queues" do
     Resque::Job.create(:high, GoodJob)
     Resque::Job.create(:critical, GoodJob)
 
@@ -251,7 +251,7 @@ context "Resque::Worker" do
     assert_equal 0, Resque.size(:high)
   end
 
-  test "can work on all queues" do
+  it "can work on all queues" do
     Resque::Job.create(:high, GoodJob)
     Resque::Job.create(:critical, GoodJob)
     Resque::Job.create(:blahblah, GoodJob)
@@ -264,7 +264,7 @@ context "Resque::Worker" do
     assert_equal 0, Resque.size(:blahblah)
   end
 
-  test "can work with wildcard at the end of the list" do
+  it "can work with wildcard at the end of the list" do
     Resque::Job.create(:high, GoodJob)
     Resque::Job.create(:critical, GoodJob)
     Resque::Job.create(:blahblah, GoodJob)
@@ -279,7 +279,7 @@ context "Resque::Worker" do
     assert_equal 0, Resque.size(:beer)
   end
 
-  test "can work with wildcard at the middle of the list" do
+  it "can work with wildcard at the middle of the list" do
     Resque::Job.create(:high, GoodJob)
     Resque::Job.create(:critical, GoodJob)
     Resque::Job.create(:blahblah, GoodJob)
@@ -294,7 +294,7 @@ context "Resque::Worker" do
     assert_equal 0, Resque.size(:beer)
   end
 
-  test "processes * queues in alphabetical order" do
+  it "processes * queues in alphabetical order" do
     Resque::Job.create(:high, GoodJob)
     Resque::Job.create(:critical, GoodJob)
     Resque::Job.create(:blahblah, GoodJob)
@@ -311,7 +311,7 @@ context "Resque::Worker" do
     assert_equal %w( jobs high critical blahblah ).sort, processed_queues
   end
 
-  test "works with globs" do
+  it "works with globs" do
     Resque::Job.create(:critical, GoodJob)
     Resque::Job.create(:test_one, GoodJob)
     Resque::Job.create(:test_two, GoodJob)
@@ -324,17 +324,17 @@ context "Resque::Worker" do
     assert_equal 0, Resque.size(:test_two)
   end
 
-  test "has a unique id" do
+  it "has a unique id" do
     assert_equal "#{`hostname`.chomp}:#{$$}:jobs", @worker.to_s
   end
 
-  test "complains if no queues are given" do
+  it "complains if no queues are given" do
     assert_raises Resque::NoQueueError do
       Resque::Worker.new
     end
   end
 
-  test "fails if a job class has no `perform` method" do
+  it "fails if a job class has no `perform` method" do
     worker = Resque::Worker.new(:perform_less)
     Resque::Job.create(:perform_less, Object)
 
@@ -343,7 +343,7 @@ context "Resque::Worker" do
     assert_equal 1, Resque::Failure.count
   end
 
-  test "inserts itself into the 'workers' list on startup" do
+  it "inserts itself into the 'workers' list on startup" do
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
         assert_equal @worker, Resque.workers[0]
@@ -351,7 +351,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "removes itself from the 'workers' list on shutdown" do
+  it "removes itself from the 'workers' list on shutdown" do
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
         assert_equal @worker, Resque.workers[0]
@@ -361,7 +361,7 @@ context "Resque::Worker" do
     assert_equal [], Resque.workers
   end
 
-  test "removes worker with stringified id" do
+  it "removes worker with stringified id" do
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
         worker_id = Resque.workers[0].to_s
@@ -371,7 +371,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "records what it is working on" do
+  it "records what it is working on" do
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
         task = @worker.job
@@ -382,12 +382,12 @@ context "Resque::Worker" do
     end
   end
 
-  test "clears its status when not working on anything" do
+  it "clears its status when not working on anything" do
     @worker.work(0)
     assert_equal Hash.new, @worker.job
   end
 
-  test "knows when it is working" do
+  it "knows when it is working" do
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
         assert @worker.working?
@@ -395,12 +395,12 @@ context "Resque::Worker" do
     end
   end
 
-  test "knows when it is idle" do
+  it "knows when it is idle" do
     @worker.work(0)
     assert @worker.idle?
   end
 
-  test "knows who is working" do
+  it "knows who is working" do
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
         assert_equal [@worker], Resque.working
@@ -408,7 +408,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "keeps track of how many jobs it has processed" do
+  it "keeps track of how many jobs it has processed" do
     Resque::Job.create(:jobs, BadJob)
     Resque::Job.create(:jobs, BadJob)
 
@@ -419,7 +419,7 @@ context "Resque::Worker" do
     assert_equal 3, @worker.processed
   end
 
-  test "keeps track of how many failures it has seen" do
+  it "keeps track of how many failures it has seen" do
     Resque::Job.create(:jobs, BadJob)
     Resque::Job.create(:jobs, BadJob)
 
@@ -430,13 +430,13 @@ context "Resque::Worker" do
     assert_equal 2, @worker.failed
   end
 
-  test "stats are erased when the worker goes away" do
+  it "stats are erased when the worker goes away" do
     @worker.work(0)
     assert_equal 0, @worker.processed
     assert_equal 0, @worker.failed
   end
 
-  test "knows when it started" do
+  it "knows when it started" do
     time = Time.now
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
@@ -445,7 +445,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "knows whether it exists or not" do
+  it "knows whether it exists or not" do
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
         assert Resque::Worker.exists?(@worker)
@@ -454,7 +454,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "sets $0 while working" do
+  it "sets $0 while working" do
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
         prefix = ENV['RESQUE_PROCLINE_PREFIX']
@@ -464,7 +464,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "can be found" do
+  it "can be found" do
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
         found = Resque::Worker.find(@worker.to_s)
@@ -480,7 +480,7 @@ context "Resque::Worker" do
     end
   end
 
-  test 'can find others' do
+  it 'can find others' do
     without_forking do
       # inject fake worker
       other_worker = Resque::Worker.new(:other_jobs)
@@ -501,7 +501,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "doesn't find fakes" do
+  it "doesn't find fakes" do
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
         found = Resque::Worker.find('blah-blah')
@@ -510,7 +510,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "cleans up dead worker info on start (crash recovery)" do
+  it "cleans up dead worker info on start (crash recovery)" do
     # first we fake out several dead workers
     # 1: matches queue and hostname; gets pruned.
     workerA = Resque::Worker.new(:jobs)
@@ -550,18 +550,18 @@ context "Resque::Worker" do
     assert worker_strings.include?("#{`hostname`.chomp}-foo:4:high")
   end
 
-  test "worker_pids returns pids" do
+  it "worker_pids returns pids" do
     @worker.work(0)
     known_workers = @worker.worker_pids
     assert !known_workers.empty?
   end
 
-  test "Processed jobs count" do
+  it "Processed jobs count" do
     @worker.work(0)
     assert_equal 1, Resque.info[:processed]
   end
 
-  test "Will call a before_first_fork hook only once" do
+  it "Will call a before_first_fork hook only once" do
     Resque.redis.flushall
     $BEFORE_FORK_CALLED = 0
     Resque.before_first_fork = Proc.new { $BEFORE_FORK_CALLED += 1 }
@@ -578,7 +578,7 @@ context "Resque::Worker" do
     assert_equal 1, $BEFORE_FORK_CALLED
   end
 
-  test "Will call a before_pause hook before pausing" do
+  it "Will call a before_pause hook before pausing" do
     Resque.redis.flushall
     $BEFORE_PAUSE_CALLED = 0
     $WORKER_NAME = nil
@@ -591,7 +591,7 @@ context "Resque::Worker" do
     assert_equal workerA.to_s, $WORKER_NAME
   end
 
-  test "Will call a after_pause hook after pausing" do
+  it "Will call a after_pause hook after pausing" do
     Resque.redis.flushall
     $AFTER_PAUSE_CALLED = 0
     $WORKER_NAME = nil
@@ -604,7 +604,7 @@ context "Resque::Worker" do
     assert_equal workerA.to_s, $WORKER_NAME
   end
 
-  test "Will call a before_fork hook before forking" do
+  it "Will call a before_fork hook before forking" do
     Resque.redis.flushall
     $BEFORE_FORK_CALLED = false
     Resque.before_fork = Proc.new { $BEFORE_FORK_CALLED = true }
@@ -617,7 +617,7 @@ context "Resque::Worker" do
     assert $BEFORE_FORK_CALLED
   end
 
-  test "Will not call a before_fork hook when the worker cannot fork" do
+  it "Will not call a before_fork hook when the worker cannot fork" do
     Resque.redis.flushall
     $BEFORE_FORK_CALLED = false
     Resque.before_fork = Proc.new { $BEFORE_FORK_CALLED = true }
@@ -630,7 +630,7 @@ context "Resque::Worker" do
     assert !$BEFORE_FORK_CALLED, "before_fork should not have been called after job runs"
   end
 
-  test "Will not call a before_fork hook when forking set to false" do
+  it "Will not call a before_fork hook when forking set to false" do
     Resque.redis.flushall
     $BEFORE_FORK_CALLED = false
     Resque.before_fork = Proc.new { $BEFORE_FORK_CALLED = true }
@@ -645,28 +645,28 @@ context "Resque::Worker" do
     assert !$BEFORE_FORK_CALLED, "before_fork should not have been called after job runs"
   end
 
-  test "setting verbose to true" do
+  it "setting verbose to true" do
     @worker.verbose = true
 
     assert @worker.verbose
     assert !@worker.very_verbose
   end
 
-  test "setting verbose to false" do
+  it "setting verbose to false" do
     @worker.verbose = false
 
     assert !@worker.verbose
     assert !@worker.very_verbose
   end
 
-  test "setting very_verbose to true" do
+  it "setting very_verbose to true" do
     @worker.very_verbose = true
 
     assert !@worker.verbose
     assert @worker.very_verbose
   end
 
-  test "setting setting verbose to true and then very_verbose to false" do
+  it "setting setting verbose to true and then very_verbose to false" do
     @worker.very_verbose = true
     @worker.verbose      = true
     @worker.very_verbose = false
@@ -675,36 +675,28 @@ context "Resque::Worker" do
     assert !@worker.very_verbose
   end
 
-  test "verbose prints out logs" do
+  it "verbose prints out logs" do
     messages        = StringIO.new
     Resque.logger   = Logger.new(messages)
     @worker.verbose = true
 
-    begin
-      @worker.log("omghi mom")
-    ensure
-      reset_logger
-    end
+    @worker.log("omghi mom")
 
     assert_equal "*** omghi mom\n", messages.string
   end
 
-  test "unsetting verbose works" do
+  it "unsetting verbose works" do
     messages        = StringIO.new
     Resque.logger   = Logger.new(messages)
     @worker.verbose = true
     @worker.verbose = false
 
-    begin
-      @worker.log("omghi mom")
-    ensure
-      reset_logger
-    end
+    @worker.log("omghi mom")
 
     assert_equal "", messages.string
   end
 
-  test "very verbose works in the afternoon" do
+  it "very verbose works in the afternoon" do
     messages        = StringIO.new
     Resque.logger   = Logger.new(messages)
 
@@ -719,11 +711,10 @@ context "Resque::Worker" do
       assert_match /\*\* \[15:44:33 2011-03-02\] \d+: some log text/, messages.string
     ensure
       Time.fake_time = nil
-      reset_logger
     end
   end
 
-  test "won't fork if ENV['FORK_PER_JOB'] is false" do
+  it "won't fork if ENV['FORK_PER_JOB'] is false" do
     workerA = Resque::Worker.new(:jobs)
 
     if workerA.will_fork?
@@ -736,7 +727,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "Will call an after_fork hook after forking" do
+  it "Will call an after_fork hook after forking" do
     Resque.redis.flushall
 
     begin
@@ -755,7 +746,7 @@ context "Resque::Worker" do
     end
   end
 
-  test "Will not call an after_fork hook when the worker won't fork" do
+  it "Will not call an after_fork hook when the worker won't fork" do
     Resque.redis.flushall
     $AFTER_FORK_CALLED = false
     Resque.after_fork = Proc.new { $AFTER_FORK_CALLED = true }
@@ -768,11 +759,11 @@ context "Resque::Worker" do
     assert !$AFTER_FORK_CALLED
   end
 
-  test "returns PID of running process" do
+  it "returns PID of running process" do
     assert_equal @worker.to_s.split(":")[1].to_i, @worker.pid
   end
 
-  test "requeue failed queue" do
+  it "requeue failed queue" do
     queue = 'good_job'
     Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(queue), :queue => queue, :payload => {'class' => 'GoodJob'})
     Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(queue), :queue => 'some_job', :payload => {'class' => 'SomeJob'})
@@ -781,7 +772,7 @@ context "Resque::Worker" do
     assert !Resque::Failure.all(1).has_key?('retried_at')
   end
 
-  test "remove failed queue" do
+  it "remove failed queue" do
     queue = 'good_job'
     queue2 = 'some_job'
     Resque::Failure.create(:exception => Exception.new, :worker => Resque::Worker.new(queue), :queue => queue, :payload => {'class' => 'GoodJob'})
@@ -792,7 +783,7 @@ context "Resque::Worker" do
     assert_equal 1, Resque::Failure.count
   end
 
-  test "no reconnects to redis when not forking" do
+  it "no reconnects to redis when not forking" do
     original_connection = Resque.redis.client.connection.instance_variable_get("@sock")
     without_forking do
       @worker.work(0)
@@ -826,15 +817,15 @@ context "Resque::Worker" do
       ForkResultJob.perform_with_result(@worker, &block)
     end
 
-    test "reconnects to redis after fork" do
+    it "reconnects to redis after fork" do
       original_connection = Resque.redis.client.connection.instance_variable_get("@sock").object_id
       new_connection = run_in_job do
         Resque.redis.client.connection.instance_variable_get("@sock").object_id
       end
-      assert_not_equal original_connection, new_connection
+      refute_equal original_connection, new_connection
     end
 
-    test "tries to reconnect three times before giving up and the failure does not unregister the parent" do
+    it "tries to reconnect three times before giving up and the failure does not unregister the parent" do
       begin
         class Redis::Client
           alias_method :original_reconnect, :reconnect
@@ -865,7 +856,7 @@ context "Resque::Worker" do
       end
     end
 
-    test "tries to reconnect three times before giving up" do
+    it "tries to reconnect three times before giving up" do
       captured_worker = nil
       begin
         class Redis::Client
@@ -898,12 +889,8 @@ context "Resque::Worker" do
         end
 
         Resque.logger = DummyLogger.new
-        begin
-          @worker.work(0)
-          messages = Resque.logger.messages
-        ensure
-          reset_logger
-        end
+        @worker.work(0)
+        messages = Resque.logger.messages
 
         assert_equal 3, messages.grep(/retrying/).count
         assert_equal 1, messages.grep(/quitting/).count
@@ -926,7 +913,7 @@ context "Resque::Worker" do
       end
     end
 
-    test "will notify failure hooks when a job is killed by a signal" do
+    it "will notify failure hooks when a job is killed by a signal" do
       Resque.enqueue(SuicidalJob)
       suppress_warnings do
         @worker.work(0)


### PR DESCRIPTION
Make all test files use the same syntax. This helps the test output appear in a single place instead of split up by file.

@steveklabnik 