### PR TITLE
Run Resque rake tasks with :environment

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-Nothing yet!
+### Fixed
+* Run Resque rake tasks with :environment
 
 ## 1.27.1 (2017-02-13)
 

--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -3,7 +3,7 @@
 
 
 namespace :resque do
-  task :setup
+  task :setup => :environment
 
   desc "Start a Resque worker"
   task :work => [ :preload, :setup ] do


### PR DESCRIPTION
This is an attempt to address #1498. I've done basic testing with this change in both a Rails 5.0.1 app and a standalone non-Rails project and it seems to work fine in both cases. My hope is that this change will make it easier to use Resque out of the box with Rails 5.