### PR TITLE
Improve failed queues list on /queues UI

### DIFF
--- a/lib/resque/server/helpers.rb
+++ b/lib/resque/server/helpers.rb
@@ -9,7 +9,9 @@ Resque::Server.helpers do
 
   def failed_multiple_queues?
     return @multiple_failed_queues if defined?(@multiple_failed_queues)
-    @multiple_failed_queues = Resque::Failure.queues.size > 1
+
+    @multiple_failed_queues = Resque::Failure.queues.size > 1 ||
+      Resque::Failure.backend == Resque::Failure::RedisMultiQueue
   end
 
   def failed_size


### PR DESCRIPTION
Explicitily check if `RedisMultiQueue` backend is enabled in `failed_multiple_queues?` helper.

With the current implementation in case if `RedisMultiQueue` failure backend is set and there is only one failed queue in the resque it would make an [assumption](https://github.com/resque/resque/blob/v1.27.4/lib/resque/server/views/queues.erb#L51-L54) the name of the queue is `failed`. When developer visits the `failed` link he or she is unable to see the failed jobs.