### PR TITLE
Fix race condition on worker startup

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -797,7 +797,7 @@ module Resque
     # Find Resque worker pids on Linux and OS X.
     #
     def linux_worker_pids
-      `ps -A -o pid,command | grep -E "[r]esque:work|[r]esque-[0-9]" | grep -v "resque-web"`.split("\n").map do |line|
+      `ps -A -o pid,command | grep -E "[r]esque:work|[r]esque:\sStarting|[r]esque-[0-9]" | grep -v "resque-web"`.split("\n").map do |line|
         line.split(' ')[0]
       end
     end


### PR DESCRIPTION
Commit 6a0746ccd7307c2caebfe8cb6170d8f8c0c55067 improved detection of
worker pids on the same host but was missing one of the valid state
a worker can be in on startup. As a result sometimes the first worker
would be unregistered by other workers starting shortly after.