### PR TITLE
Use flag to stop heartbeat thread rather than Thread.kill

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -504,9 +504,15 @@ module Resque
 
     def start_heartbeat
       heartbeat!
+
+      @stop_heartbeat_thread = false
       @heart = Thread.new do
-        loop do
-          sleep(Resque.heartbeat_interval)
+        until @stop_heartbeat_thread do
+          Resque.heartbeat_interval.times do
+            sleep(1)
+            break if @stop_heartbeat_thread
+          end
+
           heartbeat!
         end
       end
@@ -628,7 +634,7 @@ module Resque
     end
 
     def kill_background_threads
-      @heart.kill if @heart
+      @stop_heartbeat_thread = true if @heart
     end
 
     # Unregisters ourself as a worker. Useful when shutting down.


### PR DESCRIPTION
I was reading the code for heartbeats (which, btw, ❤️) and noticed that it uses `Thread.kill` to stop the heartbeat thread when Resque is exiting. While I've not observed a problem in production with this approach, I'm aware that it's [not a safe thing to do in general](http://blog.headius.com/2008/02/ruby-threadraise-threadkill-timeoutrb.html).

I figured it wouldn't hurt to switch to exiting the loop (and therefore the thread) when a variable is set, rather than calling `kill` on the thread.

I've tested this locally, and it seems to start/stop just fine.