### PR TITLE
Add a note on after_perform hooks

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -44,7 +44,7 @@ All worker hooks can also be set using a setter, e.g.
 
 
 Workers can also take advantage of running any code defined using Ruby's `at_exit` block by setting
-ENV["RUN_AT_EXIT_HOOKS"]=1. By default, this is turned off. Be advised that setting this value might execute
+`ENV["RUN_AT_EXIT_HOOKS"]=1`. By default, this is turned off. Be advised that setting this value might execute
 code from gems which register their own `at_exit` hooks.
 
 Job Hooks
@@ -88,7 +88,7 @@ The available hooks are:
   backend.
 
 * `after_perform`: Called with the job args after it performs. Uncaught
-  exceptions will propagate up to the `Resque::Failure` backend.
+  exceptions will propagate up to the `Resque::Failure` backend. *Note: If the job fails, `after_perform` hooks will not be run.*
 
 * `around_perform`: Called with the job args. It is expected to yield in order
   to perform the job (but is not required to do so). It may handle exceptions


### PR DESCRIPTION
I added a note on the `after_perform` hooks to mention that they are not run if the job fails. I noticed this when trying to log how many total jobs ran and I was getting inaccurate numbers.