### PR TITLE
Improve the command to determine the worker pids.

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -793,7 +793,7 @@ module Resque
     # Find Resque worker pids on Linux and OS X.
     #
     def linux_worker_pids
-      `ps -A -o pid,command | grep -E "[r]esque:work|[r]esque-\\d" | grep -v "resque-web"`.split("\n").map do |line|
+      `ps -A -o pid,command | grep -E "[r]esque:work|[r]esque-[0-9]" | grep -v "resque-web"`.split("\n").map do |line|
         line.split(' ')[0]
       end
     end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -793,7 +793,7 @@ module Resque
     # Find Resque worker pids on Linux and OS X.
     #
     def linux_worker_pids
-      `ps -A -o pid,command | grep "[r]esque" | grep -v "resque-web"`.split("\n").map do |line|
+      `ps -A -o pid,command | grep "[r]esque-\\d" | grep -v "resque-web"`.split("\n").map do |line|
         line.split(' ')[0]
       end
     end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -793,7 +793,7 @@ module Resque
     # Find Resque worker pids on Linux and OS X.
     #
     def linux_worker_pids
-      `ps -A -o pid,command | grep "[r]esque-\\d" | grep -v "resque-web"`.split("\n").map do |line|
+      `ps -A -o pid,command | grep -E "[r]esque:work|[r]esque-\\d" | grep -v "resque-web"`.split("\n").map do |line|
         line.split(' ')[0]
       end
     end


### PR DESCRIPTION
The old command also returns the pids of other processes. In particular, it returns the pid of resque-scheduler (https://github.com/resque/resque-scheduler) and of rake tasks with a "resque:" prefix.

This change additionally checks for a dash and a number (the version number) to fix the problem.