### PR TITLE
Only run eager_load! if config.eager_load is true

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -40,7 +40,7 @@ namespace :resque do
   # Preload app files if this is Rails
   task :preload => :setup do
     if defined?(Rails)
-      if Rails::VERSION::MAJOR > 3
+      if Rails::VERSION::MAJOR > 3 && Rails.application.config.eager_load
         ActiveSupport.run_load_hooks(:before_eager_load, Rails.application)
         Rails.application.config.eager_load_namespaces.each(&:eager_load!)
 


### PR DESCRIPTION
With resque 1.27.0+ I've run into a problem where the eager loading change for Rails 4+ is causing `ActiveSupport::Concern::MultipleIncludedBlocks` in my development environment (`eager_load = false`) but not production environment (`eager_load = true`).  I noticed that the [Rails code](https://github.com/rails/rails/blob/master/railties/lib/rails/application/finisher.rb#L67) being copied here checks the `eager_load` config option before running `config.eager_load_namespaces.each(&:eager_load!)`.  Applying this check appears to fix the error for me.

Here is an example stacktrace showing the error:
```
bash-4.1$ RAILS_ENV=development BACKGROUND=yes QUEUE=* bundle exec rake resque:work
/srv/avalon/avalon_r6/releases/20180104162955/config/initializers/fixnum_to_hms.rb:1: warning: constant ::Fixnum is deprecated
rake aborted!
ActiveSupport::Concern::MultipleIncludedBlocks: Cannot define multiple 'included' blocks for a Concern
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/activesupport-4.2.9/lib/active_support/concern.rb:126:in `included'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/blacklight-6.11.0/app/controllers/concerns/blacklight/catalog.rb:11:in `<module:Catalog>'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/blacklight-6.11.0/app/controllers/concerns/blacklight/catalog.rb:2:in `<top (required)>'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:457:in `load'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:457:in `block in load_file'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:647:in `new_constants_in'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:456:in `load_file'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:354:in `require_or_load'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:317:in `depend_on'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/activesupport-4.2.9/lib/active_support/dependencies.rb:233:in `require_dependency'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/railties-4.2.9/lib/rails/engine.rb:472:in `block (2 levels) in eager_load!'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/railties-4.2.9/lib/rails/engine.rb:471:in `each'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/railties-4.2.9/lib/rails/engine.rb:471:in `block in eager_load!'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/railties-4.2.9/lib/rails/engine.rb:469:in `each'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/railties-4.2.9/lib/rails/engine.rb:469:in `eager_load!'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/railties-4.2.9/lib/rails/engine.rb:346:in `eager_load!'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/resque-1.27.4/lib/resque/tasks.rb:45:in `each'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/resque-1.27.4/lib/resque/tasks.rb:45:in `block (2 levels) in <top (required)>'
/srv/avalon/avalon_r6/shared/bundle/ruby/2.4.0/gems/rake-12.3.0/exe/rake:27:in `<top (required)>'
/home.local/avalon/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/cli/exec.rb:74:in `load'
/home.local/avalon/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/cli/exec.rb:74:in `kernel_load'
/home.local/avalon/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/cli/exec.rb:27:in `run'
/home.local/avalon/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/cli.rb:362:in `exec'
/home.local/avalon/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home.local/avalon/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/home.local/avalon/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/home.local/avalon/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/cli.rb:22:in `dispatch'
/home.local/avalon/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/home.local/avalon/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/cli.rb:13:in `start'
/home.local/avalon/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/exe/bundle:30:in `block in <top (required)>'
/home.local/avalon/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
/home.local/avalon/.rvm/gems/ruby-2.4.1/gems/bundler-1.15.4/exe/bundle:22:in `<top (required)>'
/home.local/avalon/.rvm/gems/ruby-2.4.1/bin/bundle:22:in `load'
/home.local/avalon/.rvm/gems/ruby-2.4.1/bin/bundle:22:in `<main>'
/home.local/avalon/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
/home.local/avalon/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => resque:work => resque:preload
(See full trace by running task with --trace)
```