### PR TITLE
Add ActiveJob section to the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -505,6 +505,18 @@ From the Rails docs on [`clear_active_connections!`](http://api.rubyonrails.org/
     Returns any connections in use by the current thread back to the pool, and also returns connections to the pool cached by threads that are no longer alive.
 
 
+#### ActiveJob
+
+If you're going to need to use the database in a number of different jobs, consider adding this to your ApplicationJob file:
+
+``` ruby
+class ApplicationJob < ActiveJob::Base
+  before_perform do |job|
+    ActiveRecord::Base.clear_active_connections!
+  end
+end
+```
+
 
 The Front End
 -------------


### PR DESCRIPTION
I was going to ask this in the mailing list but librelist seems down so I thought, why not PR-it?

We used to have all our jobs inherit from a BaseWorker that would call `ActiveRecord::Base.clear_active_connections!` before calling the child's job `#perform` method. Would the approach suggedted in this PR be the recommended approach when using the `:resque` adapter for ActiveJob provided all jobs need the DB, and you're running MySQL?

Thanks!