### PR TITLE
Stop unconditionally require-ing the Airbrake gem for Resque::Failure::Airbrake

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,9 @@
 
 ### Changed
 * Remove support for Rubies < 2.0
+* Do not require the Airbrake gem unconditionally anymore when using the
+  Resque::Failure::Airbrake module. A top-level Airbrake constant implementing
+  the same interface will be used if present.
 
 ## 1.27.4 (2017-04-15)
 

--- a/lib/resque/failure/airbrake.rb
+++ b/lib/resque/failure/airbrake.rb
@@ -37,10 +37,10 @@ module Resque
 
       def notify(exception, options)
         if ::Airbrake.respond_to?(:notify_sync)
-          Airbrake.notify_sync(exception, options)
+          ::Airbrake.notify_sync(exception, options)
         else
           # Older versions of Airbrake (< 5)
-          Airbrake.notify(exception, options)
+          ::Airbrake.notify(exception, options)
         end
       end
     end

--- a/lib/resque/failure/airbrake.rb
+++ b/lib/resque/failure/airbrake.rb
@@ -1,7 +1,11 @@
-begin
-  require 'airbrake'
-rescue LoadError
-  raise "Can't find 'airbrake' gem. Please add it to your Gemfile or install it."
+if !defined? ::Airbrake
+  begin
+    require 'airbrake'
+  rescue LoadError
+    raise LoadError, "Can't find 'airbrake' gem. Please add it to your " \
+      "Gemfile and install it or define an Airbrake top-level constant " \
+      "implementing the Airbrake interface."
+  end
 end
 
 module Resque

--- a/test/airbrake_test.rb
+++ b/test/airbrake_test.rb
@@ -13,13 +13,13 @@ else
       payload = {'class' => Object, 'args' => 66}
 
       notify_method =
-        if Airbrake::AIRBRAKE_VERSION.to_i < 5
+        if ::Airbrake::AIRBRAKE_VERSION.to_i < 5
           :notify
         else
           :notify_sync
         end
 
-      Airbrake.expects(notify_method).with(
+      ::Airbrake.expects(notify_method).with(
         exception,
         :parameters => {:payload_class => 'Object', :payload_args => '66'})
 

--- a/test/airbrake_test.rb
+++ b/test/airbrake_test.rb
@@ -1,14 +1,10 @@
-
 require 'test_helper'
 
 begin
-  require 'airbrake'
-rescue LoadError
-  warn "Install airbrake gem to run Airbrake tests."
-end
-
-if defined? Airbrake
   require 'resque/failure/airbrake'
+rescue LoadError
+  warn "Install airbrake gem or define a compatible module to run Airbrake tests."
+else
   describe "Airbrake" do
     it "should be notified of an error" do
       exception = StandardError.new("BOOM")


### PR DESCRIPTION
Check first for an `::Airbrake` constant if defined, so that there's no unconditional dependency on the `airbrake` gem.

This makes this module usable with other implementations of the same interface.

While at it also fix the test and some relative references to the constant.