### PR TITLE
Fix wrong document for rails 5

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -671,7 +671,7 @@ require 'your/app'
 require 'resque/tasks'
 ```
 
-If you're using Rails 5.x, include the following in lib/tasks/resque.rb:
+If you're using Rails 5.x, include the following in lib/tasks/resque.rake:
 
 ```ruby
 require 'resque/tasks'


### PR DESCRIPTION
correct task file extension is ".rake".
".rb" is wrong.