### PR TITLE
Change $?.stopsig to $?.inspect on DirtyExit

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -880,7 +880,7 @@ module Resque
         nil
       end
 
-      job.fail(DirtyExit.new("Child process received unhandled signal #{$?.stopsig}")) if $?.signaled?
+      job.fail(DirtyExit.new("Child process received unhandled signal #{$?.inspect}")) if $?.signaled?
       @child = nil
     end
 


### PR DESCRIPTION
$?.stopsig returns the number of the signal that caused stat to stop (or
nil if self is not stopped). The **stop** does not include **terminate**.
So, we get nil at this line usually.
In the case of **terminate**, termsig is available.

$?.inpect is most elaborative for both case

ref. http://docs.ruby-lang.org/en/2.0.0/Process/Status.html#method-i-stopsig