### PR TITLE
Move Coveralls.wear! to top of test_helper.rb

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,11 @@
+require 'coveralls'
+Coveralls.wear!
+
 require 'rubygems'
 require 'bundler/setup'
 require 'minitest/autorun'
 require 'redis/namespace'
-
 require 'mocha/setup'
-
-require 'coveralls'
-Coveralls.wear!
 
 $dir = File.dirname(File.expand_path(__FILE__))
 $LOAD_PATH.unshift $dir + '/../lib'


### PR DESCRIPTION
From the Coveralls documentation:

```
Note: The Coveralls.wear! must occur before any of your 
application code is required, so should be at the very top 
of your spec_helper.rb, test_helper.rb, or env.rb, etc.
```

This causes `coverage/.last_run.json` to go from:

```json
{
  "result": {
    "covered_percent": 34.42
  }
}
```

to:

```json
{
  "result": {
    "covered_percent": 81.85
  }
}
```

This fixes #1432