### PR TITLE
Add requeue_all to Redis::Failure::Multiple

### DIFF
--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -56,6 +56,10 @@ module Resque
         classes.first.requeue(*args)
       end
 
+      def self.requeue_all
+        classes.first.requeue_all
+      end
+
       def self.remove(index, queue)
         classes.each { |klass| klass.remove(index) }
       end

--- a/test/resque_failure_multiple_test.rb
+++ b/test/resque_failure_multiple_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+require 'resque/failure/multiple'
+
+describe "Resque::Failure::Multiple" do
+
+  it 'requeue_all and does not raise an exception' do
+    with_failure_backend(Resque::Failure::Multiple) do
+      Resque::Failure::Multiple.classes = [Resque::Failure::Redis]
+      exception = StandardError.exception('some error')
+      worker = Resque::Worker.new(:test)
+      payload = { "class" => Object, "args" => 3 }
+      Resque::Failure.create({:exception => exception, :worker => worker, :queue => "queue", :payload => payload})
+      Resque::Failure::Multiple.requeue_all # should not raise an error
+    end
+  end
+end


### PR DESCRIPTION
We're using Redis::Failure::Multiple on our project and notice that after updating resque to 1.26.0, `resque/failed/requeue/all` fails. 
![37631d28-1302-11e6-9979-19b48f248448](https://cloud.githubusercontent.com/assets/1709578/15088002/684bcfd8-13bc-11e6-8c29-1dc990284009.gif)
