### PR TITLE
Fix individual test runs

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require 'bundler/setup'
 require 'minitest/autorun'
 require 'redis/namespace'
 require 'mocha/setup'
+require 'tempfile'
 
 $dir = File.dirname(File.expand_path(__FILE__))
 $LOAD_PATH.unshift $dir + '/../lib'


### PR DESCRIPTION
Otherwise you get an error when running individual tests:

```
$ bundle exec ruby -Itest test/worker_test.rb

  3) Error:
Resque::Worker#test_0005_writes to ENV['PIDFILE'] when supplied and #prepare is called:
NameError: uninitialized constant Tempfile
    /Users/kir/Projects/opensource/resque/test/test_helper.rb:264:in `with_pidfile'
    test/worker_test.rb:55:in `block (2 levels) in <main>'
```