### PR TITLE
use remove_from_failed_queue to remove multi queue failures

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-Nothing yet!
+### Fixed
+* Fix issue where removing a failure from Resque web didn't work when using `RedisMultiQueue` backend.
 
 ## 1.27.3 (2017-04-10)
 

--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -30,7 +30,7 @@ module Resque
         if queue
           if class_name
             n = 0
-            each(0, count(queue), queue, class_name) { n += 1 } 
+            each(0, count(queue), queue, class_name) { n += 1 }
             n
           else
             data_store.num_failed(queue).to_i
@@ -79,7 +79,7 @@ module Resque
       end
 
       def self.remove(id, queue = :failed)
-        data_store.remove_from_queue(id,queue)
+        data_store.remove_from_failed_queue(id,queue)
       end
 
       def self.requeue_queue(queue)


### PR DESCRIPTION
This function is already used by the regular Resque::Failure::Redis backend, and appears to be setup to work with the mutli-failure backend as well.

Current symptoms are clicking the "Remove" link in Resque Web, the HTTP request is successful but the failure is not removed.

Aside: Sorry for the extra white-space change in the commit. Vim trimmed it and I didn't notice it.