### PR TITLE
Optimization to avoid unnecessary smembers calls

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -327,6 +327,7 @@ module Resque
     end
 
     def glob_match(pattern)
+      return [] unless ['*', '?', '{', '}', '[', ']'].any? {|char| pattern.include?(char) } #optimization to avoid Resque.queues call if no glob characters
       Resque.queues.select do |queue|
         File.fnmatch?(pattern, queue)
       end.sort

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -297,6 +297,14 @@ describe "Resque::Worker" do
     assert_equal 0, Resque.size(:high)
   end
 
+  it "queues method avoids unnecessary calls to smembers" do
+    Resque::Job.create(:high, GoodJob)
+    Resque::Job.create(:critical, GoodJob)
+    worker = Resque::Worker.new(:critical, :high)
+    Resque.redis.expects(:smembers).at_most_once
+    assert_equal ["critical", "high"], worker.queues
+  end
+
   it "can work on all queues" do
     Resque::Job.create(:high, GoodJob)
     Resque::Job.create(:critical, GoodJob)


### PR DESCRIPTION
In many Resque implementations, including my company's, the workers are given a hard-coded list of queues and do not use glob (aka `*`) matching.

In these cases, Resque still loops over each queue that the worker is listening on (which could be dozens) and then for each of them calls `Resque.queues` which triggers a `Resque.redis.smembers` call. This means that if there are 100 workers and they are listening on 10 queues, each, then we issue 1,000 `smembers` calls instead of the 0 that we need (because we already know which queues we are listening on and don't need to glob match). This can really impact the performance of the `Resque.redis` instance.

This PR adds an optimization to avoid making the `Resque.redis` call in the case that the `queue` does not contain any glob matching characters.

NOTE: There is probably a larger refactor I could do around how the `worker` stores which queues it is listening on which would be even more efficient.

Thoughts? @steveklabnik