### PR TITLE
Resque::Failure::Multiple calls `save` to all backends even if some backends fail

### DIFF
--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -33,9 +33,11 @@ module Resque
         errors = {}
 
         @backends.each do |backend|
-          backend.save
-        rescue
-          errors[backend.class] = $!
+          begin
+            backend.save
+          rescue
+            errors[backend.class] = $!
+          end
         end
 
         unless errors.empty?

--- a/test/resque_failure_multiple_test.rb
+++ b/test/resque_failure_multiple_test.rb
@@ -2,15 +2,51 @@ require 'test_helper'
 require 'resque/failure/multiple'
 
 describe "Resque::Failure::Multiple" do
+  class BrokenBackend < Resque::Failure::Base
+    class OriginalError < RuntimeError
+    end
+
+    def save
+      raise OriginalError, "Raise error always"
+    end
+  end
+
+  let(:exception) { StandardError.exception('some error') }
+  let(:worker) { Resque::Worker.new(:test) }
+  let(:payload) { { "class" => Object, "args" => 3 } }
 
   it 'requeue_all and does not raise an exception' do
     with_failure_backend(Resque::Failure::Multiple) do
       Resque::Failure::Multiple.classes = [Resque::Failure::Redis]
-      exception = StandardError.exception('some error')
-      worker = Resque::Worker.new(:test)
-      payload = { "class" => Object, "args" => 3 }
+
       Resque::Failure.create({:exception => exception, :worker => worker, :queue => "queue", :payload => payload})
       Resque::Failure::Multiple.requeue_all # should not raise an error
+    end
+  end
+
+  it 'call #save to all backends even if some backends fail' do
+    with_failure_backend(Resque::Failure::Multiple) do
+      Resque::Failure::Multiple.classes = [BrokenBackend, Resque::Failure::Redis]
+      Resque::Failure::Redis.any_instance.expects(:save)
+
+      assert_raises(Resque::Failure::Multiple::BackendError) {
+        Resque::Failure.create({:exception => exception, :worker => worker, :queue => "queue", :payload => payload})
+      }
+    end
+  end
+
+  it 'raises BackendError with original error when some backends fail' do
+    with_failure_backend(Resque::Failure::Multiple) do
+      Resque::Failure::Multiple.classes = [BrokenBackend, Resque::Failure::Redis]
+
+      begin
+        Resque::Failure.create({:exception => exception, :worker => worker, :queue => "queue", :payload => payload})
+      rescue Resque::Failure::Multiple::BackendError => err
+        assert_equal err.original_errors.keys.size, 1
+        assert_instance_of BrokenBackend::OriginalError, err.original_errors[BrokenBackend]
+      else
+        raise "Expect to raise BackendError but not raised"
+      end
     end
   end
 end


### PR DESCRIPTION
When some failure backend raise error during `Resque::Failure::Multiple#save`, the rest backends' `save` are never called.

```ruby
class BrokenBackend < Resque::Failure::Base
  def save
    raise "Broken"
  end
end

Resque::Failure::Multiple.classes = [BrokenBackend, Resque::Failure::Redis]
Resque::Failure.backend = Resque::Failure::Multiple

# When a job fails, Resque::Failure::Redis#save is never called.
```

I want to call all backends' `save` for redundancy. I wrote patch to call all backends and wrap original error(s).
