### PR TITLE
Pull common test setup into main before

### DIFF
--- a/test/child_killing_test.rb
+++ b/test/child_killing_test.rb
@@ -44,11 +44,6 @@ describe "Resque::Worker" do
     assert !child_still_running
   end
 
-  before do
-    remaining_keys = Resque.redis.keys('sigterm-test:*') || []
-    Resque.redis.del(*remaining_keys) unless remaining_keys.empty?
-  end
-
   if !defined?(RUBY_ENGINE) || RUBY_ENGINE != "jruby"
     it "old signal handling just kills off the child" do
       worker_pid, child_pid, result = start_worker(0, false)

--- a/test/resque_hook_test.rb
+++ b/test/resque_hook_test.rb
@@ -2,16 +2,7 @@ require 'test_helper'
 require 'tempfile'
 
 describe "Resque Hooks" do
-  def cleanup
-    Resque.redis.flushall
-
-    Resque.before_first_fork = nil
-    Resque.before_fork = nil
-    Resque.after_fork = nil
-  end
-
   before do
-    cleanup
     @worker = Resque::Worker.new(:jobs)
 
     $called = false
@@ -21,10 +12,6 @@ describe "Resque Hooks" do
         $called = true
       end
     end
-  end
-
-  after do
-    cleanup
   end
 
   it 'retrieving hooks if none have been set' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,6 +47,10 @@ module MiniTest::Unit::LifecycleHooks
 
   def before_setup
     reset_logger
+    Resque.redis.flushall
+    Resque.before_first_fork = nil
+    Resque.before_fork = nil
+    Resque.after_fork = nil
   end
 
 end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -3,12 +3,6 @@ require 'tmpdir'
 
 describe "Resque::Worker" do
   before do
-    Resque.redis.flushall
-
-    Resque.before_first_fork = nil
-    Resque.before_fork = nil
-    Resque.after_fork = nil
-
     @worker = Resque::Worker.new(:jobs)
     Resque::Job.create(:jobs, SomeJob, 20, '/tmp')
   end
@@ -562,7 +556,6 @@ describe "Resque::Worker" do
   end
 
   it "Will call a before_first_fork hook only once" do
-    Resque.redis.flushall
     $BEFORE_FORK_CALLED = 0
     Resque.before_first_fork = Proc.new { $BEFORE_FORK_CALLED += 1 }
     workerA = Resque::Worker.new(:jobs)
@@ -579,7 +572,6 @@ describe "Resque::Worker" do
   end
 
   it "Will call a before_pause hook before pausing" do
-    Resque.redis.flushall
     $BEFORE_PAUSE_CALLED = 0
     $WORKER_NAME = nil
     Resque.before_pause = Proc.new { |w| $BEFORE_PAUSE_CALLED += 1; $WORKER_NAME = w.to_s; }
@@ -592,7 +584,6 @@ describe "Resque::Worker" do
   end
 
   it "Will call a after_pause hook after pausing" do
-    Resque.redis.flushall
     $AFTER_PAUSE_CALLED = 0
     $WORKER_NAME = nil
     Resque.after_pause = Proc.new { |w| $AFTER_PAUSE_CALLED += 1; $WORKER_NAME = w.to_s; }
@@ -605,7 +596,6 @@ describe "Resque::Worker" do
   end
 
   it "Will call a before_fork hook before forking" do
-    Resque.redis.flushall
     $BEFORE_FORK_CALLED = false
     Resque.before_fork = Proc.new { $BEFORE_FORK_CALLED = true }
     workerA = Resque::Worker.new(:jobs)
@@ -618,7 +608,6 @@ describe "Resque::Worker" do
   end
 
   it "Will not call a before_fork hook when the worker cannot fork" do
-    Resque.redis.flushall
     $BEFORE_FORK_CALLED = false
     Resque.before_fork = Proc.new { $BEFORE_FORK_CALLED = true }
     workerA = Resque::Worker.new(:jobs)
@@ -631,7 +620,6 @@ describe "Resque::Worker" do
   end
 
   it "Will not call a before_fork hook when forking set to false" do
-    Resque.redis.flushall
     $BEFORE_FORK_CALLED = false
     Resque.before_fork = Proc.new { $BEFORE_FORK_CALLED = true }
     workerA = Resque::Worker.new(:jobs)
@@ -728,8 +716,6 @@ describe "Resque::Worker" do
   end
 
   it "Will call an after_fork hook after forking" do
-    Resque.redis.flushall
-
     begin
       pipe_rd, pipe_wr = IO.pipe
 
@@ -747,7 +733,6 @@ describe "Resque::Worker" do
   end
 
   it "Will not call an after_fork hook when the worker won't fork" do
-    Resque.redis.flushall
     $AFTER_FORK_CALLED = false
     Resque.after_fork = Proc.new { $AFTER_FORK_CALLED = true }
     workerA = Resque::Worker.new(:jobs)


### PR DESCRIPTION
There were a few common pieces of test reset code sprinkled around the test files. I think it will make it easier to manage and add future tests if test authors don't need to worry about this common setup and instead it always happens before every test

@steveklabnik 