### PR TITLE
Use Minitest 5 for test.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 gem "json"
 
-gem "minitest", "4.7.0"
+gem "minitest", "5.11.3"
 gem "mocha", :require => false
 gem "rack-test", "~> 0.5"
 gem "rake"

--- a/test/job_hooks_test.rb
+++ b/test/job_hooks_test.rb
@@ -357,7 +357,7 @@ describe "Resque::Job before_dequeue" do
 
   it "a before dequeue hook that returns false should prevent the job from getting dequeued" do
     history = []
-    assert_equal nil, Resque.dequeue(BeforeDequeueJobAbort, history)
+    assert_nil Resque.dequeue(BeforeDequeueJobAbort, history)
   end
 end
 

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -70,7 +70,7 @@ describe "Resque" do
     assert_equal '/tmp', job.args[1]
 
     assert Resque.reserve(:ivar)
-    assert_equal nil, Resque.reserve(:ivar)
+    assert_nil Resque.reserve(:ivar)
   end
 
   it "can remove jobs from a queue by way of an ivar" do
@@ -135,7 +135,7 @@ describe "Resque" do
     assert_equal '/tmp', job.args[1]
 
     assert Resque.reserve(:method)
-    assert_equal nil, Resque.reserve(:method)
+    assert_nil Resque.reserve(:method)
   end
 
   it "can define a queue for jobs by way of a method" do
@@ -202,7 +202,7 @@ describe "Resque" do
       assert_equal({ 'name' => 'chris' }, Resque.pop(:people))
       assert_equal({ 'name' => 'bob' }, Resque.pop(:people))
       assert_equal({ 'name' => 'mark' }, Resque.pop(:people))
-      assert_equal nil, Resque.pop(:people)
+      assert_nil Resque.pop(:people)
     end
 
     it "knows how big a queue is" do
@@ -228,7 +228,7 @@ describe "Resque" do
       assert_equal([{ 'name' => 'chris' }, { 'name' => 'bob' }], Resque.peek(:people, 0, 2))
       assert_equal([{ 'name' => 'chris' }, { 'name' => 'bob' }, { 'name' => 'mark' }], Resque.peek(:people, 0, 3))
       assert_equal({ 'name' => 'mark' }, Resque.peek(:people, 2, 1))
-      assert_equal nil, Resque.peek(:people, 3)
+      assert_nil Resque.peek(:people, 3)
       assert_equal [], Resque.peek(:people, 3, 2)
     end
 
@@ -237,7 +237,7 @@ describe "Resque" do
       assert_equal %w( cars people ).sort, Resque.queues.sort
       Resque.remove_queue(:people)
       assert_equal %w( cars ), Resque.queues
-      assert_equal nil, Resque.pop(:people)
+      assert_nil Resque.pop(:people)
     end
 
     it "knows what queues it is managing" do

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -625,7 +625,7 @@ describe "Resque::Worker" do
     without_forking do
       @worker.extend(AssertInWorkBlock).work(0) do
         found = Resque::Worker.find('blah-blah')
-        assert_equal nil, found
+        assert_nil found
       end
     end
   end
@@ -728,7 +728,7 @@ describe "Resque::Worker" do
     assert_instance_of Time, workerA.heartbeat
 
     workerA.remove_heartbeat
-    assert_equal nil, workerA.heartbeat
+    assert_nil workerA.heartbeat
   end
 
   it "removes old heartbeats before starting heartbeat thread" do
@@ -753,7 +753,7 @@ describe "Resque::Worker" do
       sleep 0.1 until Resque::Worker.all_heartbeats.empty?
     end
 
-    assert_equal nil, workerA.heartbeat
+    assert_nil workerA.heartbeat
   end
 
   it "does not generate heartbeats that depend on the worker clock, but only on the server clock" do


### PR DESCRIPTION
This PR enables to use minitest 5.
I updated it to the latest version.
https://rubygems.org/gems/minitest

As "assert_equal nil, foo" is deprecated from Minitest 5, I fixed it.

```
DEPRECATED: Use assert_nil if expecting nil from /home/jaruga/git/resque/test/resque_test.rb:205. This will fail in Minitest 6.
```

