### PR TITLE
Make sure that calls to Airbrake.notify are always synchronous

### DIFF
--- a/lib/resque/failure/airbrake.rb
+++ b/lib/resque/failure/airbrake.rb
@@ -21,12 +21,23 @@ module Resque
       end
 
       def save
-        ::Airbrake.notify(exception,
-            :parameters => {
-            :payload_class => payload['class'].to_s,
-            :payload_args => payload['args'].inspect
-            }
-          )
+        notify(exception,
+          :parameters => {
+          :payload_class => payload['class'].to_s,
+          :payload_args => payload['args'].inspect
+          }
+        )
+      end
+
+      private
+
+      def notify(exception, options)
+        if ::Airbrake.respond_to?(:notify_sync)
+          Airbrake.notify_sync(exception, options)
+        else
+          # Older versions of Airbrake (< 5)
+          Airbrake.notify(exception, options)
+        end
       end
     end
   end

--- a/test/airbrake_test.rb
+++ b/test/airbrake_test.rb
@@ -16,7 +16,14 @@ if defined? Airbrake
       queue = "test"
       payload = {'class' => Object, 'args' => 66}
 
-      Airbrake.expects(:notify).with(
+      notify_method =
+        if Airbrake::AIRBRAKE_VERSION.to_i < 5
+          :notify
+        else
+          :notify_sync
+        end
+
+      Airbrake.expects(notify_method).with(
         exception,
         :parameters => {:payload_class => 'Object', :payload_args => '66'})
 


### PR DESCRIPTION
Resque still relies on `Airbrake.notify`, which is asynchronous by default since version `5` of the Airbrake gem. `Airbrake.notify_sync` should be used instead. Reference [here](https://github.com/airbrake/airbrake/blob/910814b8b6d5c169e29ee85c646ac03a6deb2f1e/docs/Migration_guide_from_v4_to_v5.md#airbrake-notify).

Sending notifications asynchronously to Airbrake within a Job can cause the notification to never reach their servers, since the ruby process that is running the job can exit before the notification is actually sent. A detailed explanation of this issue including a failing app can be found in #1580.

This PR fixes it by making sure that the notification is always sent synchronously.

I'm unfamiliar with `Resque`'s coding style and conventions, so I would appreciate someone's help on this.

Thanks