### PR TITLE
Update HOOKS.md plugin link

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -5,7 +5,7 @@ You can customize Resque or write plugins using its hook API. In many
 cases you can use a hook rather than mess with Resque's internals.
 
 For a list of available plugins see
-<http://wiki.github.com/resque/resque/plugins>.
+<https://github.com/resque/resque/wiki/plugins>.
 
 
 Worker Hooks


### PR DESCRIPTION
When I visited http://wiki.github.com/resque/resque/plugins I got an error page that said "We didn't receive a proper request from your browser. Please contact us if the problem persists." - I believe the correct link here is https://github.com/resque/resque/wiki/plugins but if it isn't let me know and I can update this PR.

@rafaelfranca I see you merged last to this repo, are you the best person to ping on this? 🤔 