### PR TITLE
Avoid N+1 query by caching job in Worker instance

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -78,7 +78,9 @@ module Resque
       end
 
       reportedly_working.keys.map do |key|
-        find(key.sub("worker:", ''), :skip_exists => true)
+        worker = find(key.sub("worker:", ''), :skip_exists => true)
+        worker.job = worker.decode(reportedly_working[key])
+        worker
       end.compact
     end
 
@@ -716,9 +718,11 @@ module Resque
     end
 
     # Returns a hash explaining the Job we're currently processing, if any.
-    def job
-      decode(redis.get("worker:#{self}")) || {}
+    def job(reload = true)
+      @job = nil if reload
+      @job ||= decode(redis.get("worker:#{self}")) || {}
     end
+    attr_writer :job
     alias_method :processing, :job
 
     # Boolean - true if working, false if not

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -464,6 +464,20 @@ describe "Resque::Worker" do
     end
   end
 
+  it "caches the current job iff reloading is disabled" do
+    without_forking do
+      @worker.extend(AssertInWorkBlock).work(0) do
+        first_instance = @worker.job
+        second_instance = @worker.job
+        refute_equal first_instance.object_id, second_instance.object_id
+
+        first_instance = @worker.job(false)
+        second_instance = @worker.job(false)
+        assert_equal first_instance.object_id, second_instance.object_id
+      end
+    end
+  end
+
   it "keeps track of how many jobs it has processed" do
     Resque::Job.create(:jobs, BadJob)
     Resque::Job.create(:jobs, BadJob)


### PR DESCRIPTION
This is essentially https://github.com/Shopify/resque/pull/11.

The problem that we run into is that we call `Reqsue::Worker.working` (at which point we already know all of the jobs, since they are part of the serialization that we already fetched from the Redis server). Then, later, for each of those working workers, we call `#job`, which fetches the current job again with an additional Redis call.

This PR adds an optional flag to the `#job` method that allows you to avoid this kind of N+1 query and use the cached previous value. The default is to not do that, so this should be backwards compatible.

Thoughts?

@Sirupsen @steveklabnik 