### PR TITLE
Fix passing an Redis::Namespace object into Resque.redis=

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -123,7 +123,7 @@ module Resque
 
       @data_store = Resque::DataStore.new(Redis::Namespace.new(namespace, :redis => redis))
     when Redis::Namespace
-      @data_store = server
+      @data_store = Resque::DataStore.new(server)
     when Resque::DataStore
       @data_store = server
     when Hash

--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -80,7 +80,7 @@ module Resque
     # is O(N) for the keyspace, so be careful - this can be slow for big databases.
     def all_resque_keys
       @redis.keys("*").map do |key|
-        key.sub("#{Resque.redis.namespace}:", '')
+        key.sub("#{@redis.namespace}:", '')
       end
     end
 

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -27,9 +27,9 @@ describe "Resque" do
     new_redis = Redis.new(:host => "localhost", :port => 9736)
     new_namespace = Redis::Namespace.new("namespace", :redis => new_redis)
     Resque.redis = new_namespace
-    assert_equal new_namespace, Resque.redis
 
-    Resque.redis = 'localhost:9736/namespace'
+    assert_equal new_namespace.client, Resque.redis.client
+    assert_equal 0, Resque.size(:default)
   end
 
   it "can put jobs on a queue" do


### PR DESCRIPTION
@chrisccerami & @fw42 for review

## Problem

`@data_store` on Resque was being set to a Redis::Namespace instance instead of a Resque::DataStore instance if Resque.redis= was given a Redis::Namespace instance.

## Solution

* Wrap the Resque::Namespace instance with Resque::DataStore like all the other assignments
* Fix the test that expected this broken behaviour