### PR TITLE
Restore 1.23.0 behavior and return block

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -539,9 +539,8 @@ module Resque
 
     @hooks ||= {}
     @hooks[name] ||= []
-
-    block = Array(block)
-    @hooks[name].concat(block)
+    @hooks[name] << block
+    return block
   end
 
   # Clear all hooks given a hook name.

--- a/test/resque_hook_test.rb
+++ b/test/resque_hook_test.rb
@@ -191,4 +191,14 @@ describe "Resque Hooks" do
       file2.delete
     end
   end
+
+  [:before_first_fork, :before_fork, :after_fork, :before_pause, :after_pause].each do |hook_name|
+    it "returns the block from #{hook_name}" do
+      result = Resque.public_send(hook_name) do
+        3 * 7
+      end
+      assert_equal result.call, 21
+    end
+  end
+
 end

--- a/test/resque_hook_test.rb
+++ b/test/resque_hook_test.rb
@@ -194,7 +194,7 @@ describe "Resque Hooks" do
 
   [:before_first_fork, :before_fork, :after_fork, :before_pause, :after_pause].each do |hook_name|
     it "returns the block from #{hook_name}" do
-      result = Resque.public_send(hook_name) do
+      result = Resque.send(hook_name) do
         3 * 7
       end
       assert_equal result.call, 21


### PR DESCRIPTION
Fix for #1074. Return the passed block for all of the hooks.

@steveklabnik 