### PR TITLE
worker: do not trigger verbose logging if env variables are not set

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -127,8 +127,9 @@ module Resque
       @paused = nil
       @before_first_fork_hook_ran = false
 
-      self.verbose = ENV['LOGGING'] || ENV['VERBOSE']
-      self.very_verbose = ENV['VVERBOSE']
+      verbose_value = ENV['LOGGING'] || ENV['VERBOSE']
+      self.verbose = verbose_value if verbose_value
+      self.very_verbose = ENV['VVERBOSE'] if ENV['VVERBOSE']
       self.term_timeout = ENV['RESQUE_TERM_TIMEOUT'] || 4.0
       self.term_child = ENV['TERM_CHILD']
       self.graceful_term = ENV['GRACEFUL_TERM']

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -824,6 +824,26 @@ describe "Resque::Worker" do
     end
   end
 
+  it "keeps a custom logger state after a new worker is instantiated if there is no verbose options" do
+    messages                = StringIO.new
+    custom_logger           = Logger.new(messages)
+    custom_logger.level     = Logger::FATAL
+    custom_formatter        = proc do |severity, datetime, progname, msg|
+      formatter.call(severity, datetime, progname, msg.dump)
+    end
+    custom_logger.formatter = custom_formatter
+
+    Resque.logger = custom_logger
+
+    ENV.delete 'VERBOSE'
+    ENV.delete 'VVERBOSE'
+    @worker = Resque::Worker.new(:jobs)
+
+    assert_equal custom_logger, Resque.logger
+    assert_equal Logger::FATAL, Resque.logger.level
+    assert_equal custom_formatter, Resque.logger.formatter
+  end
+
   it "won't fork if ENV['FORK_PER_JOB'] is false" do
     workerA = Resque::Worker.new(:jobs)
 


### PR DESCRIPTION
When setting a custom logger the logger state is lost due to a regression added in the following commit:

,----
| commit 87ae6d5e1cd6ebc498dc0a04ada74dc770c7facf
| Author: Jacob Green <jacob@nationbuilder.com>
| Date:   Mon Jan 25 11:22:17 2016 -0500
|
|     Refactor worker#initialize
`----

The verbose and very_verbose setter methods are always called, even when no verbose environment variables are set. This makes a custom logger loose its level or custom formatter.