### PR TITLE
Add `requeue_queue` method to `Resque::Failure::Multiple`

### DIFF
--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -60,6 +60,10 @@ module Resque
         classes.first.requeue_all
       end
 
+      def self.requeue_queue(queue)
+        classes.first.requeue_queue(queue)
+      end
+
       def self.remove(index, queue)
         classes.each { |klass| klass.remove(index) }
       end

--- a/test/resque_failure_multiple_test.rb
+++ b/test/resque_failure_multiple_test.rb
@@ -1,16 +1,24 @@
 require 'test_helper'
 require 'resque/failure/multiple'
 
-describe "Resque::Failure::Multiple" do
-
+describe 'Resque::Failure::Multiple' do
   it 'requeue_all and does not raise an exception' do
     with_failure_backend(Resque::Failure::Multiple) do
       Resque::Failure::Multiple.classes = [Resque::Failure::Redis]
       exception = StandardError.exception('some error')
       worker = Resque::Worker.new(:test)
-      payload = { "class" => "Object", "args" => 3 }
-      Resque::Failure.create({:exception => exception, :worker => worker, :queue => "queue", :payload => payload})
+      payload = { 'class' => 'Object', 'args' => 3 }
+      Resque::Failure.create({:exception => exception, :worker => worker, :queue => 'queue', :payload => payload})
       Resque::Failure::Multiple.requeue_all # should not raise an error
+    end
+  end
+
+  it 'requeue_queue delegates to the first class and returns a mapped queue name' do
+    with_failure_backend(Resque::Failure::Multiple) do
+      mock_class = MiniTest::Mock.new
+      mock_class.expect(:requeue_queue, 'mapped_queue', ['queue'])
+      Resque::Failure::Multiple.classes = [mock_class]
+      assert_equal 'mapped_queue', Resque::Failure::Multiple.requeue_queue('queue')
     end
   end
 end


### PR DESCRIPTION
This change adds the `requeue_queue` method to `Resque::Failure::Multiple` this is a hard requirement for the "retry-all" functionality to work via the Web UI and is currently causing issues w/in the `resque-retry` gem (which I maintain). This also seems to be an innocuous change to `Resque` itself.