### PR TITLE
Remove to_h function invocation

### DIFF
--- a/lib/resque/server/views/working.erb
+++ b/lib/resque/server/views/working.erb
@@ -17,10 +17,11 @@
         <% queue = data['queue'] %>
         <td><a class="queue" href="<%=u "/queues/#{queue}" %>"><%= queue %></a></td>
         <td><span class="time"><%= data['run_at'] %></span></td>
+	<% payload = data.key?('payload') ? data['payload'] : {} %>
         <td>
-          <code><%= data['payload'].to_h['class'] %></code>
+          <code><%= payload.key?('class') ? payload['class'] : "—" %></code>
         </td>
-        <td><%=h data['payload'].to_h['args'].inspect %></td>
+        <td><%=h payload.key?('args') ? payload['args'].inspect : "—" %></td>
       </tr>
   </table>
 

--- a/lib/resque/server/views/working.erb
+++ b/lib/resque/server/views/working.erb
@@ -17,7 +17,7 @@
         <% queue = data['queue'] %>
         <td><a class="queue" href="<%=u "/queues/#{queue}" %>"><%= queue %></a></td>
         <td><span class="time"><%= data['run_at'] %></span></td>
-	<% payload = data.key?('payload') ? data['payload'] : {} %>
+        <% payload = data.key?('payload') ? data['payload'] : {} %>
         <td>
           <code><%= payload.key?('class') ? payload['class'] : "—" %></code>
         </td>


### PR DESCRIPTION
The `to_h` function does not exist in Ruby 1.9 yet. 
This replaces it with some custom logic. 

I'm actually not a Ruby programmer, so please correct me if that's wrong. 