### PR TITLE
Remove old heartbeats before starting heartbeat thread

### DIFF
--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -42,6 +42,7 @@ module Resque
                               :unregister_worker,
                               :heartbeat,
                               :heartbeat!,
+                              :remove_heartbeat,
                               :all_heartbeats,
                               :set_worker_payload,
                               :worker_start_time,
@@ -255,6 +256,10 @@ module Resque
 
           block.call
         end
+      end
+
+      def remove_heartbeat(worker)
+        @redis.hdel(HEARTBEAT_KEY, worker.to_s)
       end
 
       def heartbeat(worker)

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -472,6 +472,10 @@ module Resque
       data_store.heartbeat(self)
     end
 
+    def remove_heartbeat
+      data_store.remove_heartbeat(self)
+    end
+
     def heartbeat!(time = data_store.server_time)
       data_store.heartbeat!(self, time)
     end
@@ -501,6 +505,8 @@ module Resque
     end
 
     def start_heartbeat
+      remove_heartbeat
+
       @heartbeat_thread_signal = Resque::ThreadSignal.new
 
       @heartbeat_thread = Thread.new do

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -672,6 +672,16 @@ describe "Resque::Worker" do
     workerA.heartbeat!
 
     assert_instance_of Time, workerA.heartbeat
+
+    workerA.remove_heartbeat
+    assert_equal nil, workerA.heartbeat
+  end
+
+  it "removes old heartbeats before starting heartbeat thread" do
+    workerA = Resque::Worker.new(:jobs)
+    workerA.register_worker
+    workerA.expects(:remove_heartbeat).once
+    workerA.start_heartbeat
   end
 
   it "cleans up heartbeat after unregistering" do


### PR DESCRIPTION
It seems like https://github.com/resque/resque/pull/1485 did not fix the issue fully. I'm still seeing some PruneDeadWorker exceptions in production, which leads me to believe that there is still a race condition. Sadly I'm not really sure what the race condition is though :-(

This PR should once and for all fix it, by explicitly removing old heartbeats (of the same worker id) before sending any new heartbeats (and before registering the worker).

@dylanahsmith @Sirupsen 