### PR TITLE
Add check encoding to UTF8Util::clean!

### DIFF
--- a/lib/resque/vendor/utf8_util/utf8_util_19.rb
+++ b/lib/resque/vendor/utf8_util/utf8_util_19.rb
@@ -1,5 +1,6 @@
 module UTF8Util
   def self.clean!(str)
+    return str if str.encoding.to_s == "UTF-8"
     str.force_encoding("binary").encode("UTF-8", :invalid => :replace, :undef => :replace, :replace => REPLACEMENT_CHAR)
   end
 end


### PR DESCRIPTION
Current version of [UTF8Util::clean!](https://github.com/resque/resque/blob/1-x-stable/lib/resque/vendor/utf8_util/utf8_util_19.rb#L2) replaces all not ASCII-8BIT characters to "?". It brings problems with logging UTF-8 strings, that contain not only ASCII-8BIT. Also that logic contradicts to description above [UTF8Util::clean](https://github.com/resque/resque/blob/1-x-stable/lib/resque/vendor/utf8_util.rb#L13):

>   # Replace invalid UTF-8 character sequences with a replacement character

You can reproduce problem with next steps:

```ruby
2.2.1 :001 > require 'resque'
 => true
2.2.1 :002 > str = "Error: какая-то ошибка"
 => "Error: какая-то ошибка"
2.2.1 :003 > str.encoding
 => #<Encoding:UTF-8>
2.2.1 :004 > UTF8Util::clean!(str)
 => "Error: ??????????-???? ????????????"
```

Here in correct UTF-8 string, all not ASCII-8BIT characters replaced by "?".

Simple solution - not to do encoding converting for UTF-8 strings.

If anyone have thoughts how to improve solution - I will glad to hear that and ready to improve PR.
