### PR TITLE
Indicate license in gemspec

### DIFF
--- a/resque.gemspec
+++ b/resque.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("man/**/*")
   s.files            += Dir.glob("tasks/**/*")
   s.executables       = [ "resque", "resque-web" ]
+  s.license           = 'MIT'
 
   s.extra_rdoc_files  = [ "LICENSE", "README.markdown" ]
   s.rdoc_options      = ["--charset=UTF-8"]


### PR DESCRIPTION
If I see it correctly, you are using the MIT license for the `resque` gem.

This PR indicates the license in the gemspec.