### PR TITLE
Worker only needs to call Resque.queues once to build queue list

### DIFF
--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -334,10 +334,11 @@ describe "Resque::Worker" do
     assert_equal false, @worker.work_one_job
   end
 
-  it "the queues method avoids unnecessary calls to smembers" do
-    worker = Resque::Worker.new(:critical, :high)
-    Resque.redis.expects(:smembers).at_most_once
-    assert_equal ["critical", "high"], worker.queues
+  it "the queues method avoids unnecessary calls to retrieve queue names" do
+    worker = Resque::Worker.new(:critical, :high, "num*")
+    actual_queues = ["critical", "high", "num1", "num2"]
+    Resque.data_store.expects(:queue_names).once.returns(actual_queues)
+    assert_equal actual_queues, worker.queues
   end
 
   it "can work on all queues" do


### PR DESCRIPTION
A previous PR https://github.com/resque/resque/pull/1404 added an optimization to avoid unnecessary redundant calls to redis `smembers` to get the list of queues. However, it only helped if none of the specified queues has wildcards. If you had a long list of queue specifications, and any one of them had a wildcard, you would lose the optimization.

For example, the queue list:

```
high,medium,priority*
```

Would make three calls to `Resque.queues`, when only one is needed.

This PR makes sure `Resque.queues` is never called more than once in a call to `#queues`.

It also moves away from using two different ivars to hold the list of queues, and instead uses a flag to determine if we need to apply glob matching.