### PR TITLE
Drop complex Redis identifier logic in favor of simple inspect

### DIFF
--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -68,14 +68,7 @@ module Resque
     # Get a string identifying the underlying server.
     # Probably should be private, but was public so must stay public
     def identifier
-      # support 1.x versions of redis-rb
-      if @redis.respond_to?(:server)
-        @redis.server
-      elsif @redis.respond_to?(:nodes) # distributed
-        @redis.nodes.map { |n| n.id }.join(', ')
-      else
-        @redis.client.id
-      end
+      @redis.inspect
     end
 
     # Force a reconnect to Redis.

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -281,11 +281,7 @@ describe "Resque" do
       assert_equal 3, stats[:queues]
       assert_equal 3, stats[:processed]
       assert_equal 1, stats[:failed]
-      if ENV.key? 'RESQUE_DISTRIBUTED'
-        assert_equal [Resque.redis.respond_to?(:server) ? 'localhost:9736, localhost:9737' : 'redis://localhost:9736/0, redis://localhost:9737/0'], stats[:servers]
-      else
-        assert_equal [Resque.redis.respond_to?(:server) ? 'localhost:9736' : 'redis://localhost:9736/0'], stats[:servers]
-      end
+      assert_equal [Resque.redis_id], stats[:servers]
     end
 
   end


### PR DESCRIPTION
Fixes #1591 since we no longer reference `redis.client` directly.