### PR TITLE
adds rails 4 installation instruction

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -687,7 +687,7 @@ Don't forget you can define a `resque:setup` hook in
 `lib/tasks/whatever.rake` that loads the `environment` task every time.
 
 
-### In a Rails 3 app, as a gem
+### In a Rails 3.x or 4.x app, as a gem
 
 First include it in your Gemfile.
 


### PR DESCRIPTION
This is a small addition, but I believe that if you're new to the gem (I'm not) and you don't see a Rails 4 installation, you'll probably move on. 