### PR TITLE
Fix failed jobs page "argument out of range" error

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ### Changed
 * Remove support for Rubies < 2.0
+* Fix failed jobs page "argument out of range" error
 
 ## 1.27.4 (2017-04-15)
 

--- a/lib/resque/server/views/failed_job.erb
+++ b/lib/resque/server/views/failed_job.erb
@@ -6,10 +6,10 @@
     <% else %>
     <dt>Worker</dt>
     <dd>
-      <a href="<%= u(:workers, job['worker']) %>"><%= job['worker'].split(':')[0...2].join(':') %></a> on <b class='queue-tag'><%= job['queue'] %></b > at <b><span class="time"><%= Time.parse(job['failed_at']).strftime(failed_date_format) %></span></b>
+      <a href="<%= u(:workers, job['worker']) %>"><%= job['worker'].split(':')[0...2].join(':') %></a> on <b class='queue-tag'><%= job['queue'] %></b > at <b><span class="time"><%= DateTime.parse(job['failed_at']).strftime(failed_date_format) %></span></b>
       <% if job['retried_at'] %>
         <div class='retried'>
-          Retried <b><span class="time"><%= Time.parse(job['retried_at']).strftime(failed_date_format) %></span></b>
+          Retried <b><span class="time"><%= DateTime.parse(job['retried_at']).strftime(failed_date_format) %></span></b>
           <a href="<%= u "#{queue}/remove/#{id}" %>" class="remove" rel="remove">Remove</a>
         </div>
       <% else %>


### PR DESCRIPTION
Recreating PR from https://github.com/resque/resque/pull/1563 with rebased branch off of master.

# Original Issue
The failed_at date is always set to basically a UTC formatted date value (https://github.com/resque/resque/blob/master/lib/resque/failure/redis.rb#L17), but this line on the "failures" page on the Resque UI fails because the date format it's expecting for `Time.parse` is `YYYY-mm-dd HH:MM:SS Z` instead of `YYYY/mm/dd HH:MM:SS Z`.  DateTime.parse however properly handles the currently set format.  I guess an alternative would be to change the format that gets stored in redis in lib/resque/failure/redis.rb, but that wouldn't necessarily fix jobs already stored with the incorrect date format.