### PR TITLE
Add support for specifying negated queues

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,7 @@
 
 ### Added
 
-*
+* Add support for specifying queues that workers should ignore when using globs
 *
 
 ## 2.2.0

--- a/README.markdown
+++ b/README.markdown
@@ -253,6 +253,22 @@ Or, prioritize some queues above `*`:
 
     # QUEUE=critical,* rake resque:work
 
+#### Running All Queues Except for Some
+
+If you want your workers to work off of all queues except for some,
+you can use negation:
+
+    $ QUEUE=*,!low rake resque:work
+
+Negated globs also work. The following will instruct workers to work
+off of all queues except those beginning with `file_`:
+
+    $ QUEUE=*,!file_* rake resque:work
+
+Note that the order in which negated queues are specified does not
+matter, so `QUEUE=*,!file_*` and `QUEUE=!file_*,*` will have the same
+effect.
+
 #### Process IDs (PIDs)
 
 There are scenarios where it's helpful to record the PID of a resque

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -186,6 +186,8 @@ module Resque
       @skip_queues, @queues = queues.partition { |queue| queue.start_with?('!') }
       @skip_queues.map! { |queue| queue[1..-1] }
 
+      # The behavior of `queues` is dependent on the value of `@has_dynamic_queues: if it's true, the method returns the result of filtering @queues with `glob_match`
+      # if it's false, the method returns @queues directly. Since `glob_match` will cause skipped queues to be filtered out, we want to make sure it's called if we have @skip_queues.any?
       @has_dynamic_queues =
         @skip_queues.any? || WILDCARDS.any? { |char| @queues.join.include?(char) }
 


### PR DESCRIPTION
## What this change does

Augments the syntax used to specify worker queues to support negation.

Sample usage:

```
$ QUEUES=!priority,* rake resque:work
```

## Motivation

We would like to configure one worker to handle a specific queue, say `priority`, while configuring other workers to work off of all queues (splat) *except* for the `priority` queue. Our desired Procfile looks like this:

```
priority: env TERM_CHILD=1 QUEUES=priority bundle exec rake resque:work
worker: env TERM_CHILD=1 COUNT=3 QUEUES=!priority,* bundle exec rake resque:work
```

This is currently not possible without enumerating a whitelist of queues that workers should work off of, which is not an option for us as we would like to continue to have workers pick up new queues as they are added.