### PR TITLE
Cache static queues to avoid extra reds calls from glob match

### DIFF
--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -297,6 +297,12 @@ describe "Resque::Worker" do
     assert_equal 0, Resque.size(:high)
   end
 
+  it "the queues method avoids unnecessary calls to smembers" do
+    worker = Resque::Worker.new(:critical, :high)
+    Resque.redis.expects(:smembers).at_most_once
+    assert_equal ["critical", "high"], worker.queues
+  end
+
   it "can work on all queues" do
     Resque::Job.create(:high, GoodJob)
     Resque::Job.create(:critical, GoodJob)


### PR DESCRIPTION
In many Resque implementations, including my company's, the workers are given a hard-coded list of queues and do not use glob (aka *) matching.

In these cases, Resque still loops over each queue that the worker is listening on (which could be dozens) and then for each of them calls Resque.queues which triggers a Resque.redis.smembers call. This means that if there are 100 workers and they are listening on 10 queues, each, then we issue 1,000 smembers calls instead of the 0 that we need (because we already know which queues we are listening on and don't need to glob match). This can really impact the performance of the Resque.redis instance.

This PR adds an optimization to avoid making the Resque.redis call in the case that the queue does not contain any glob matching characters.

(Better implementation of closed PR https://github.com/resque/resque/pull/1395/files)

@steveklabnik 