### PR TITLE
Add new backend that does not allow duplicates

### DIFF
--- a/lib/resque/failure/redis_unique_failures.rb
+++ b/lib/resque/failure/redis_unique_failures.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'resque/failure/redis'
+
+module Resque
+  module Failure
+    class RedisUniqueFailures < Redis
+      def save
+        super unless failure_already_exists?
+      end
+
+      private
+
+      def failure_already_exists?
+        self.class.each(0, self.class.count, :failed) do |_, item|
+          if item['exception'] == exception.class.to_s && item['payload'] == payload
+            return true
+          end
+        end
+        false
+      end
+    end
+  end
+end

--- a/test/resque_failure_multi_queue_test.rb
+++ b/test/resque_failure_multi_queue_test.rb
@@ -6,7 +6,7 @@ describe "Resque::Failure::RedisMultiQueue" do
   let(:exception)  { StandardError.exception(bad_string) }
   let(:worker)     { Resque::Worker.new(:test) }
   let(:queue)      { 'queue' }
-  let(:payload)    { { "class" => Object, "args" => 3 } }
+  let(:payload)    { { "class" => "Object", "args" => 3 } }
 
   before do
     Resque::Failure::RedisMultiQueue.clear

--- a/test/resque_failure_multiple_test.rb
+++ b/test/resque_failure_multiple_test.rb
@@ -8,7 +8,7 @@ describe "Resque::Failure::Multiple" do
       Resque::Failure::Multiple.classes = [Resque::Failure::Redis]
       exception = StandardError.exception('some error')
       worker = Resque::Worker.new(:test)
-      payload = { "class" => Object, "args" => 3 }
+      payload = { "class" => "Object", "args" => 3 }
       Resque::Failure.create({:exception => exception, :worker => worker, :queue => "queue", :payload => payload})
       Resque::Failure::Multiple.requeue_all # should not raise an error
     end

--- a/test/resque_failure_redis_test.rb
+++ b/test/resque_failure_redis_test.rb
@@ -6,7 +6,7 @@ describe "Resque::Failure::Redis" do
   let(:exception)  { StandardError.exception(bad_string) }
   let(:worker)     { Resque::Worker.new(:test) }
   let(:queue)      { "queue" }
-  let(:payload)    { { "class" => Object, "args" => 3 } }
+  let(:payload)    { { "class" => "Object", "args" => 3 } }
 
   before do
     Resque::Failure::Redis.clear

--- a/test/resque_failure_redis_unique_failures_test.rb
+++ b/test/resque_failure_redis_unique_failures_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+require 'resque/failure/redis_unique_failures'
+
+describe 'Resque::Failure::RedisUniqueFailures' do
+  let(:bad_string) { [39, 52, 127, 86, 93, 95, 39].map(&:chr).join }
+  let(:exception)  { StandardError.exception(bad_string) }
+  let(:worker)     { Resque::Worker.new(:test) }
+  let(:queue)      { 'queue' }
+  let(:payload)    { { 'class' => 'Object', 'args' => 3 } }
+  let(:redis_backend_instance) do
+    Resque::Failure::RedisUniqueFailures.new(
+      exception, worker, queue, payload
+    )
+  end
+  let(:another_redis_backend_instance) do
+    Resque::Failure::RedisUniqueFailures.new(
+      exception, worker, queue, payload_with_different_order
+    )
+  end
+
+  describe '#save' do
+    describe 'with duplicates' do
+      it 'saves the failure only once' do
+        redis_backend_instance.save
+        redis_backend_instance.save
+        assert_equal 1, Resque::Failure::RedisUniqueFailures.count
+      end
+    end
+
+    describe 'with payload in different order' do
+      let(:payload_with_different_order) { { 'args' => 3, 'class' => 'Object' } }
+
+      it 'saves the failure only once' do
+        redis_backend_instance.save
+        another_redis_backend_instance.save
+        assert_equal 1, Resque::Failure::RedisUniqueFailures.count
+      end
+    end
+
+    describe 'with nested hashes in the payload' do
+      let(:payload) do
+        {
+          'class' => 'Object',
+          'args' => { 'first_name' => 'Peter', 'last_name' => 'Parker' }
+        }
+      end
+      let(:payload_with_different_order) do
+        {
+          'args' => { 'last_name' => 'Parker', 'first_name' => 'Peter' },
+          'class' => 'Object'
+        }
+      end
+
+      it 'saves the failure only once' do
+        redis_backend_instance.save
+        another_redis_backend_instance.save
+        assert_equal 1, Resque::Failure::RedisUniqueFailures.count
+      end
+    end
+  end
+end


### PR DESCRIPTION
With the `Resque::Failure::Redis` class, a job failure instance keeps being added to redis until someone fixes it. So sometimes, we end up with 500 failed jobs in the dashboard where the actual number of unique failures is 15. (This happens often for poller jobs)

This PR introduces a class `Resque::Failure::RedisUniqueFailures` that stops resque from adding multiple instances of the same failed jobs.

- It also fixes the tests for the other backends that were representing incorrectly the `payload` as including `"class" => Object` instead of `"class" => "Object"`