### PR TITLE
Add 'Clear Retried Jobs' button to Failed page

### DIFF
--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -91,6 +91,12 @@ module Resque
       backend.clear(queue)
     end
 
+    def self.clear_retried
+      each do |index, job|
+        remove(index) unless job['retried_at'].nil?
+      end
+    end
+
     def self.requeue(id, queue = nil)
       backend.requeue(id, queue)
     end

--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -205,6 +205,11 @@ module Resque
       redirect u('failed')
     end
 
+    post "/failed/clear_retried" do
+      Resque::Failure.clear_retried
+      redirect u('failed')
+    end
+
     post "/failed/:queue/clear" do
       Resque::Failure.clear params[:queue]
       redirect u('failed')

--- a/lib/resque/server/views/failed.erb
+++ b/lib/resque/server/views/failed.erb
@@ -8,6 +8,12 @@
 <form method="POST" action="<%= u "failed#{'/' + params[:queue] if params[:queue]}/clear" %>">
   <input type="submit" name="" value="Clear <%= params[:queue] ? "'#{params[:queue]}'" : 'Failed' %> Jobs" onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
 </form>
+
+<% unless params[:queue] %>
+  <form method="POST" action="<%= u "failed/clear_retried" %>">
+    <input type="submit" name="" value="Clear Retried Jobs" onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
+  </form>
+<% end %>
 <form method="POST" action="<%= u "failed#{'/' + params[:queue] if params[:queue]}/requeue/all" %>">
   <input type="submit" name="" value="Retry <%= params[:queue] ? "'#{params[:queue]}'" : 'Failed' %> Jobs" onclick='return confirm("Are you absolutely sure? This cannot be undone."); />
 </form>


### PR DESCRIPTION
Right now we can either clear or retry *all* jobs using buttons on top.

But the problem is if we retry few using single retries and later we simply want to get rid of them - this PR adds a 'Clear Retried Jobs' to Resque Failed section using already existing methods defined in Resque::Failure class.