### PR TITLE
Exclude files in `test` directory for Coveralls test coverage

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,7 @@
+require 'simplecov'
+require 'coveralls'
+
+SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+SimpleCov.start do
+   add_filter 'test'
+end


### PR DESCRIPTION
Coveralls seems to be analyzing test coverage of files in the `test` directory and this should not be the case. This PR excludes these files from coverage analysis.