### PR TITLE
Support secure Redis URLs

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -112,7 +112,7 @@ module Resque
   def redis=(server)
     case server
     when String
-      if server =~ /redis\:\/\//
+      if server =~ /rediss?\:\/\//
         redis = Redis.new(:url => server, :thread_safe => true)
       else
         server, namespace = server.split('/', 2)


### PR DESCRIPTION
Resolves #1626 by extending the regex in `redis=` to allow `rediss://` secure URLs in addition to the standard `redis://`