### PR TITLE
Add SIGHUP because golang (and therefore docker) can't forward SIGCONT

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -435,6 +435,7 @@ Resque workers respond to a few different signals:
 * `USR1` - Immediately kill child but don't exit
 * `USR2` - Don't start to process any new jobs
 * `CONT` - Start to process new jobs again after a USR2
+* `HUP` - Start to process new jobs again after a USR2
 
 If you want to gracefully shutdown a Resque worker, use `QUIT`.
 
@@ -446,7 +447,7 @@ If you want to kill a stale or stuck child and shutdown, use `TERM`
 
 If you want to stop processing jobs, but want to leave the worker running
 (for example, to temporarily alleviate load), use `USR2` to stop processing,
-then `CONT` to start it again.
+then `CONT` or `HUP` to start it again.
 
 ### Mysql::Error: MySQL server has gone away
 

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -223,7 +223,7 @@ module Resque
   end
 
   # The `after_pause` hook will be run in the parent process after the
-  # worker has paused (via SIGCONT).
+  # worker has paused (via SIGCONT or SIGHUP).
   def after_pause(&block)
     block ? register_hook(:after_pause, block) : hooks(:after_pause)
   end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -383,6 +383,7 @@ module Resque
     # USR1: Kill the forked child immediately, continue processing jobs.
     # USR2: Don't process any new jobs
     # CONT: Start processing jobs again after a USR2
+    # HUP: Start processing jobs again after a USR2
     def register_signal_handlers
       trap('TERM') { graceful_term ? shutdown : shutdown!  }
       trap('INT')  { shutdown!  }
@@ -396,8 +397,9 @@ module Resque
         end
         trap('USR2') { pause_processing }
         trap('CONT') { unpause_processing }
+        trap('HUP') { unpause_processing }
       rescue ArgumentError
-        log_with_severity :warn, "Signals QUIT, USR1, USR2, and/or CONT not supported."
+        log_with_severity :warn, "Signals QUIT, USR1, USR2, and/or CONT/HUP not supported."
       end
 
       log_with_severity :debug, "Registered signals"


### PR DESCRIPTION
This is a (rebased) cherry-pick of https://github.com/Shopify/resque/commit/96f4ddb80f5842d6f43323f0076a2f9cdcb22b33 and a work-around for https://github.com/golang/go/issues/8953 (https://go-review.googlesource.com/#/c/18185/).

This PR effectively makes SIGHUP an alias of SIGCONT, so that we can actually use this functionality with Docker. This can be removed at some point in the future (who knows when), but since the upstream golang change is pretty recent, I think it might be worth it to merge it for now.

Ping @burke @steveklabnik @dylanahsmith for review.

Probably should ping someone (?) from Docker in case anyone cares or has similar problems with other applications that also want to use SIGCONT? cc @jfrazelle