### PR TITLE
Initializing a worker should not write the PID file or re-daemonize

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,9 @@
 
 None yet!
 
+* Fix issue where calling Worker.find, Worker.all, or Worker.working from withing
+  a running job would rewrite the PID file with the PID of the forked worker. (@jeremywadsack)
+
 ## 1.26.0 (2016-03-10)
 
 This changelog is a bit incomplete. We will be much stricter about the changelog for

--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -15,6 +15,7 @@ namespace :resque do
       abort "set QUEUE env var, e.g. $ QUEUE=critical,high rake resque:work"
     end
 
+    worker.prepare
     worker.log "Starting worker #{self}"
     worker.work(ENV['INTERVAL'] || 5) # interval, will block
   end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -124,6 +124,9 @@ module Resque
     # If passed a single "*", this Worker will operate on all queues
     # in alphabetical order. Queues can be dynamically added or
     # removed without needing to restart workers using this method.
+    #
+    # Workers should have `#prepare` called after they are initialized
+    # if you are running work on the worker.
     def initialize(*queues)
       @shutdown = nil
       @paused = nil
@@ -137,6 +140,13 @@ module Resque
       self.graceful_term = ENV['GRACEFUL_TERM']
       self.run_at_exit_hooks = ENV['RUN_AT_EXIT_HOOKS']
 
+      self.queues = queues
+    end
+
+    # Daemonizes the worker if ENV['BACKGROUND'] is set and writes
+    # the process id to ENV['PIDFILE'] if set. Should only be called
+    # once per worker.
+    def prepare
       if ENV['BACKGROUND']
         unless Process.respond_to?('daemon')
             abort "env var BACKGROUND is set, which requires ruby >= 1.9"
@@ -148,8 +158,6 @@ module Resque
       if ENV['PIDFILE']
         File.open(ENV['PIDFILE'], 'w') { |f| f << pid }
       end
-
-      self.queues = queues
     end
 
     def queues=(queues)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -253,3 +253,26 @@ def without_forking
     ENV['FORK_PER_JOB'] = orig_fork_per_job
   end
 end
+
+def with_pidfile
+  old_pidfile = ENV["PIDFILE"]
+  begin
+    file = Tempfile.new("pidfile")
+    file.close
+    ENV["PIDFILE"] = file.path
+    yield
+  ensure
+    file.unlink if file
+    ENV["PIDFILE"] = old_pidfile
+  end
+end
+
+def with_background
+  old_background = ENV["BACKGROUND"]
+  begin
+    ENV["BACKGROUND"] = "true"
+    yield
+  ensure
+    ENV["BACKGROUND"] = old_background
+  end
+end


### PR DESCRIPTION
Class methods like `::find` (and those that depend on it, like `::all` and `::working`) call `#new` to create new instances of the worker objects. If these methods are called from within the forked object it would cause `#initialize` to rewrite the `PIDFILE` or (possibly?) re-daemonize the process. 

This resolves that by making a separate method called by the rake task when starting a worker.

See #1446. I have run this in our environment and looks like it resolves the issue, although I want to monitor it some more to ensure this is the correct fix.

I have two concerns about this and could use some suggestions from someone more familiar with the code base:

1. Is it a problem that we are now daemonizing (if `ENV["BACKGROUND"]` is set) _after_ we assign the queues? I don't use this approach so I'm not familiar with how it works.

2. I created the new `#prepare` method that handles these which requires the rake task to call that explicitly. I think this is a good idea because then the consumer can decide whether to perform these actions. I considered having the `#work` method automatically call `#prepare` if it had not been called before which would make this an implicit call. But I think that hides too much magic (which could lead to further issues like this), adds complexity, and delays these two actions later in the start up which could also be a problem. Feedback on my approach, though, is appreciated.