### PR TITLE
Prevent thundering herd when pruning dead workers

### DIFF
--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -44,6 +44,7 @@ module Resque
                               :heartbeat!,
                               :remove_heartbeat,
                               :all_heartbeats,
+                              :acquire_pruning_dead_worker_lock,
                               :set_worker_payload,
                               :worker_start_time,
                               :worker_done_working
@@ -275,6 +276,10 @@ module Resque
         @redis.hgetall(HEARTBEAT_KEY)
       end
 
+      def acquire_pruning_dead_worker_lock(worker, expiry)
+        @redis.set(redis_key_for_worker_pruning, worker.to_s, :ex => expiry, :nx => true)
+      end
+
       def set_worker_payload(worker, data)
         @redis.set(redis_key_for_worker(worker), data)
       end
@@ -298,6 +303,10 @@ module Resque
 
       def redis_key_for_worker_start_time(worker)
         "#{redis_key_for_worker(worker)}:started"
+      end
+
+      def redis_key_for_worker_pruning
+        "pruning_dead_workers_in_progress"
       end
     end
 

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -585,6 +585,8 @@ module Resque
     # By checking the current Redis state against the actual
     # environment, we can determine if Redis is old and clean it up a bit.
     def prune_dead_workers
+      return unless data_store.acquire_pruning_dead_worker_lock(self, Resque.heartbeat_interval)
+
       all_workers = Worker.all
 
       unless all_workers.empty?


### PR DESCRIPTION
We've recently had a small service disruption where a large number of workers died and were dead for longer than `Resque.prune_interval`. Once the problem was fixed, all of our (thousands of) workers were able to boot again around the same time, meaning that all of them tried to prune all of the dead old workers at once (see [Thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem)), therefore causing a huge load spike (pruning workers is a somewhat expensive operation, involving multiple server roundtrips to Redis).

This PR fixes that by making it so that only one worker can be pruning and all subsequent attempts will be skipped for the next `Resque.prune_interval` seconds.

@es @pushrax @xldenis @hkdsun @sirupsen
cc @chrisccerami 