### PR TITLE
Fix parsing worker_id to retrieve queue name includes colon

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -103,7 +103,7 @@ module Resque
       skip_exists = options[:skip_exists]
 
       if skip_exists || exists?(worker_id)
-        host, pid, queues_raw = worker_id.split(':')
+        host, pid, queues_raw = worker_id.split(':', 3)
         queues = queues_raw.split(',')
         worker = new(*queues)
         worker.hostname = host

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -642,6 +642,14 @@ describe "Resque::Worker" do
     end
   end
 
+  it "retrieve queues (includes colon) from worker_id" do
+    worker = Resque::Worker.new("jobs", "foo:bar")
+    worker.register_worker
+
+    found = Resque::Worker.find(worker.to_s)
+    assert_equal worker.queues, found.queues
+  end
+
   it "prunes dead workers with heartbeat older than prune interval" do
     assert_equal({}, Resque::Worker.all_heartbeats)
     now = Time.now


### PR DESCRIPTION
`Resque::Worker.find` parses `worker_id` to retrieve host, pid, and queue names.
But when queue name includes colon `:`, that method ignores string after first colon.
I expect to allow the method to retrieve queue name that includes colon correctly (this PR), or reject the queue name somewhere.

```ruby
w = Resque::Worker.find("localhost:123:foo:bar")
w.queues # expected ["foo:bar] but ["foo"]
```

