### PR TITLE
Fix Airbrake failure backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ gem "mocha", :require => false
 gem "rack-test", "~> 0.5"
 gem "rake"
 gem "pry"
+gem "airbrake", require: false # to make airbrake backend test work

--- a/lib/resque/failure/airbrake.rb
+++ b/lib/resque/failure/airbrake.rb
@@ -21,10 +21,11 @@ module Resque
       end
 
       def save
-        notify(exception,
-          :parameters => {
-          :payload_class => payload['class'].to_s,
-          :payload_args => payload['args'].inspect
+        notify(
+          exception,
+          parameters: {
+            payload_class: payload['class'].to_s,
+            payload_args: payload['args'].inspect
           }
         )
       end
@@ -33,10 +34,10 @@ module Resque
 
       def notify(exception, options)
         if ::Airbrake.respond_to?(:notify_sync)
-          Airbrake.notify_sync(exception, options)
+          ::Airbrake.notify_sync(exception, options)
         else
           # Older versions of Airbrake (< 5)
-          Airbrake.notify(exception, options)
+          ::Airbrake.notify(exception, options)
         end
       end
     end


### PR DESCRIPTION
Airbrake failure backend doesn't work now. And the tests are skipped because no airbrake dependency in Gemfile