### PR TITLE
Add more tests

### DIFF
--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -627,33 +627,41 @@ describe "Resque::Worker" do
   end
 
   it "prunes dead workers with heartbeat older than prune interval" do
+    assert_equal({}, Resque::Worker.all_heartbeats)
     now = Time.now
 
     workerA = Resque::Worker.new(:jobs)
-    workerA.instance_variable_set(:@to_s, "bar:3:jobs")
+    workerA.to_s = "bar:3:jobs"
     workerA.register_worker
     workerA.heartbeat!(now - Resque.prune_interval - 1)
 
     assert_equal 1, Resque.workers.size
+    assert Resque::Worker.all_heartbeats.key?(workerA.to_s)
 
     workerB = Resque::Worker.new(:jobs)
-    workerB.instance_variable_set(:@to_s, "foo:5:jobs")
+    workerB.to_s = "foo:5:jobs"
     workerB.register_worker
     workerB.heartbeat!(now)
 
     assert_equal 2, Resque.workers.size
+    assert Resque::Worker.all_heartbeats.key?(workerB.to_s)
+    assert_equal [workerA], Resque::Worker.all_workers_with_expired_heartbeats
 
     @worker.prune_dead_workers
 
     assert_equal 1, Resque.workers.size
+    refute Resque::Worker.all_heartbeats.key?(workerA.to_s)
+    assert Resque::Worker.all_heartbeats.key?(workerB.to_s)
+    assert_equal [], Resque::Worker.all_workers_with_expired_heartbeats
   end
 
   it "does not prune workers that haven't set a heartbeat" do
     workerA = Resque::Worker.new(:jobs)
-    workerA.instance_variable_set(:@to_s, "bar:3:jobs")
+    workerA.to_s = "bar:3:jobs"
     workerA.register_worker
 
     assert_equal 1, Resque.workers.size
+    assert_equal({}, Resque::Worker.all_heartbeats)
 
     @worker.prune_dead_workers
 


### PR DESCRIPTION
Follow-up to https://github.com/resque/resque/pull/1485.

Just add some more tests for this to ensure workers are also cleaned up when `prune_dead_workers` is being called (this is implicitly true because `prune_dead_workers` calls `unregister_worker`, but I feel like it deserves dedicated test coverage).

@Sirupsen @dylanahsmith if one of you could take a quick look?