### PR TITLE
Fix bug when encontering an error while pruning workers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "i18n"
 if RUBY_VERSION < "2.0"
   gem "json", '~> 1.8'
   gem "coveralls", "0.8.13", :require => false
+  gem "term-ansicolor", "1.3.2" # A dependency of coveralls. The next version requires ruby >= 2.0.
 else
   gem "json"
   gem "coveralls", :require => false

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -650,8 +650,8 @@ module Resque
     rescue Exception => exception_while_unregistering
       message = exception_while_unregistering.message
       if exception
-        message = message + "\nOriginal Exception (#{exception.class}): #{exception.message}\n" +
-                            "  #{(exception.backtrace || []).join("  \n")}"
+        message += "\nOriginal Exception (#{exception.class}): #{exception.message}"
+        message += "\n  #{exception.backtrace.join("  \n")}" if exception.backtrace
       end
       fail(exception_while_unregistering.class,
            message,

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -651,7 +651,7 @@ module Resque
       message = exception_while_unregistering.message
       if exception
         message = message + "\nOriginal Exception (#{exception.class}): #{exception.message}\n" +
-                            "  #{exception.backtrace.join("  \n")}"
+                            "  #{(exception.backtrace || []).join("  \n")}"
       end
       fail(exception_while_unregistering.class,
            message,

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -744,7 +744,9 @@ describe "Resque::Worker" do
     end
   end
 
-  it "reports errors correctly when an error occurs while pruning workers" do
+  # This was added because PruneDeadWorkerDirtyExit does not have a backtrace,
+  # and the error handling code did not account for that.
+  it "correctly reports errors that occur while pruning workers" do
     workerA = Resque::Worker.new(:jobs)
     workerA.to_s = "bar:3:jobs"
     workerA.register_worker

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -744,6 +744,24 @@ describe "Resque::Worker" do
     end
   end
 
+  it "reports errors correctly when an error occurs while pruning workers" do
+    workerA = Resque::Worker.new(:jobs)
+    workerA.to_s = "bar:3:jobs"
+    workerA.register_worker
+    workerA.heartbeat!(Time.now - Resque.prune_interval - 1)
+
+    # the specific error isn't important, could be something else
+    Resque.data_store.redis.stubs(:get).raises(Redis::CannotConnectError)
+
+    exception_caught = assert_raises Redis::CannotConnectError do
+      @worker.prune_dead_workers
+    end
+
+    assert_match /PruneDeadWorkerDirtyExit/, exception_caught.message
+    assert_match /bar:3:jobs/, exception_caught.message
+    assert_match /Redis::CannotConnectError/, exception_caught.message
+  end
+
   it "cleans up dead worker info on start (crash recovery)" do
     # first we fake out several dead workers
     # 1: matches queue and hostname; gets pruned.


### PR DESCRIPTION
The error handling while pruning workers had a bug.

In our case this was our temporary monkeypatch of `Job#fail` caused an error.

Regardless of that, this error reporting code was broken and should be fixed.

/ tomas and joakim