### PR TITLE
Drop Coveralls. High noise, low action. Keep it to dev only.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "json"
-gem "coveralls", :require => false
 
 gem "minitest", "4.7.0"
 gem "mocha", :require => false

--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,6 @@ Resque
 
 [![Gem Version](https://badge.fury.io/rb/resque.svg)](https://rubygems.org/gems/resque)
 [![Build Status](https://travis-ci.org/resque/resque.svg)](https://travis-ci.org/resque/resque)
-[![Coverage Status](https://coveralls.io/repos/github/resque/resque/badge.svg?branch=master)](https://coveralls.io/github/resque/resque?branch=master)
 
 Resque (pronounced like "rescue") is a Redis-backed library for creating
 background jobs, placing those jobs on multiple queues, and processing

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,3 @@
-require 'coveralls'
-Coveralls.wear!
-
 require 'rubygems'
 require 'bundler/setup'
 require 'minitest/autorun'


### PR DESCRIPTION
It cluttering up all PR threads due to multiple test runs in CI.