### PR TITLE
Fix Resque::DataStore#decrement_stat

### DIFF
--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -320,8 +320,12 @@ module Resque
         @redis.incrby("stat:#{stat}", by)
       end
 
-      def decremet_stat(stat, by = 1)
+      def decrement_stat(stat, by = 1)
         @redis.decrby("stat:#{stat}", by)
+      end
+
+      def decremet_stat(stat, by = 1)
+        decrement_stat(stat, by)
       end
 
       def clear_stat(stat)


### PR DESCRIPTION
`Resque::DataStore#decreme{,n}t_stat` delegates to `Resque::DataStore::StatsAccess#decrement_stat`, which does not exist.

```
[1] pry(main)> Resque.stat_data_store.class
=> Resque::DataStore

[2] pry(main)> Resque.stat_data_store.decrement_stat('test')
(pry):2:in `<main>': Resque::DataStore#decrement_stat at /Users/uasi/.rbenv/versions/2.4.1/lib/ruby/2.4.0/forwardable.rb:157 forwarding to private method Resque::DataStore::StatsAccess#decrement_stat
NoMethodError: undefined method `decrement_stat' for #<Resque::DataStore::StatsAccess:0x007ff461c78c08>
Did you mean?  decremet_stat
               increment_stat
from /Users/uasi/.rbenv/versions/2.4.1/lib/ruby/2.4.0/forwardable.rb:227:in `decrement_stat'

[3] pry(main)> Resque.stat_data_store.decremet_stat('test')
[Resque] [Deprecation] Resque::DataStore #decremet_stat method is deprecated (please use #decrement_stat)
/Users/uasi/Dev/Git/github.com/increments/Qiita/path/ruby/2.4.0/gems/resque-2.0.0/lib/resque/data_store.rb:59:in `decremet_stat': Resque::DataStore#decrement_stat at /Users/uasi/.rbenv/versions/2.4.1/lib/ruby/2.4.0/forwardable.rb:157 forwarding to private method Resque::DataStore::StatsAccess#decrement_stat
NoMethodError: undefined method `decrement_stat' for #<Resque::DataStore::StatsAccess:0x007ff461c78c08>
Did you mean?  decremet_stat
               increment_stat
from /Users/uasi/.rbenv/versions/2.4.1/lib/ruby/2.4.0/forwardable.rb:227:in `decrement_stat'

[4] pry(main)> Resque::VERSION
=> "2.0.0"
```

This PR adds `Resque::DataStore::StatsAccess#decrement_stat`, leaving `#decremet_stat` (note the typo) as it is.