### PR TITLE
Add queue_empty and worker_exit hooks on the worker

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+### Added
+* Added two new hooks.
+  - `queue_empty` when the job queue empties and the worker becomes idle
+  - `worker_exit` when the worker exits
+
+  See [docs/HOOKS.md](http://github.com/resque/resque/blob/master/docs/HOOKS.md) for
+  further details. (@jeremywadsack)
+
 ## 2.0.0 (2018-11-06)
 
 ### Fixed

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -35,13 +35,28 @@ And after forking:
     end
 
 The `after_fork` hook will be run in the child process and is passed
-the current job. Any changes you make, therefor, will only live as
+the current job. Any changes you make, therefore, will only live as
 long as the job currently being processes.
 
 All worker hooks can also be set using a setter, e.g.
 
     Resque.after_fork = proc { puts "called" }
 
+When the worker finds no more jobs in the queue:
+
+    Resque.queue_empty do
+      puts "Call me whenever the worker becomes idle"
+    end
+
+The `queue_empty` hook will be run in the **parent** process.
+
+When the worker exits:
+
+    Resque.worker_exit do
+      puts "Call me when the work is about to terminate"
+    end
+
+The `worker_exit` hook will be run in the **parent** process.
 
 Workers can also take advantage of running any code defined using Ruby's `at_exit` block by setting
 `ENV["RUN_AT_EXIT_HOOKS"]=1`. By default, this is turned off. Be advised that setting this value might execute

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -287,6 +287,34 @@ module Resque
     register_hook(:after_pause, block)
   end
 
+  # The `queue_empty` hook will be run in the **parent** process when
+  # the worker finds no more jobs in the queue and becomes idle.
+  #
+  # Call with a block to register a hook.
+  # Call with no arguments to return all registered hooks.
+  def queue_empty(&block)
+    block ? register_hook(:queue_empty, block) : hooks(:queue_empty)
+  end
+
+  # Register a queue_empty proc.
+  def queue_empty=(block)
+    register_hook(:queue_empty, block)
+  end
+
+  # The `worker_exit` hook will be run in the **parent** process
+  # after the worker has existed (via SIGQUIT, SIGTERM, SIGINT, etc.).
+  #
+  # Call with a block to register a hook.
+  # Call with no arguments to return all registered hooks.
+  def worker_exit(&block)
+    block ? register_hook(:worker_exit, block) : hooks(:worker_exit)
+  end
+
+  # Register a worker_exit proc.
+  def worker_exit=(block)
+    register_hook(:worker_exit, block)
+  end
+
   def to_s
     "Resque Client connected to #{redis_id}"
   end


### PR DESCRIPTION
As discussed in #1647, to allow plugins and such to act on events such as the worker becoming idle (queue is now empty) and the worker exiting, this PR adds support for two new worker hooks.

  - `queue_empty` when the job queue empties and the worker becomes idle
  - `worker_exit` when the worker exits

Please review and let me know comments, thoughts. I'm happy to rename those if they don't feel "hook-y" enough. I wasn't sure, but also considered "after_queue_empty" and "before_exit".