### PR TITLE
Kill all heartbeat threads after each test run

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -16,6 +16,12 @@ module Resque
 
     WORKER_HEARTBEAT_KEY = "workers:heartbeat"
 
+    @@all_heartbeat_threads = []
+    def self.kill_all_heartbeat_threads
+      @@all_heartbeat_threads.each(&:kill)
+      @@all_heartbeat_threads = []
+    end
+
     def redis
       Resque.redis
     end
@@ -527,6 +533,8 @@ module Resque
           heartbeat!
         end
       end
+
+      @@all_heartbeat_threads << @heart
     end
 
     # Kills the forked child immediately with minimal remorse. The job it

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,7 +46,6 @@ MiniTest::Unit.after_tests do
 end
 
 module MiniTest::Unit::LifecycleHooks
-
   def before_setup
     reset_logger
     Resque.redis.flushall
@@ -55,6 +54,9 @@ module MiniTest::Unit::LifecycleHooks
     Resque.after_fork = nil
   end
 
+  def after_teardown
+    Resque::Worker.kill_all_heartbeat_threads
+  end
 end
 
 if ENV.key? 'RESQUE_DISTRIBUTED'


### PR DESCRIPTION
See https://github.com/resque/resque/pull/1477. Prevent threads from leaking across tests.

@dylanahsmith @Sirupsen 