### PR TITLE
Report a job that pruned worker was processing

### DIFF
--- a/lib/resque/errors.rb
+++ b/lib/resque/errors.rb
@@ -14,7 +14,13 @@ module Resque
       super message
     end
   end
-  class PruneDeadWorkerDirtyExit < DirtyExit; end
+
+  class PruneDeadWorkerDirtyExit < DirtyExit
+    def initialize(hostname, job)
+      job ||= "<Unknown Job>"
+      super("Worker #{hostname} did not gracefully exit while processing #{job}")
+    end
+  end
 
   # Raised when child process is TERM'd so job can rescue this to do shutdown work.
   class TermException < SignalException; end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -610,7 +610,9 @@ module Resque
         # client library or an older version of Resque. We won't touch these.
         if all_workers_with_expired_heartbeats.include?(worker)
           log_with_severity :info, "Pruning dead worker: #{worker}"
-          worker.unregister_worker(PruneDeadWorkerDirtyExit.new(worker.to_s))
+
+          job_class = worker.job(false)['payload']['class'] rescue nil
+          worker.unregister_worker(PruneDeadWorkerDirtyExit.new(worker.to_s, job_class))
           next
         end
 


### PR DESCRIPTION
When you run into `PruneDeadWorkerDirtyExit` in production, you have no idea what job the pruned worker was processing. That's what the PR is trying to address. It also makes the exception message a bit more user friendly.

@hkdsun @fw42 this should help us to find out if there's any pattern in workers that are killed in ungraceful way.