### PR TITLE
test: Ignore the heartbeat key when testing Resque.keys

### DIFF
--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -247,7 +247,10 @@ describe "Resque" do
     end
 
     it "keeps track of resque keys" do
-      assert_equal ["queue:people", "queues"].sort, Resque.keys.sort
+      # ignore the heartbeat key that gets set in a background thread
+      keys = Resque.keys - ['workers:heartbeat']
+
+      assert_equal ["queue:people", "queues"].sort, keys.sort
     end
 
     it "keeps stats" do


### PR DESCRIPTION
@fw42 or @Sirupsen for review

## Problem

I noticed this flaky test failure in CI on master (https://travis-ci.org/resque/resque/jobs/139518504)

```
  1) Failure:
Resque::with people in the queue#test_0007_keeps track of resque keys [/home/travis/build/resque/resque/test/resque_test.rb:250]:
--- expected
+++ actual
@@ -1 +1 @@
-["queue:people", "queues"]
+["queue:people", "queues", "workers:heartbeat"]
```

The problem is that anywhere that any test that calls Resque::Worker#work will start a background thread that creates this key.  There is nothing that forces the thread to be stopped between tests, so this can cause the key to be created between the before_setup for the Resque.keys test where redis is flushed and when `Resque.keys` is called in the test.

## Solution

Delete the heartbeat key from the list of keys before doing the assertion.

## Limitation

Perhaps we should have an easier way to cleanup all these heartbeat threads.  Right now that needs to be done while having a reference to the Resque::Worker instance, but we create many of these instances during the tests without cleanup.  I think that means we probably have a lot of hearbeat threads running during the tests for every time Resque::Worker#work is called, even if it is called on the same Resque::Worker instance.