### PR TITLE
Update HISTORY.md with details about API change for plugin authors.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,9 @@
 None yet!
 
 * Fix issue where calling Worker.find, Worker.all, or Worker.working from withing
-  a running job would rewrite the PID file with the PID of the forked worker. (@jeremywadsack)
+  a running job would rewrite the PID file with the PID of the forked worker.
+  This causes a change to the Worker#new API that may affect plugin
+  implementations. See Worker#new and Worker#prepare for details. (@jeremywadsack)
 
 ## 1.26.0 (2016-03-10)
 


### PR DESCRIPTION
See #1448.

This adds more information about the change to the `Worker#new` API for plugin authors that may depend on `ENV["PIDFILE"]` or `ENV["BACKGROUD"]` behavior and are not using the rake task.