### PR TITLE
[Bugfix] Heartbeat with server time, not worker time

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -269,6 +269,14 @@ def with_pidfile
   end
 end
 
+def with_fake_time(time)
+  old_time = Time.fake_time
+  Time.fake_time = time
+  yield
+ensure
+  Time.fake_time = old_time
+end
+
 def with_background
   old_background = ENV["BACKGROUND"]
   begin


### PR DESCRIPTION
This addresses an issue mentioned in https://github.com/resque/resque/issues/1357#issuecomment-229613020 where a worker might prune previous workers if it's clock has significant drift compared to the other workers.

This PR attempts to fix that by using the server time for all heartbeat timestamps instead of the local worker's clock.

@Sirupsen @dylanahsmith @hackhowtofaq