### PR TITLE
Fix regression

### DIFF
--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -56,7 +56,7 @@ module Resque
         classes.first.requeue(*args)
       end
 
-      def self.remove(index)
+      def self.remove(index, queue)
         classes.each { |klass| klass.remove(index) }
       end
     end


### PR DESCRIPTION
reported here: https://github.com/resque/resque/pull/1374#issuecomment-172924862

This seems like a straightforward fix: the methods had different signatures. Since this proxies everything to the first backend, adding the param and ignoring it _should_ fix it, I think.

@lukeasrodgers can you maybe try with this patch and see if it fixes said regression? That would be very awesome. I' going to do my own investigation as well...