### PR TITLE
Deprecate repeated methods in Resque stdlib.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,9 @@
  * Add support for RESQUE_PROCLINE_PREFIX environment variable to prefix procline
    strings with a static identifier. (@rbroemeling)
 * Resque::Worker logs errors at the correct logging level (@chrisccerami)
+  * Deprecate repeated methods in Resque stdlib. These methods are all
+    provided by ActiveSupport, and will be removed in 2.0
+(@maclover7)
 
 ## 1.25.2 (2014-3-3)
 

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -1,6 +1,7 @@
 require 'mono_logger'
 require 'redis/namespace'
 require 'forwardable'
+require 'active_support/deprecation'
 
 require 'resque/version'
 
@@ -54,6 +55,7 @@ module Resque
   #
   # classify('job-name') # => 'JobName'
   def classify(dashed_word)
+    ActiveSupport::Deprecation.warn("This is deprecated and will be removed in Resque 2.0 with no replacement.")
     dashed_word.split('-').each { |part| part[0] = part[0].chr.upcase }.join
   end
 
@@ -75,6 +77,7 @@ module Resque
   #
   # NameError is raised when the constant is unknown.
   def constantize(camel_cased_word)
+    ActiveSupport::Deprecation.warn("This is deprecated and will be removed in Resque 2.0 with no replacement.")
     camel_cased_word = camel_cased_word.to_s
 
     if camel_cased_word.include?('-')

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -15,42 +15,50 @@ module Resque
     include Helpers
     extend Helpers
     def redis
+      ActiveSupport::Deprecation.warn("This is deprecated and will be removed in Resque 2.0 with no replacement.")
       Resque.redis
     end
 
     def self.redis
+      ActiveSupport::Deprecation.warn("This is deprecated and will be removed in Resque 2.0 with no replacement.")
       Resque.redis
     end
 
     # Given a Ruby object, returns a string suitable for storage in a
     # queue.
     def encode(object)
+      ActiveSupport::Deprecation.warn("This is deprecated and will be removed in Resque 2.0 with no replacement.")
       Resque.encode(object)
     end
 
     # Given a string, returns a Ruby object.
     def decode(object)
+      ActiveSupport::Deprecation.warn("This is deprecated and will be removed in Resque 2.0 with no replacement.")
       Resque.decode(object)
     end
 
     # Given a Ruby object, returns a string suitable for storage in a
     # queue.
     def self.encode(object)
+      ActiveSupport::Deprecation.warn("This is deprecated and will be removed in Resque 2.0 with no replacement.")
       Resque.encode(object)
     end
 
     # Given a string, returns a Ruby object.
     def self.decode(object)
+      ActiveSupport::Deprecation.warn("This is deprecated and will be removed in Resque 2.0.")
       Resque.decode(object)
     end
-    
+
     # Given a word with dashes, returns a camel cased version of it.
     def classify(dashed_word)
+      ActiveSupport::Deprecation.warn("This is deprecated and will be removed in Resque 2.0.")
       Resque.classify(dashed_word)
     end
 
     # Tries to find a constant with the name specified in the argument string
     def constantize(camel_cased_word)
+      ActiveSupport::Deprecation.warn("This is deprecated and will be removed in Resque 2.0.")
       Resque.constantize(camel_cased_word)
     end
 

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sinatra", ">= 0.9.2"
   s.add_dependency "multi_json", "~> 1.0"
   s.add_dependency "mono_logger", "~> 1.0"
+  s.add_dependency "activesupport", "~> 3.0"
 
   s.description = <<description
     Resque is a Redis-backed Ruby library for creating background jobs,


### PR DESCRIPTION
All of these methods are all provided by ActiveSupport, and will be removed in 2.0. In v2.0, the methods in Resque::Helpers should be converted to use `ActiveSupport`. These methods should be standardized in one location, and not spread out throughout the whole codebase.

cc @steveklabnik 