### PR TITLE
CHANGE: Adjust header namespace color to be obvious

### DIFF
--- a/lib/resque/server/public/style.css
+++ b/lib/resque/server/public/style.css
@@ -8,7 +8,7 @@ body { padding:0; margin:0; }
 .header ul li a:hover { background:#333;}
 .header ul li.current a { background:#ce1212; font-weight:bold; color:#fff;}
 
-.header .namespace { position: absolute; right: 75px; top: 10px; color: #7A7A7A; }
+.header .namespace { position: absolute; right: 75px; top: 12px; color: #FFF; font-weight: bold; }
 
 .subnav { padding:2px 5% 7px 5%; background:#ce1212; font-size:90%;}
 .subnav li { display:inline;}


### PR DESCRIPTION
After:
<img width="197" alt="screen shot 2017-02-13 at 19 06 35" src="https://cloud.githubusercontent.com/assets/6284234/22896629/27f50f6e-f221-11e6-9316-7c76b5fad69e.png">
Before:
<img width="600" alt="screen shot 2017-02-13 at 19 09 00" src="https://cloud.githubusercontent.com/assets/6284234/22896630/27f5dc28-f221-11e6-802d-f51ab965e14e.png">
