### PR TITLE
job.hooks array instead of hash

### DIFF
--- a/lib/resque/plugin.rb
+++ b/lib/resque/plugin.rb
@@ -31,7 +31,7 @@ module Resque
     # Given an object, and a method prefix, returns a list of methods prefixed
     # with that name (hook names).
     def get_hook_names(job, hook_method_prefix)
-      methods = (job.respond_to?(:hooks) && job.hooks.keys) || job_methods(job)
+      methods = (job.respond_to?(:hooks) && job.hooks) || job_methods(job)
       methods.select{|m| m.start_with?(hook_method_prefix)}.sort
     end
 

--- a/test/plugin_test.rb
+++ b/test/plugin_test.rb
@@ -18,6 +18,16 @@ describe "Resque::Plugin finding hooks" do
     def on_failure2; end
   end
 
+  module HookBlacklistJob
+    extend self
+    def around_perform_blacklisted; end
+    def around_perform_ok; end
+
+    def hooks
+      @hooks ||= Resque::Plugin.job_methods(self) - ['around_perform_blacklisted']
+    end
+  end
+
   it "before_perform hooks are found and sorted" do
     assert_equal ["before_perform", "before_perform1", "before_perform2"], Resque::Plugin.before_hooks(SimplePlugin).map {|m| m.to_s}
   end
@@ -32,6 +42,10 @@ describe "Resque::Plugin finding hooks" do
 
   it "on_failure hooks are found and sorted" do
     assert_equal ["on_failure", "on_failure1", "on_failure2"], Resque::Plugin.failure_hooks(SimplePlugin).map {|m| m.to_s}
+  end
+
+  it 'uses job.hooks if available get hook methods' do
+    assert_equal ['around_perform_ok'], Resque::Plugin.around_hooks(HookBlacklistJob)
   end
 end
 


### PR DESCRIPTION
I think this might be a bug that was accidentally introduced in https://github.com/resque/resque/commit/62ca48d521062cf703d4daa94cece8f930a46a10. In fact, the original PR (https://github.com/resque/resque/pull/508/) did it this way. I see no reason why it should be an array (the values are never used as far as I can tell, only the keys).

But maybe I'm missing something?

<s>Also, no tests :-(</s>

@steveklabnik @dylanahsmith @jeznet 