### PR TITLE
Wait for heartbeat threads to die

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -19,6 +19,7 @@ require 'resque/job'
 require 'resque/worker'
 require 'resque/plugin'
 require 'resque/data_store'
+require 'resque/thread_signal'
 
 require 'resque/vendor/utf8_util'
 

--- a/lib/resque/thread_signal.rb
+++ b/lib/resque/thread_signal.rb
@@ -1,0 +1,45 @@
+class Resque::ThreadSignal
+  if RUBY_VERSION <= "1.9"
+    def initialize
+      @signaled = false
+    end
+
+    def signal
+      @signaled = true
+    end
+
+    def wait_for_signal(timeout)
+      (10 * timeout).times do
+        sleep(0.1)
+        return true if @signaled
+      end
+
+      @signaled
+    end
+
+  else
+    def initialize
+      @mutex = Mutex.new
+      @signaled = false
+      @received = ConditionVariable.new
+    end
+
+    def signal
+      @mutex.synchronize do
+        @signaled = true
+        @received.signal
+      end
+    end
+
+    def wait_for_signal(timeout)
+      @mutex.synchronize do
+        unless @signaled
+          @received.wait(@mutex, timeout)
+        end
+
+        @signaled
+      end
+    end
+
+  end
+end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -18,7 +18,7 @@ module Resque
 
     @@all_heartbeat_threads = []
     def self.kill_all_heartbeat_threads
-      @@all_heartbeat_threads.each(&:kill)
+      @@all_heartbeat_threads.each(&:kill).each(&:join)
       @@all_heartbeat_threads = []
     end
 
@@ -509,19 +509,17 @@ module Resque
     end
 
     def start_heartbeat
-      @stop_heartbeat_thread = false
-      @heart = Thread.new do
-        until @stop_heartbeat_thread do
-          heartbeat!
+      @heartbeat_thread_signal = Resque::ThreadSignal.new
 
-          Resque.heartbeat_interval.times do
-            sleep(1)
-            break if @stop_heartbeat_thread
-          end
+      @heartbeat_thread = Thread.new do
+        loop do
+          heartbeat!
+          signaled = @heartbeat_thread_signal.wait_for_signal(Resque.heartbeat_interval)
+          break if signaled
         end
       end
 
-      @@all_heartbeat_threads << @heart
+      @@all_heartbeat_threads << @heartbeat_thread
     end
 
     # Kills the forked child immediately with minimal remorse. The job it
@@ -637,7 +635,10 @@ module Resque
     end
 
     def kill_background_threads
-      @stop_heartbeat_thread = true if @heart
+      if @heartbeat_thread
+        @heartbeat_thread_signal.signal
+        @heartbeat_thread.join
+      end
     end
 
     # Unregisters ourself as a worker. Useful when shutting down.

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -21,11 +21,9 @@ describe "Resque::Worker" do
 
   before do
     @worker = Resque::Worker.new(:jobs)
+    Resque::Worker.any_instance.stubs(:register_signal_handlers)
+    Resque::Worker.any_instance.stubs(:unregister_signal_handlers)
     Resque::Job.create(:jobs, SomeJob, 20, '/tmp')
-  end
-
-  after do
-    @worker.kill_background_threads
   end
 
   it "can fail jobs" do


### PR DESCRIPTION
follow-up to https://github.com/resque/resque/pull/1478

turns out we have to wait for the threads today, otherwise stuff seems to still be leaking.

also stub signal handler registration and unregistration, since those would also leak into other tests.

@dylanahsmith @Sirupsen 