### PR TITLE
Switch queue direction in preperation for resilient queues

### DIFF
--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -101,13 +101,13 @@ module Resque
       def push_to_queue(queue,encoded_item)
         @redis.pipelined do
           watch_queue(queue)
-          @redis.rpush redis_key_for_queue(queue), encoded_item
+          @redis.lpush redis_key_for_queue(queue), encoded_item
         end
       end
 
       # Pop whatever is on queue
       def pop_from_queue(queue)
-        @redis.lpop(redis_key_for_queue(queue))
+        @redis.rpop(redis_key_for_queue(queue))
       end
 
       # Get the number of items in the queue

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -219,17 +219,17 @@ describe "Resque" do
     end
 
     it "can peek at a queue" do
-      assert_equal({ 'name' => 'chris' }, Resque.peek(:people))
+      assert_equal({ 'name' => 'mark' }, Resque.peek(:people))
       assert_equal 3, Resque.size(:people)
     end
 
     it "can peek multiple items on a queue" do
       assert_equal({ 'name' => 'bob' }, Resque.peek(:people, 1, 1))
 
-      assert_equal([{ 'name' => 'bob' }, { 'name' => 'mark' }], Resque.peek(:people, 1, 2))
-      assert_equal([{ 'name' => 'chris' }, { 'name' => 'bob' }], Resque.peek(:people, 0, 2))
-      assert_equal([{ 'name' => 'chris' }, { 'name' => 'bob' }, { 'name' => 'mark' }], Resque.peek(:people, 0, 3))
-      assert_equal({ 'name' => 'mark' }, Resque.peek(:people, 2, 1))
+      assert_equal([{ 'name' => 'bob' }, { 'name' => 'chris' }], Resque.peek(:people, 1, 2))
+      assert_equal([{ 'name' => 'mark' }, { 'name' => 'bob' }], Resque.peek(:people, 0, 2))
+      assert_equal([{ 'name' => 'mark' }, { 'name' => 'bob' }, { 'name' => 'chris' }], Resque.peek(:people, 0, 3))
+      assert_equal({ 'name' => 'chris' }, Resque.peek(:people, 2, 1))
       assert_nil Resque.peek(:people, 3)
       assert_equal [], Resque.peek(:people, 3, 2)
     end
@@ -356,8 +356,8 @@ describe "Resque" do
       assert_equal 2, queues['queue1'][:size]
 
       samples = queues['queue1'][:samples]
-      assert_equal([{'arg1' => '1'}], samples[0]['args'])
-      assert_equal([{'arg1' => '2'}], samples[1]['args'])
+      assert_equal([{'arg1' => '2'}], samples[0]['args'])
+      assert_equal([{'arg1' => '1'}], samples[1]['args'])
     end
 
     it "sample_queues with more jobs only returns sample size number of jobs" do


### PR DESCRIPTION
This is the first PR for resilient queues using `rpoplpush` within Resque. This PR changes the direction of the jobs pushed to the queue and the location where the jobs are poped off the queue. This is required since there is no `lpoprpush` command in Redis. 

I will follow up with another PR to make the changes required for utilizing `rpoplpush`. 