### PR TITLE
Remove fullstop from Admin title

### DIFF
--- a/lib/resque/server/views/layout.erb
+++ b/lib/resque/server/views/layout.erb
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Resque.</title>
+  <title>Resque</title>
   <link href="<%=u 'reset.css' %>" media="screen" rel="stylesheet" type="text/css">
   <link href="<%=u 'style.css' %>" media="screen" rel="stylesheet" type="text/css">
   <script src="<%=u 'jquery-1.3.2.min.js' %>" type="text/javascript"></script>


### PR DESCRIPTION
This has always really minorly annoyed me. Any reason for that full stop in the title bar?