### PR TITLE
Shuffle glob queues per env flag

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -200,9 +200,15 @@ module Resque
     end
 
     def glob_match(pattern)
-      Resque.queues.select do |queue|
+      matches = Resque.queues.select do |queue|
         File.fnmatch?(pattern, queue)
-      end.sort
+      end
+
+      if ENV['SHUFFLE'] && ENV['SHUFFLE'] != 'false'
+        matches.shuffle
+      else
+        matches.sort
+      end
     end
 
     # This is the main workhorse method. Called on a Worker instance,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -286,3 +286,13 @@ def with_background
     ENV["BACKGROUND"] = old_background
   end
 end
+
+def with_shuffling
+  old_shuffle = ENV["SHUFFLE"]
+  begin
+    ENV["SHUFFLE"] = "true"
+    yield
+  ensure
+    ENV["SHUFFLE"] = old_shuffle
+  end
+end


### PR DESCRIPTION
Allows developers the option to have shuffling `*` queue processing via `ENV['SHUFFLE']`.

The reasoning behind is two fold:

1. As mentioned by @steveklabnik in https://github.com/resque/resque/issues/1075#issuecomment-20768201, `*` processing kind of implies lack of explicit prioritization. If you really care about certain prioritization to be maintained, explicit queue lists are suited. 

2. Alphabetical prioritization means queues that are processed by general `*` workers are more prone to having one obnoxious queue (on purpose or accidentally) effectively block others just because they are higher up alphabetically. Using shuffling, an obnoxious queue cannot block or even slow down other queues as all have statistically similar chances of being processed every turn.

Usage is non-default, so the default behavior is still sorted `*` queues. 

Feature is enabled via `SHUFFLE=true QUEUE=* rake resque:work`