### PR TITLE
Purge VERBOSE mention from readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -199,7 +199,7 @@ We plan to provide first class `async` support in a future release.
 If a job raises an exception, it is logged and handed off to the
 `Resque::Failure` module. Failures are logged either locally in Redis
 or using some different backend. To see exceptions while developing,
-use VERBOSE env variable, see details below under Logging.
+see details below under Logging.
 
 For example, Resque ships with Airbrake support. To configure it, put
 the following into an initialisation file or into your rake job:


### PR DESCRIPTION
Based on https://github.com/resque/resque/commit/7f3d86427e1c00ca458baa1423d5deefcba2ac3e, the `VERBOSE` variable is no longer supported and should be removed from the documentation.