### PR TITLE
Fixed reverse proxy prefix for overview and stats

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -42,10 +42,6 @@ module Resque
       end
       alias_method :u, :url_path
 
-      def redirect_url_path(*path_parts)
-        [ path_prefix, path_parts ].join("/").squeeze('/')
-      end
-
       def path_prefix
         request.env['SCRIPT_NAME']
       end
@@ -158,7 +154,7 @@ module Resque
 
     # to make things easier on ourselves
     get "/?" do
-      redirect redirect_url_path(:overview)
+      redirect url_path(:overview)
     end
 
     %w( overview workers ).each do |page|
@@ -219,7 +215,7 @@ module Resque
 
     post "/failed/:queue/requeue/all" do
       Resque::Failure.requeue_queue Resque::Failure.job_queue_name(params[:queue])
-      redirect redirect_url_path("/failed/#{params[:queue]}")
+      redirect url_path("/failed/#{params[:queue]}")
     end
 
     get "/failed/requeue/:index/?" do
@@ -251,7 +247,7 @@ module Resque
     end
 
     get "/stats/?" do
-      redirect redirect_url_path("/stats/resque")
+      redirect url_path("/stats/resque")
     end
 
     get "/stats/:id/?" do


### PR DESCRIPTION
This fixes PR #1375 since the overview page and stats page were not using the prefix.

I did not add anything, just reverted the extra changes, works good like this for us.
