### PR TITLE
Fix leaky tests and use proper stubs

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -622,6 +622,10 @@ module Resque
       end
     end
 
+    def kill_background_threads
+      @heart.kill if @heart
+    end
+
     # Unregisters ourself as a worker. Useful when shutting down.
     def unregister_worker(exception = nil)
       # If we're still processing a job, make sure it gets logged as a
@@ -638,7 +642,7 @@ module Resque
         end
       end
 
-      @heart.kill if @heart
+      kill_background_threads
 
       redis.pipelined do
         redis.srem(:workers, self)


### PR DESCRIPTION
https://github.com/resque/resque/pull/1380 introduced a background thread to the Worker class in order to do heartbeats. However, this thread is sometimes not cleaned up in the tests (only if `unregister_worker` is called) and keeps running, thus potentially leaking state into other tests or causing deadlocks (we saw this already while trying to figure out why the tests in https://github.com/resque/resque/pull/1410 fail sporadically).

This PR fixes that by always killing the threads after each test. Not the most bullet-proof method but works for now (suggestions welcome). Also, replace some ghetto instance method monkey-patching with a simple `stubs`.

@csfrancis @steveklabnik, please review