### PR TITLE
Explicit require tilt/erubis.

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -1,5 +1,5 @@
 require 'sinatra/base'
-require 'erb'
+require 'tilt/erb'
 require 'resque'
 require 'resque/version'
 require 'time'


### PR DESCRIPTION
This change will make disappear the following warning message on threaded environments like Puma.
> WARN: tilt autoloading 'tilt/erubis' in a non thread-safe way; explicit require 'tilt/erubis' suggested.