### PR TITLE
Documentation fix wrong repo name

### DIFF
--- a/examples/demo/README.markdown
+++ b/examples/demo/README.markdown
@@ -8,7 +8,7 @@ This is a dirt simple Resque setup for you to play with.
 
 Here's how to run the Sinatra app:
 
-    $ git clone git://github.com/defunkt/resque.git
+    $ git clone git://github.com/resque/resque.git
     $ cd resque/examples/demo
     $ rackup config.ru
     $ open http://localhost:9292/


### PR DESCRIPTION
Just a doc using defunkt repo instead of resque repo