### PR TITLE
notify_or_ignore is gone in v5

### DIFF
--- a/lib/resque/failure/airbrake.rb
+++ b/lib/resque/failure/airbrake.rb
@@ -21,7 +21,7 @@ module Resque
       end
 
       def save
-        ::Airbrake.notify_or_ignore(exception,
+        ::Airbrake.notify(exception,
             :parameters => {
             :payload_class => payload['class'].to_s,
             :payload_args => payload['args'].inspect

--- a/test/airbrake_test.rb
+++ b/test/airbrake_test.rb
@@ -16,7 +16,7 @@ if defined? Airbrake
       queue = "test"
       payload = {'class' => Object, 'args' => 66}
 
-      Airbrake.expects(:notify_or_ignore).with(
+      Airbrake.expects(:notify).with(
         exception,
         :parameters => {:payload_class => 'Object', :payload_args => '66'})
 


### PR DESCRIPTION
Updated my airbrake earlier this week and my jobs all immediately started failing due to this change: https://github.com/airbrake/airbrake/blob/23457a14144013959ffc4f54683238929e30f908/docs/Migration_guide_from_v4_to_v5.md#notify-or-ignore