### PR TITLE
Use fork with a block to avoid having a child process escape its code path

### DIFF
--- a/test/child_killing_test.rb
+++ b/test/child_killing_test.rb
@@ -89,13 +89,14 @@ describe "Resque::Worker" do
   end
 
   it "exits with Resque::TermException when using TERM_CHILD and not forking" do
+    old_job_per_fork = ENV['FORK_PER_JOB']
     begin
       ENV['FORK_PER_JOB'] = 'false'
       worker_pid, child_pid, result = start_worker(0, true)
       assert_equal worker_pid, child_pid, "child_pid should equal worker_pid, since we are not forking"
       assert Resque.redis.lpop( 'sigterm-test:ensure_block_executed' ), 'post cleanup did not occur. SIGKILL sent too early?'
     ensure
-      ENV['FORK_PER_JOB'] = 'true'
+      ENV['FORK_PER_JOB'] = old_job_per_fork
     end
   end
 end

--- a/test/resque_hook_test.rb
+++ b/test/resque_hook_test.rb
@@ -33,9 +33,7 @@ describe "Resque Hooks" do
 
   it 'it calls before_fork before each job' do
     skip("TRAAAVIS!!!!") if RUBY_VERSION == "1.8.7"
-    # We have to stub out will_fork? to return true, which is going to cause an actual fork(). As such, the
-    # exit!(true) will be called in Worker#work; to share state, use a tempfile
-    file = Tempfile.new("resque_before_fork")
+    file = Tempfile.new("resque_before_fork") # to share state with forked process
 
     begin
       File.open(file.path, "w") {|f| f.write(0)}
@@ -47,7 +45,6 @@ describe "Resque Hooks" do
 
       val = File.read(file.path).strip.to_i
       assert_equal(0, val)
-      @worker.stubs(:will_fork?).returns(true)
       @worker.work(0)
       val = File.read(file.path).strip.to_i
       assert_equal(2, val)
@@ -58,9 +55,7 @@ describe "Resque Hooks" do
 
   it 'it calls after_fork after each job' do
     skip("TRAAAVIS!!!!") if RUBY_VERSION == "1.8.7"
-    # We have to stub out will_fork? to return true, which is going to cause an actual fork(). As such, the
-    # exit!(true) will be called in Worker#work; to share state, use a tempfile
-    file = Tempfile.new("resque_after_fork")
+    file = Tempfile.new("resque_after_fork") # to share state with forked process
 
     begin
       File.open(file.path, "w") {|f| f.write(0)}
@@ -72,7 +67,6 @@ describe "Resque Hooks" do
 
       val = File.read(file.path).strip.to_i
       assert_equal(0, val)
-      @worker.stubs(:will_fork?).returns(true)
       @worker.work(0)
       val = File.read(file.path).strip.to_i
       assert_equal(2, val)
@@ -116,10 +110,10 @@ describe "Resque Hooks" do
   end
 
   it 'it registers multiple before_forks' do
-    # We have to stub out will_fork? to return true, which is going to cause an actual fork(). As such, the
-    # exit!(true) will be called in Worker#work; to share state, use a tempfile
+    # use tempfiles to share state with forked process
     file = Tempfile.new("resque_before_fork_first")
     file2 = Tempfile.new("resque_before_fork_second")
+
     begin
       File.open(file.path, "w") {|f| f.write(1)}
       File.open(file2.path, "w") {|f| f.write(2)}
@@ -135,7 +129,6 @@ describe "Resque Hooks" do
       end
       Resque::Job.create(:jobs, CallNotifyJob)
 
-      @worker.stubs(:will_fork?).returns(true)
       @worker.work(0)
       val = File.read(file.path).strip.to_i
       val2 = File.read(file2.path).strip.to_i
@@ -148,10 +141,10 @@ describe "Resque Hooks" do
   end
 
   it 'it registers multiple after_forks' do
-    # We have to stub out will_fork? to return true, which is going to cause an actual fork(). As such, the
-    # exit!(true) will be called in Worker#work; to share state, use a tempfile
+    # use tempfiles to share state with forked process
     file = Tempfile.new("resque_after_fork_first")
     file2 = Tempfile.new("resque_after_fork_second")
+
     begin
       File.open(file.path, "w") {|f| f.write(1)}
       File.open(file2.path, "w") {|f| f.write(2)}
@@ -167,7 +160,6 @@ describe "Resque Hooks" do
       end
       Resque::Job.create(:jobs, CallNotifyJob)
 
-      @worker.stubs(:will_fork?).returns(true)
       @worker.work(0)
       val = File.read(file.path).strip.to_i
       val2 = File.read(file2.path).strip.to_i

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -891,11 +891,12 @@ describe "Resque::Worker" do
   end
 
   it "won't fork if ENV['FORK_PER_JOB'] is false" do
+    old_fork_per_job = ENV["FORK_PER_JOB"]
     begin
       ENV["FORK_PER_JOB"] = 'false'
       assert_equal false, Resque::Worker.new(:jobs).fork_per_job?
     ensure
-      ENV["FORK_PER_JOB"] = 'true'
+      ENV["FORK_PER_JOB"] = old_fork_per_job
     end
   end
 


### PR DESCRIPTION
@fw42 & @Sirupsen for review

## Problem

When `Kernel.fork` is used without a block, then there will be a race condition where an exception can occur from a signal that causes the child process to leave its code path and execute exceptions handlers for the parent process.

Additionally, the Resque::Worker#fork abstraction was combining code paths for the child process and the non-forking code path, which was making the code harder to reason about.

## Solution

Refactor Resque::Worker#work to make the code easier to read and understand by separating the three code paths (no forking, fork parent and fork child) and isolating the child process code path by using fork with a block.

I also moved the reconnect to redis into the Resque::Worker#perform method, since it is related to the after_fork hooks which are run from that method, and because it avoids the need for another rescue for job failures.

I also removed `will_fork?` since using it before the first fork will cause a confusing result.  Instead, there is a fork_per_jobs attribute that gets explicitly set to `false` in Resque::Worker#work so this fork fallback flow is more straightforward to understand and refactor.