### PR TITLE
When a child process is killed, report the signal it was terminated with

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -913,7 +913,7 @@ module Resque
         nil
       end
 
-      job.fail(DirtyExit.new("Child process received unhandled signal #{$?.stopsig}", $?)) if $?.signaled?
+      job.fail(DirtyExit.new("Child process received unhandled signal #{$?}", $?)) if $?.signaled?
       @child = nil
     end
 


### PR DESCRIPTION
Fixes that reporting `stopsig` only works for suspended processes, returns `nil` for terminated processes.

Fixes #1588.