### PR TITLE
Remove Ruby warnings related to hooks

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -561,11 +561,6 @@ module Resque
     @hooks[name] = []
   end
 
-  # Retrieve all hooks
-  def hooks
-    @hooks
-  end
-
   # Retrieve all hooks of a given name.
   def hooks(name)
     @hooks[name]

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -543,6 +543,8 @@ module Resque
 
   private
 
+  @hooks = Hash.new { |h, k| h[k] = [] }
+
   # Register a new proc as a hook. If the block is nil this is the
   # equivalent of removing all hooks of the given name.
   #
@@ -550,26 +552,23 @@ module Resque
   def register_hook(name, block)
     return clear_hooks(name) if block.nil?
 
-    @hooks ||= {}
-    @hooks[name] ||= []
-
     block = Array(block)
     @hooks[name].concat(block)
   end
 
   # Clear all hooks given a hook name.
   def clear_hooks(name)
-    @hooks && @hooks[name] = []
+    @hooks[name] = []
   end
 
   # Retrieve all hooks
   def hooks
-    @hooks || {}
+    @hooks
   end
 
   # Retrieve all hooks of a given name.
   def hooks(name)
-    (@hooks && @hooks[name]) || []
+    @hooks[name]
   end
 end
 


### PR DESCRIPTION
Initialize the @hooks to avoid warnings and also some conditionals and memoization.

I also delete the unused definition of `hooks` that was being redefined by the `hooks(name)` method below and never was used.