### PR TITLE
Always perform heatbeats in the heartbeat thread

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -503,17 +503,15 @@ module Resque
     end
 
     def start_heartbeat
-      heartbeat!
-
       @stop_heartbeat_thread = false
       @heart = Thread.new do
         until @stop_heartbeat_thread do
+          heartbeat!
+
           Resque.heartbeat_interval.times do
             sleep(1)
             break if @stop_heartbeat_thread
           end
-
-          heartbeat!
         end
       end
 


### PR DESCRIPTION
I think it's cleaner to always perform the heartbeats in the actual heartbeat thread, never outside of it (and this makes another refactor that I'm working on a little bit easier).

@dylanahsmith @Sirupsen @jpittis