### PR TITLE
Enable Rails logger to be displayed in STDOUT by default in the devel…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ Layout/Tab:
   Enabled: true
 
 # Blank lines should not have any spaces.
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Enabled: true
 
 # No trailing whitespace.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,6 @@
+### Changed
+* Enable Rails logger to be displayed in STDOUT by default in the development environment.
+
 ## 2.0.0 (2018-11-06)
 
 ### Fixed

--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -44,6 +44,17 @@ namespace :resque do
         ActiveSupport.run_load_hooks(:before_eager_load, Rails.application)
         Rails.application.config.eager_load_namespaces.each(&:eager_load!)
       end
+
+      if Rails.env.development? && !ENV['BACKGROUND'] &&
+        !ActiveSupport::Logger.logger_outputs_to?(Rails.logger, STDOUT)
+
+        # log to stdout
+        console = ActiveSupport::Logger.new(STDOUT)
+        console.formatter = Rails.logger.formatter
+        console.level = Rails.logger.level
+
+        Rails.logger.extend(ActiveSupport::Logger.broadcast(console))
+      end
     end
   end
 


### PR DESCRIPTION
…opment environment.

I saw a lot of developers feel confused for Resque log in the development environment. Just set it to STDOUT by default and make the consistent logger experience between `rails server` and `rails resque:work`.

Most of the code is referenced from https://github.com/rails/rails/blob/bf625f7fecabbcda22b388e088ad5c29016b2385/railties/lib/rails/commands/server/server_command.rb#L76-L86