### PR TITLE
Add Coveralls to 1-x-stable branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ gem "minitest", "4.7.0"
 gem "mocha", :require => false
 gem "rack-test", "~> 0.5"
 gem "rake"
+gem "coveralls", :require => false

--- a/Gemfiles/Gemfile.1.8.7
+++ b/Gemfiles/Gemfile.1.8.7
@@ -10,6 +10,10 @@ group :test do
   gem "minitest", "4.7.0"
   gem "json"
   gem 'redis', '~> 3.0.0', '< 3.0.7'
+
+  gem 'coveralls', :require => false
+  gem 'mime-types', '~> 1.25.1', :require => false
+  gem 'rest-client', '~> 1.6.9', :require => false
 end
 
 gemspec :path => "../"

--- a/Gemfiles/Gemfile.1.8.7.lock
+++ b/Gemfiles/Gemfile.1.8.7.lock
@@ -18,9 +18,18 @@ GEM
       builder
       multi_json
     builder (3.2.2)
+    coveralls (0.8.10)
+      json (~> 1.8)
+      rest-client (>= 1.6.8, < 2)
+      simplecov (~> 0.11.0)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.1)
+      tins (~> 1.6.0)
+    docile (1.1.5)
     i18n (0.6.11)
     json (1.8.3)
     metaclass (0.0.4)
+    mime-types (1.25.1)
     minitest (4.7.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
@@ -35,11 +44,22 @@ GEM
     redis (3.0.6)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    rest-client (1.6.9)
+      mime-types (~> 1.16)
+    simplecov (0.11.2)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    term-ansicolor (1.3.2)
+      tins (~> 1.0)
+    thor (0.19.1)
     tilt (2.0.1)
+    tins (1.6.0)
     vegas (0.1.11)
       rack (>= 1.0.0)
 
@@ -49,14 +69,14 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 3.0)
   airbrake (= 4.3.2)
+  coveralls
   i18n (~> 0.6.0)
   json
+  mime-types (~> 1.25.1)
   minitest (= 4.7.0)
   mocha
   rack-test (~> 0.5)
   rake
   redis (~> 3.0.0, < 3.0.7)
   resque!
-
-BUNDLED WITH
-   1.10.6
+  rest-client (~> 1.6.9)

--- a/README.markdown
+++ b/README.markdown
@@ -3,6 +3,7 @@ Resque
 
 [![Gem Version](https://badge.fury.io/rb/resque.svg)](https://rubygems.org/gems/resque)
 [![Build Status](https://travis-ci.org/resque/resque.svg)](https://travis-ci.org/resque/resque)
+[![Coverage Status](https://coveralls.io/repos/github/resque/resque/badge.svg?branch=1-x-stable)](https://coveralls.io/r/resque/resque?branch=1-x-stable)
 
 Resque (pronounced like "rescue") is a Redis-backed library for creating
 background jobs, placing those jobs on multiple queues, and processing

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,9 @@ require 'redis/namespace'
 
 require 'mocha/setup'
 
+require 'coveralls'
+Coveralls.wear!
+
 $dir = File.dirname(File.expand_path(__FILE__))
 $LOAD_PATH.unshift $dir + '/../lib'
 ENV['TERM_CHILD'] = "1"


### PR DESCRIPTION
This has been in master for years, so seems like a no-brainer to add it here if this is eventually going to be the new master.