### PR TITLE
`Redis.connect` is abolition in redis v4.0.0

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -113,7 +113,7 @@ module Resque
     case server
     when String
       if server =~ /redis\:\/\//
-        redis = Redis.connect(:url => server, :thread_safe => true)
+        redis = Redis.new(:url => server, :thread_safe => true)
       else
         server, namespace = server.split('/', 2)
         host, port, db = server.split(':')


### PR DESCRIPTION
When I updated gems, the following error occurred.

```
/path/to/my_project/vendor/bundle/ruby/2.3.0/gems/resque-1.27.4/lib/resque.rb:116:in `redis=': undefined method `connect' for Redis:Class
Did you mean?  context (NoMethodError)
```
