### PR TITLE
Use older json version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,13 @@ gemspec
 
 gem "activesupport", "~> 3.0"
 gem "i18n"
-gem "json"
+
+if RUBY_VERSION < "2.0"
+  gem "json", '~> 1.8'
+else
+  gem "json"
+end
+
 gem "minitest", "4.7.0"
 gem "mocha", :require => false
 gem "rack-test", "~> 0.5"

--- a/Gemfiles/Gemfile.1.8.7
+++ b/Gemfiles/Gemfile.1.8.7
@@ -8,7 +8,7 @@ group :test do
   gem "activesupport", "~> 3.0"
   gem "i18n", "~> 0.6.0"
   gem "minitest", "4.7.0"
-  gem "json"
+  gem "json", "~> 1.8"
   gem 'redis', '~> 3.0.0', '< 3.0.7'
 
   gem 'coveralls', :require => false


### PR DESCRIPTION
Not sure why but CI is currently failing for Ruby 1.9 and Ruby 1.8 because it's installing json 2.x which requires Ruby 2.x. See if this fixes it.