### PR TITLE
Don't display log message if running without hooks

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -632,7 +632,8 @@ module Resque
 
     # Runs a named hook, passing along any arguments.
     def run_hook(name, *args)
-      return unless hooks = Resque.send(name)
+      hooks = Resque.send(name)
+      return if hooks.blank?
       return if name == :before_first_fork && @before_first_fork_hook_ran
       msg = "Running #{name} hooks"
       msg << " with #{args.inspect}" if args.any?


### PR DESCRIPTION
Currently, Resque shows up an info log message for before_fork and after_fork hooks, even when you don't have any of those hooks set up. This causes a lot of useless logs.

```
*** Running before_fork hooks with [(Job{...} | ... | [])]
*** Running after_fork hooks with [(Job{...} | ... | [])]
```

This small PR prevents these log messages when there are no hooks set up.