### PR TITLE
Use notify_sync when calling Airbrake

### DIFF
--- a/lib/resque/failure/airbrake.rb
+++ b/lib/resque/failure/airbrake.rb
@@ -21,7 +21,7 @@ module Resque
       end
 
       def save
-        ::Airbrake.notify(exception,
+        ::Airbrake.notify_sync(exception,
             :parameters => {
             :payload_class => payload['class'].to_s,
             :payload_args => payload['args'].inspect


### PR DESCRIPTION
Inside of Airbrake, for the class Resque::Failure::Airbrake, they use the method `notify_sync` (https://github.com/airbrake/airbrake/blob/master/lib/airbrake/resque/failure.rb), while inside of Resque, it calls `notify`.  I believe that the Airbrake behavior is correct.

Here's my thinking:  under the hood of Airbrake, `notify` uses a thread pool of async
notifiers. This appears to be incompatible with Resque and errors
are being swallowed.
