### PR TITLE
README cleanup

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -37,15 +37,38 @@ Resque now supports Ruby 2.3.0 and above.
 We will also only be supporting Redis 3.0 and above going forward.
 
 
-The Blog Post
--------------
+Table of Contents
+-----------------
 
-For the backstory, philosophy, and history of Resque's beginnings,
-please see [the blog post][0].
-
+* [Overview](#overview)
+* [Installation](#installation)
+* [Running Workers](#running-workers)
+* [The Front End](#the-front-end)
+* [Jobs](#jobs)
+* [Configuration](#configuration)
+* * [Redis](#redis)
+* * [Logging](#logging)
+* * [Namespaces](#namespaces)
+* * [Storing Statistics](#storing-statistics)
+* [Plugins and Hooks](#plugins-and-hooks)
+* [Additional Information](#additional-information)
+* * [Resque vs DelayedJob](#resque-vs-delayedjob)
+* * [Forking](#forking)
+* * [Signals](#signals)
+* * [Heroku](#heroku)
+* * [Monitoring](#monitoring)
+* * [Mysql::Error](#mysqlerror-mysql-server-has-gone-away)
+* [Development](#development)
+* * [Demo](#demo)
+* * [Contributing](#contributing)
+* [Questions](#questions)
+* [Meta](#meta)
+* [Author](#author)
 
 Overview
 --------
+
+For the backstory, philosophy, and history of Resque's beginnings, please see [the blog post](http://github.com/blog/542-introducing-resque).
 
 Resque allows you to create jobs and place them on a queue, then,
 later, pull those jobs off the queue and process them.
@@ -112,6 +135,211 @@ Workers can be given multiple queues (a "queue list") and run on
 multiple machines. In fact they can be run anywhere with network
 access to the Redis server.
 
+Installation
+------------
+
+Add the gem to your Gemfile:
+
+    gem 'resque'
+
+Next, install it with Bundler:
+
+    $ bundle
+
+#### Rack
+
+In your Rakefile, or some other file in `lib/tasks` (ex: `lib/tasks/resque.rake`), load the resque rake tasks:
+
+``` ruby
+require 'resque'
+require 'resque/tasks'
+require 'your/app' # Include this line if you want your workers to have access to your application
+```
+
+#### Rails 3+
+
+In your Rakefile, or some other file in `lib/tasks` (ex: `lib/tasks/resque.rake`),
+load the resque rake tasks. Also, by default Resque won't know about your application's
+environment. That is, it won't be able to find and run your jobs. You'll need to define
+a `resque:setup` task with a dependency on the `environment` rake task:
+
+``` ruby
+require 'resque/tasks'
+task "resque:setup" => :environment
+```
+
+GitHub's setup task looks like this:
+
+``` ruby
+task "resque:setup" => :environment do
+  Grit::Git.git_timeout = 10.minutes
+end
+```
+
+We don't want the `git_timeout` as high as 10 minutes in our web app,
+but in the Resque workers it's fine.
+
+Running Workers
+---------------
+
+Resque workers are rake tasks that run forever. They basically do this:
+
+``` ruby
+start
+loop do
+  if job = reserve
+    job.process
+  else
+    sleep 5 # Polling frequency = 5
+  end
+end
+shutdown
+```
+
+Starting a worker is simple:
+
+    $ QUEUE=* rake resque:work
+
+Or, you can start multiple workers:
+
+    $ COUNT=2 QUEUE=* rake resque:workers
+
+This will spawn five Resque workers, each in its own process. Hitting
+ctrl-c should be sufficient to stop them all.
+
+#### Priorities and Queue Lists
+
+Resque doesn't support numeric priorities but instead uses the order
+of queues you give it. We call this list of queues the "queue list."
+
+Let's say we add a `warm_cache` queue in addition to our `file_serve`
+queue. We'd now start a worker like so:
+
+    $ QUEUES=file_serve,warm_cache rake resque:work
+
+When the worker looks for new jobs, it will first check
+`file_serve`. If it finds a job, it'll process it then check
+`file_serve` again. It will keep checking `file_serve` until no more
+jobs are available. At that point, it will check `warm_cache`. If it
+finds a job it'll process it then check `file_serve` (repeating the
+whole process).
+
+In this way you can prioritize certain queues. At GitHub we start our
+workers with something like this:
+
+    $ QUEUES=critical,archive,high,low rake resque:work
+
+Notice the `archive` queue - it is specialized and in our future
+architecture will only be run from a single machine.
+
+At that point we'll start workers on our generalized background
+machines with this command:
+
+    $ QUEUES=critical,high,low rake resque:work
+
+And workers on our specialized archive machine with this command:
+
+    $ QUEUE=archive rake resque:work
+
+#### Running All Queues
+
+If you want your workers to work off of every queue, including new
+queues created on the fly, you can use a splat:
+
+    $ QUEUE=* rake resque:work
+
+Queues will be processed in alphabetical order.
+
+Or, prioritize some queues above `*`:
+
+    # QUEUE=critical,* rake resque:work
+
+#### Process IDs (PIDs)
+
+There are scenarios where it's helpful to record the PID of a resque
+worker process.  Use the PIDFILE option for easy access to the PID:
+
+    $ PIDFILE=./resque.pid QUEUE=file_serve rake resque:work
+
+#### Running in the background
+
+There are scenarios where it's helpful for
+the resque worker to run itself in the background (usually in combination with
+PIDFILE).  Use the BACKGROUND option so that rake will return as soon as the
+worker is started.
+
+    $ PIDFILE=./resque.pid BACKGROUND=yes QUEUE=file_serve rake resque:work
+
+#### Polling frequency
+
+You can pass an INTERVAL option which is a float representing the polling frequency.
+The default is 5 seconds, but for a semi-active app you may want to use a smaller value.
+
+    $ INTERVAL=0.1 QUEUE=file_serve rake environment resque:work
+
+The Front End
+-------------
+
+Resque comes with a Sinatra-based front end for seeing what's up with
+your queue.
+
+![The Front End](https://camo.githubusercontent.com/64d150a243987ffbc33f588bd6d7722a0bb8d69a/687474703a2f2f7475746f7269616c732e6a756d7073746172746c61622e636f6d2f696d616765732f7265737175655f6f766572766965772e706e67)
+
+#### Standalone
+
+If you've installed Resque as a gem running the front end standalone is easy:
+
+    $ resque-web
+
+It's a thin layer around `rackup` so it's configurable as well:
+
+    $ resque-web -p 8282
+
+If you have a Resque config file you want evaluated just pass it to
+the script as the final argument:
+
+    $ resque-web -p 8282 rails_root/config/initializers/resque.rb
+
+You can also set the namespace directly using `resque-web`:
+
+    $ resque-web -p 8282 -N myapp
+
+or set the Redis connection string if you need to do something like select a different database:
+
+    $ resque-web -p 8282 -r localhost:6379:2
+
+#### Passenger
+
+Using Passenger? Resque ships with a `config.ru` you can use. See
+Phusion's guide:
+
+Apache: <https://www.phusionpassenger.com/library/deploy/apache/deploy/ruby/>
+Nginx: <https://www.phusionpassenger.com/library/deploy/nginx/deploy/ruby/>
+
+#### Rack::URLMap
+
+If you want to load Resque on a subpath, possibly alongside other
+apps, it's easy to do with Rack's `URLMap`:
+
+``` ruby
+require 'resque/server'
+
+run Rack::URLMap.new \
+  "/"       => Your::App.new,
+  "/resque" => Resque::Server.new
+```
+
+Check `examples/demo/config.ru` for a functional example (including
+HTTP basic auth).
+
+#### Rails 3+
+
+You can also mount Resque on a subpath in your existing Rails 3 app by adding `require 'resque/server'` to the top of your routes file or in an initializer then adding this to `routes.rb`:
+
+``` ruby
+mount Resque::Server.new, :at => "/resque"
+```
+
 Jobs
 ----
 
@@ -137,7 +365,7 @@ mention "foreground" and "background" because they make conceptual
 sense. You could easily be spidering sites and sticking data which
 needs to be crunched later into a queue.
 
-### Persistence
+#### Persistence
 
 Jobs are persisted to queues as JSON objects. Let's take our `Archive`
 example from above. We'll run the following code to create a job:
@@ -182,7 +410,7 @@ If your jobs were run against marshaled objects, they could
 potentially be operating on a stale record with out-of-date information.
 
 
-### send_later / async
+#### send_later / async
 
 Want something like DelayedJob's `send_later` or the ability to use
 instance methods instead of just methods for jobs? See the `examples/`
@@ -191,7 +419,7 @@ directory for goodies.
 We plan to provide first class `async` support in a future release.
 
 
-### Failure
+#### Failure
 
 If a job raises an exception, it is logged and handed off to the
 `Resque::Failure` module. Failures are logged either locally in Redis
@@ -214,446 +442,11 @@ Resque::Failure.backend = Resque::Failure::Multiple
 Keep this in mind when writing your jobs: you may want to throw
 exceptions you would not normally throw in order to assist debugging.
 
-### Logging
 
-Workers support basic logging to STDOUT.
-
-You can control the logging threshold using `Resque.logger.level`:
-
-```ruby
-# config/initializers/resque.rb
-Resque.logger.level = Logger::DEBUG
-```
-
-If you want Resque to log to a file, in Rails do:
-
-```ruby
-# config/initializers/resque.rb
-Resque.logger = Logger.new(Rails.root.join('log', "#{Rails.env}_resque.log"))
-```
-
-### Storing Statistics
- Resque allows to store count of processed and failed jobs.
-
- By default it will store it in Redis using the keys `stats:processed` and `stats:failed`.
-
- Some apps would want another stats store, or even a null store:
-
- ```ruby
-# config/initializers/resque.rb
-class NullDataStore
-  def stat(stat)
-    0
-  end
-
-  def increment_stat(stat, by)
-  end
-
-  def decrement_stat(stat, by)
-  end
-
-  def clear_stat(stat)
-  end
-end
-
-Resque.stat_data_store = NullDataStore.new
-```
-
-### Forking
-
-On certain platforms, when a Resque worker reserves a job it
-immediately forks a child process. The child processes the job then
-exits. When the child has exited successfully, the worker reserves
-another job and repeats the process.
-
-Why?
-
-Because Resque assumes chaos.
-
-Resque assumes your background workers will lock up, run too long, or
-have unwanted memory growth.
-
-If Resque workers processed jobs themselves, it'd be hard to whip them
-into shape. Let's say one is using too much memory: you send it a
-signal that says "shutdown after you finish processing the current
-job," and it does so. It then starts up again - loading your entire
-application environment. This adds useless CPU cycles and causes a
-delay in queue processing.
-
-Plus, what if it's using too much memory and has stopped responding to
-signals?
-
-Thanks to Resque's parent / child architecture, jobs that use too much memory
-release that memory upon completion. No unwanted growth.
-
-And what if a job is running too long? You'd need to `kill -9` it then
-start the worker again. With Resque's parent / child architecture you
-can tell the parent to forcefully kill the child then immediately
-start processing more jobs. No startup delay or wasted cycles.
-
-The parent / child architecture helps us keep tabs on what workers are
-doing, too. By eliminating the need to `kill -9` workers we can have
-parents remove themselves from the global listing of workers. If we
-just ruthlessly killed workers, we'd need a separate watchdog process
-to add and remove them to the global listing - which becomes
-complicated.
-
-Workers instead handle their own state.
-
-### Parents and Children
-
-Here's a parent / child pair doing some work:
-
-    $ ps -e -o pid,command | grep [r]esque
-    92099 resque: Forked 92102 at 1253142769
-    92102 resque: Processing file_serve since 1253142769
-
-You can clearly see that process 92099 forked 92102, which has been
-working since 1253142769.
-
-(By advertising the time they began processing you can easily use monit
-or god to kill stale workers.)
-
-When a parent process is idle, it lets you know what queues it is
-waiting for work on:
-
-    $ ps -e -o pid,command | grep [r]esque
-    92099 resque: Waiting for file_serve,warm_cache
-
-
-### Signals
-
-Resque workers respond to a few different signals:
-
-* `QUIT` - Wait for child to finish processing then exit
-* `TERM` / `INT` - Immediately kill child then exit
-* `USR1` - Immediately kill child but don't exit
-* `USR2` - Don't start to process any new jobs
-* `CONT` - Start to process new jobs again after a USR2
-
-If you want to gracefully shutdown a Resque worker, use `QUIT`.
-
-If you want to kill a stale or stuck child, use `USR1`. Processing
-will continue as normal unless the child was not found. In that case
-Resque assumes the parent process is in a bad state and shuts down.
-
-If you want to kill a stale or stuck child and shutdown, use `TERM`
-
-If you want to stop processing jobs, but want to leave the worker running
-(for example, to temporarily alleviate load), use `USR2` to stop processing,
-then `CONT` to start it again.
-
-#### Signals on Heroku
-
-When shutting down processes, Heroku sends every process a TERM signal at the
-same time. By default this causes an immediate shutdown of any running job
-leading to frequent `Resque::TermException` errors.  For short running jobs, a simple
-solution is to give a small amount of time for the job to finish
-before killing it.
-
-Resque doesn't handle this out of the box (for both cedar-14 and heroku-16), you need to
-install the [`resque-heroku-signals`](https://github.com/iloveitaly/resque-heroku-signals)
-addon which adds the required signal handling to make the behavior described above work.
-Related issue: https://github.com/resque/resque/issues/1559
-
-To accomplish this set the following environment variables:
-
-* `RESQUE_PRE_SHUTDOWN_TIMEOUT` - The time between the parent receiving a shutdown signal (TERM by default) and it sending that signal on to the child process. Designed to give the child process
-time to complete before being forced to die.
-
-* `TERM_CHILD` - Must be set for `RESQUE_PRE_SHUTDOWN_TIMEOUT` to be used. After the timeout, if the child is still running it will raise a `Resque::TermException` and exit.
-
-* `RESQUE_TERM_TIMEOUT` - By default you have a few seconds to handle `Resque::TermException` in your job. `RESQUE_TERM_TIMEOUT` and `RESQUE_PRE_SHUTDOWN_TIMEOUT` must be lower than the [heroku dyno timeout](https://devcenter.heroku.com/articles/limits#exit-timeout).
-
-### Mysql::Error: MySQL server has gone away
-
-If your workers remain idle for too long they may lose their MySQL connection. Depending on your version of Rails, we recommend the following:
-
-#### Rails 3.x
-In your `perform` method, add the following line:
-
-``` ruby
-class MyTask
-  def self.perform
-    ActiveRecord::Base.verify_active_connections!
-    # rest of your code
-  end
-end
-```
-
-The Rails doc says the following about `verify_active_connections!`:
-
-    Verify active connections and remove and disconnect connections associated with stale threads.
-
-#### Rails 4.x
-
-In your `perform` method, instead of `verify_active_connections!`, use:
-
-``` ruby
-class MyTask
-  def self.perform
-    ActiveRecord::Base.clear_active_connections!
-    # rest of your code
-  end
-end
-```
-
-From the Rails docs on [`clear_active_connections!`](http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/ConnectionHandler.html#method-i-clear_active_connections-21):
-
-    Returns any connections in use by the current thread back to the pool, and also returns connections to the pool cached by threads that are no longer alive.
-
-The Front End
+Configuration
 -------------
 
-Resque comes with a Sinatra-based front end for seeing what's up with
-your queue.
-
-![The Front End](https://camo.githubusercontent.com/64d150a243987ffbc33f588bd6d7722a0bb8d69a/687474703a2f2f7475746f7269616c732e6a756d7073746172746c61622e636f6d2f696d616765732f7265737175655f6f766572766965772e706e67)
-
-### Standalone
-
-If you've installed Resque as a gem running the front end standalone is easy:
-
-    $ resque-web
-
-It's a thin layer around `rackup` so it's configurable as well:
-
-    $ resque-web -p 8282
-
-If you have a Resque config file you want evaluated just pass it to
-the script as the final argument:
-
-    $ resque-web -p 8282 rails_root/config/initializers/resque.rb
-
-You can also set the namespace directly using `resque-web`:
-
-    $ resque-web -p 8282 -N myapp
-
-or set the Redis connection string if you need to do something like select a different database:
-
-    $ resque-web -p 8282 -r localhost:6379:2
-
-### Passenger
-
-Using Passenger? Resque ships with a `config.ru` you can use. See
-Phusion's guide:
-
-Apache: <https://www.phusionpassenger.com/library/deploy/apache/deploy/ruby/>
-Nginx: <https://www.phusionpassenger.com/library/deploy/nginx/deploy/ruby/>
-
-### Rack::URLMap
-
-If you want to load Resque on a subpath, possibly alongside other
-apps, it's easy to do with Rack's `URLMap`:
-
-``` ruby
-require 'resque/server'
-
-run Rack::URLMap.new \
-  "/"       => Your::App.new,
-  "/resque" => Resque::Server.new
-```
-
-Check `examples/demo/config.ru` for a functional example (including
-HTTP basic auth).
-
-### Rails 3+
-
-You can also mount Resque on a subpath in your existing Rails 3 app by adding `require 'resque/server'` to the top of your routes file or in an initializer then adding this to `routes.rb`:
-
-``` ruby
-mount Resque::Server.new, :at => "/resque"
-```
-
-Resque vs DelayedJob
---------------------
-
-How does Resque compare to DelayedJob, and why would you choose one
-over the other?
-
-* Resque supports multiple queues
-* DelayedJob supports finer grained priorities
-* Resque workers are resilient to memory leaks / bloat
-* DelayedJob workers are extremely simple and easy to modify
-* Resque requires Redis
-* DelayedJob requires ActiveRecord
-* Resque can only place JSONable Ruby objects on a queue as arguments
-* DelayedJob can place _any_ Ruby object on its queue as arguments
-* Resque includes a Sinatra app for monitoring what's going on
-* DelayedJob can be queried from within your Rails app if you want to
-  add an interface
-
-If you're doing Rails development, you already have a database and
-ActiveRecord. DelayedJob is super easy to setup and works great.
-GitHub used it for many months to process almost 200 million jobs.
-
-Choose Resque if:
-
-* You need multiple queues
-* You don't care / dislike numeric priorities
-* You don't need to persist every Ruby object ever
-* You have potentially huge queues
-* You want to see what's going on
-* You expect a lot of failure / chaos
-* You can setup Redis
-* You're not running short on RAM
-
-Choose DelayedJob if:
-
-* You like numeric priorities
-* You're not doing a gigantic amount of jobs each day
-* Your queue stays small and nimble
-* There is not a lot failure / chaos
-* You want to easily throw anything on the queue
-* You don't want to setup Redis
-
-In no way is Resque a "better" DelayedJob, so make sure you pick the
-tool that's best for your app.
-
-Installing Resque
------------------
-
-Add the gem to your Gemfile:
-
-    gem 'resque'
-
-Next, install it with Bundler:
-
-    $ bundle
-
-### Rack
-
-In your Rakefile, or some other file in `lib/tasks` (ex: `lib/tasks/resque.rake`), load the resque rake tasks:
-
-``` ruby
-require 'resque'
-require 'resque/tasks'
-require 'your/app' # Include this line if you want your workers to have access to your application
-```
-
-### Rails 3+
-
-In your Rakefile, or some other file in `lib/tasks` (ex: `lib/tasks/resque.rake`),
-load the resque rake tasks. Also, by default Resque won't know about your application's
-environment. That is, it won't be able to find and run your jobs. You'll need to define
-a `resque:setup` task with a dependency on the `environment` rake task:
-
-``` ruby
-require 'resque/tasks'
-task "resque:setup" => :environment
-```
-
-GitHub's setup task looks like this:
-
-``` ruby
-task "resque:setup" => :environment do
-  Grit::Git.git_timeout = 10.minutes
-end
-```
-
-We don't want the `git_timeout` as high as 10 minutes in our web app,
-but in the Resque workers it's fine.
-
-Running Workers
--------
-
-Resque workers are rake tasks that run forever. They basically do this:
-
-``` ruby
-start
-loop do
-  if job = reserve
-    job.process
-  else
-    sleep 5 # Polling frequency = 5
-  end
-end
-shutdown
-```
-
-Starting a worker is simple:
-
-    $ QUEUE=* rake resque:work
-
-Or, you can start multiple workers:
-
-    $ COUNT=2 QUEUE=* rake resque:workers
-
-This will spawn five Resque workers, each in its own process. Hitting
-ctrl-c should be sufficient to stop them all.
-
-### Priorities and Queue Lists
-
-Resque doesn't support numeric priorities but instead uses the order
-of queues you give it. We call this list of queues the "queue list."
-
-Let's say we add a `warm_cache` queue in addition to our `file_serve`
-queue. We'd now start a worker like so:
-
-    $ QUEUES=file_serve,warm_cache rake resque:work
-
-When the worker looks for new jobs, it will first check
-`file_serve`. If it finds a job, it'll process it then check
-`file_serve` again. It will keep checking `file_serve` until no more
-jobs are available. At that point, it will check `warm_cache`. If it
-finds a job it'll process it then check `file_serve` (repeating the
-whole process).
-
-In this way you can prioritize certain queues. At GitHub we start our
-workers with something like this:
-
-    $ QUEUES=critical,archive,high,low rake resque:work
-
-Notice the `archive` queue - it is specialized and in our future
-architecture will only be run from a single machine.
-
-At that point we'll start workers on our generalized background
-machines with this command:
-
-    $ QUEUES=critical,high,low rake resque:work
-
-And workers on our specialized archive machine with this command:
-
-    $ QUEUE=archive rake resque:work
-
-### Running All Queues
-
-If you want your workers to work off of every queue, including new
-queues created on the fly, you can use a splat:
-
-    $ QUEUE=* rake resque:work
-
-Queues will be processed in alphabetical order.
-
-Or, prioritize some queues above `*`:
-
-    # QUEUE=critical,* rake resque:work
-
-### Process IDs (PIDs)
-
-There are scenarios where it's helpful to record the PID of a resque
-worker process.  Use the PIDFILE option for easy access to the PID:
-
-    $ PIDFILE=./resque.pid QUEUE=file_serve rake resque:work
-
-### Running in the background
-
-There are scenarios where it's helpful for
-the resque worker to run itself in the background (usually in combination with
-PIDFILE).  Use the BACKGROUND option so that rake will return as soon as the
-worker is started.
-
-    $ PIDFILE=./resque.pid BACKGROUND=yes QUEUE=file_serve rake resque:work
-
-### Polling frequency
-
-You can pass an INTERVAL option which is a float representing the polling frequency.
-The default is 5 seconds, but for a semi-active app you may want to use a smaller value.
-
-    $ INTERVAL=0.1 QUEUE=file_serve rake environment resque:work
-
-Configuring Redis
--------------
+#### Redis
 
 You may want to change the Redis host and port Resque connects to, or
 set various other options at startup.
@@ -703,25 +496,31 @@ For example, if you want to run all jobs in the same process for cucumber, try:
 Resque.inline = ENV['RAILS_ENV'] == "cucumber"
 ```
 
-Plugins and Hooks
------------------
+#### Logging
 
-For a list of available plugins see
-<https://github.com/resque/resque/wiki/plugins>.
+Workers support basic logging to STDOUT.
 
-If you'd like to write your own plugin, or want to customize Resque
-using hooks (such as `Resque.after_fork`), see
-[docs/HOOKS.md](http://github.com/resque/resque/blob/master/docs/HOOKS.md).
+You can control the logging threshold using `Resque.logger.level`:
 
+```ruby
+# config/initializers/resque.rb
+Resque.logger.level = Logger::DEBUG
+```
 
-Namespaces
-----------
+If you want Resque to log to a file, in Rails do:
+
+```ruby
+# config/initializers/resque.rb
+Resque.logger = Logger.new(Rails.root.join('log', "#{Rails.env}_resque.log"))
+```
+
+#### Namespaces
 
 If you're running multiple, separate instances of Resque you may want
 to namespace the keyspaces so they do not overlap. This is not unlike
 the approach taken by many memcached clients.
 
-This feature is provided by the [redis-namespace][rs] library, which
+This feature is provided by the [redis-namespace](http://github.com/resque/redis-namespace) library, which
 Resque uses by default to separate the keys it manages from other keys
 in your Redis server.
 
@@ -734,37 +533,247 @@ Resque.redis.namespace = "resque:GitHub"
 We recommend sticking this in your initializer somewhere after Redis
 is configured.
 
+#### Storing Statistics
+ Resque allows to store count of processed and failed jobs.
 
-Demo
-----
+ By default it will store it in Redis using the keys `stats:processed` and `stats:failed`.
 
-Resque ships with a demo Sinatra app for creating jobs that are later
-processed in the background.
+ Some apps would want another stats store, or even a null store:
 
-Try it out by looking at the README, found at `examples/demo/README.markdown`.
+ ```ruby
+# config/initializers/resque.rb
+class NullDataStore
+  def stat(stat)
+    0
+  end
+
+  def increment_stat(stat, by)
+  end
+
+  def decrement_stat(stat, by)
+  end
+
+  def clear_stat(stat)
+  end
+end
+
+Resque.stat_data_store = NullDataStore.new
+```
+
+Plugins and Hooks
+-----------------
+
+For a list of available plugins see
+<https://github.com/resque/resque/wiki/plugins>.
+
+If you'd like to write your own plugin, or want to customize Resque
+using hooks (such as `Resque.after_fork`), see
+[docs/HOOKS.md](http://github.com/resque/resque/blob/master/docs/HOOKS.md).
 
 
-Monitoring
-----------
+Additional Information
+----------------------
 
-### god
+#### Resque vs DelayedJob
+
+How does Resque compare to DelayedJob, and why would you choose one
+over the other?
+
+* Resque supports multiple queues
+* DelayedJob supports finer grained priorities
+* Resque workers are resilient to memory leaks / bloat
+* DelayedJob workers are extremely simple and easy to modify
+* Resque requires Redis
+* DelayedJob requires ActiveRecord
+* Resque can only place JSONable Ruby objects on a queue as arguments
+* DelayedJob can place _any_ Ruby object on its queue as arguments
+* Resque includes a Sinatra app for monitoring what's going on
+* DelayedJob can be queried from within your Rails app if you want to
+  add an interface
+
+If you're doing Rails development, you already have a database and
+ActiveRecord. DelayedJob is super easy to setup and works great.
+GitHub used it for many months to process almost 200 million jobs.
+
+Choose Resque if:
+
+* You need multiple queues
+* You don't care / dislike numeric priorities
+* You don't need to persist every Ruby object ever
+* You have potentially huge queues
+* You want to see what's going on
+* You expect a lot of failure / chaos
+* You can setup Redis
+* You're not running short on RAM
+
+Choose DelayedJob if:
+
+* You like numeric priorities
+* You're not doing a gigantic amount of jobs each day
+* Your queue stays small and nimble
+* There is not a lot failure / chaos
+* You want to easily throw anything on the queue
+* You don't want to setup Redis
+
+In no way is Resque a "better" DelayedJob, so make sure you pick the
+tool that's best for your app.
+
+#### Forking
+
+On certain platforms, when a Resque worker reserves a job it
+immediately forks a child process. The child processes the job then
+exits. When the child has exited successfully, the worker reserves
+another job and repeats the process.
+
+Why?
+
+Because Resque assumes chaos.
+
+Resque assumes your background workers will lock up, run too long, or
+have unwanted memory growth.
+
+If Resque workers processed jobs themselves, it'd be hard to whip them
+into shape. Let's say one is using too much memory: you send it a
+signal that says "shutdown after you finish processing the current
+job," and it does so. It then starts up again - loading your entire
+application environment. This adds useless CPU cycles and causes a
+delay in queue processing.
+
+Plus, what if it's using too much memory and has stopped responding to
+signals?
+
+Thanks to Resque's parent / child architecture, jobs that use too much memory
+release that memory upon completion. No unwanted growth.
+
+And what if a job is running too long? You'd need to `kill -9` it then
+start the worker again. With Resque's parent / child architecture you
+can tell the parent to forcefully kill the child then immediately
+start processing more jobs. No startup delay or wasted cycles.
+
+The parent / child architecture helps us keep tabs on what workers are
+doing, too. By eliminating the need to `kill -9` workers we can have
+parents remove themselves from the global listing of workers. If we
+just ruthlessly killed workers, we'd need a separate watchdog process
+to add and remove them to the global listing - which becomes
+complicated.
+
+Workers instead handle their own state.
+
+#### Parents and Children
+
+Here's a parent / child pair doing some work:
+
+    $ ps -e -o pid,command | grep [r]esque
+    92099 resque: Forked 92102 at 1253142769
+    92102 resque: Processing file_serve since 1253142769
+
+You can clearly see that process 92099 forked 92102, which has been
+working since 1253142769.
+
+(By advertising the time they began processing you can easily use monit
+or god to kill stale workers.)
+
+When a parent process is idle, it lets you know what queues it is
+waiting for work on:
+
+    $ ps -e -o pid,command | grep [r]esque
+    92099 resque: Waiting for file_serve,warm_cache
+
+
+#### Signals
+
+Resque workers respond to a few different signals:
+
+* `QUIT` - Wait for child to finish processing then exit
+* `TERM` / `INT` - Immediately kill child then exit
+* `USR1` - Immediately kill child but don't exit
+* `USR2` - Don't start to process any new jobs
+* `CONT` - Start to process new jobs again after a USR2
+
+If you want to gracefully shutdown a Resque worker, use `QUIT`.
+
+If you want to kill a stale or stuck child, use `USR1`. Processing
+will continue as normal unless the child was not found. In that case
+Resque assumes the parent process is in a bad state and shuts down.
+
+If you want to kill a stale or stuck child and shutdown, use `TERM`
+
+If you want to stop processing jobs, but want to leave the worker running
+(for example, to temporarily alleviate load), use `USR2` to stop processing,
+then `CONT` to start it again.
+
+#### Heroku
+
+When shutting down processes, Heroku sends every process a TERM signal at the
+same time. By default this causes an immediate shutdown of any running job
+leading to frequent `Resque::TermException` errors.  For short running jobs, a simple
+solution is to give a small amount of time for the job to finish
+before killing it.
+
+Resque doesn't handle this out of the box (for both cedar-14 and heroku-16), you need to
+install the [`resque-heroku-signals`](https://github.com/iloveitaly/resque-heroku-signals)
+addon which adds the required signal handling to make the behavior described above work.
+Related issue: https://github.com/resque/resque/issues/1559
+
+To accomplish this set the following environment variables:
+
+* `RESQUE_PRE_SHUTDOWN_TIMEOUT` - The time between the parent receiving a shutdown signal (TERM by default) and it sending that signal on to the child process. Designed to give the child process
+time to complete before being forced to die.
+
+* `TERM_CHILD` - Must be set for `RESQUE_PRE_SHUTDOWN_TIMEOUT` to be used. After the timeout, if the child is still running it will raise a `Resque::TermException` and exit.
+
+* `RESQUE_TERM_TIMEOUT` - By default you have a few seconds to handle `Resque::TermException` in your job. `RESQUE_TERM_TIMEOUT` and `RESQUE_PRE_SHUTDOWN_TIMEOUT` must be lower than the [heroku dyno timeout](https://devcenter.heroku.com/articles/limits#exit-timeout).
+
+#### Monitoring
+
+##### god
 
 If you're using god to monitor Resque, we have provided example
 configs in `examples/god/`. One is for starting / stopping workers,
 the other is for killing workers that have been running too long.
 
-### monit
+##### monit
 
 If you're using monit, `examples/monit/resque.monit` is provided free
 of charge. This is **not** used by GitHub in production, so please
 send patches for any tweaks or improvements you can make to it.
 
+#### Mysql::Error: MySQL server has gone away
 
-Questions
----------
+If your workers remain idle for too long they may lose their MySQL connection. Depending on your version of Rails, we recommend the following:
 
-Please add them to the [FAQ](https://github.com/resque/resque/wiki/FAQ) or open an issue on this repo.
+##### Rails 3.x
+In your `perform` method, add the following line:
 
+``` ruby
+class MyTask
+  def self.perform
+    ActiveRecord::Base.verify_active_connections!
+    # rest of your code
+  end
+end
+```
+
+The Rails doc says the following about `verify_active_connections!`:
+
+    Verify active connections and remove and disconnect connections associated with stale threads.
+
+##### Rails 4.x
+
+In your `perform` method, instead of `verify_active_connections!`, use:
+
+``` ruby
+class MyTask
+  def self.perform
+    ActiveRecord::Base.clear_active_connections!
+    # rest of your code
+  end
+end
+```
+
+From the Rails docs on [`clear_active_connections!`](http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/ConnectionHandler.html#method-i-clear_active_connections-21):
+
+    Returns any connections in use by the current thread back to the pool, and also returns connections to the pool cached by threads that are no longer alive.
 
 Development
 -----------
@@ -795,26 +804,27 @@ it:
 If you get an error requiring any of the dependencies, you may have
 failed to install them or be seeing load path issues.
 
+#### Demo
+Resque ships with a demo Sinatra app for creating jobs that are later
+processed in the background.
 
-Contributing
-------------
+Try it out by looking at the README, found at `examples/demo/README.markdown`.
+
+#### Contributing
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md) first.
 
 Once you've made your great commits:
 
-1. [Fork][1] Resque
+1. [Fork](http://help.github.com/forking/) Resque
 2. Create a topic branch - `git checkout -b my_branch`
 3. Push to your branch - `git push origin my_branch`
 4. Create a [Pull Request](http://help.github.com/pull-requests/) from your branch
-5. That's it!
 
+Questions
+---------
 
-Mailing List
-------------
-
-This mailing list is no longer maintained. The archive can be found at <http://librelist.com/browser/resque/>.
-
+Please add them to the [FAQ](https://github.com/resque/resque/wiki/FAQ) or open an issue on this repo.
 
 Meta
 ----
@@ -823,21 +833,13 @@ Meta
 * Home: <http://github.com/resque/resque>
 * Docs: <http://rubydoc.info/gems/resque>
 * Bugs: <http://github.com/resque/resque/issues>
-* List: <resque@librelist.com>
 * Chat: <irc://irc.freenode.net/resque>
-* Gems: <http://gemcutter.org/gems/resque>
+* Gems: <https://rubygems.org/gems/resque>
 
-This project uses [Semantic Versioning][sv].
-
+This project uses [Semantic Versioning](http://semver.org/)
 
 Author
 ------
 
 Chris Wanstrath :: chris@ozmm.org :: @defunkt
 
-[0]: http://github.com/blog/542-introducing-resque
-[1]: http://help.github.com/forking/
-[2]: http://github.com/resque/resque/issues
-[sv]: http://semver.org/
-[rs]: http://github.com/resque/redis-namespace
-[cb]: http://wiki.github.com/resque/resque/contributing

--- a/README.markdown
+++ b/README.markdown
@@ -239,16 +239,8 @@ Starting a worker is simple. Here's our example from earlier:
     $ QUEUE=file_serve rake resque:work
 
 By default Resque won't know about your application's
-environment. That is, it won't be able to find and run your jobs - it
-needs to load your application into memory.
-
-If we've installed Resque as a Rails plugin, we might run this command
-from our RAILS_ROOT:
-
-    $ QUEUE=file_serve rake environment resque:work
-
-This will load the environment before starting a worker. Alternately
-we can define a `resque:setup` task with a dependency on the
+environment. That is, it won't be able to find and run your jobs.
+You'll need to define a `resque:setup` task with a dependency on the
 `environment` rake task:
 
 ``` ruby
@@ -265,7 +257,6 @@ end
 
 We don't want the `git_timeout` as high as 10 minutes in our web app,
 but in the Resque workers it's fine.
-
 
 ### Logging
 
@@ -700,53 +691,6 @@ Now:
 
 Alternately you can define a `resque:setup` hook in your Rakefile if you
 don't want to load your app every time rake runs.
-
-
-### In a Rails 2.x app, as a gem
-
-First install the gem.
-
-    $ gem install resque
-
-Next include it in your application.
-
-    $ cat config/initializers/load_resque.rb
-    require 'resque'
-
-Now start your application:
-
-    $ ./script/server
-
-That's it! You can now create Resque jobs from within your app.
-
-To start a worker, add this to your Rakefile in `RAILS_ROOT`:
-
-``` ruby
-require 'resque/tasks'
-```
-
-Now:
-
-    $ QUEUE=* rake environment resque:work
-
-Don't forget you can define a `resque:setup` hook in
-`lib/tasks/whatever.rake` that loads the `environment` task every time.
-
-
-### In a Rails 2.x app, as a plugin
-
-    $ ./script/plugin install git://github.com/resque/resque
-
-That's it! Resque will automatically be available when your Rails app
-loads.
-
-To start a worker:
-
-    $ QUEUE=* rake environment resque:work
-
-Don't forget you can define a `resque:setup` hook in
-`lib/tasks/whatever.rake` that loads the `environment` task every time.
-
 
 ### In a Rails 3.x or 4.x app, as a gem
 

--- a/README.markdown
+++ b/README.markdown
@@ -531,8 +531,6 @@ From the Rails docs on [`clear_active_connections!`](http://api.rubyonrails.org/
 
     Returns any connections in use by the current thread back to the pool, and also returns connections to the pool cached by threads that are no longer alive.
 
-
-
 The Front End
 -------------
 
@@ -642,89 +640,39 @@ Choose DelayedJob if:
 In no way is Resque a "better" DelayedJob, so make sure you pick the
 tool that's best for your app.
 
-Resque Dependencies
--------------------
-
-    $ gem install bundler
-    $ bundle install
-
-
 Installing Resque
 -----------------
 
-### In a Rack app, as a gem
+Add the gem to your Gemfile:
 
-First install the gem.
+    gem 'resque'
 
-    $ gem install resque
+Next, install it with Bundler:
 
-Next include it in your application.
+    $ bundle
+
+### Rack
+
+Include it in your application.
 
 ``` ruby
 require 'resque'
 ```
-
-Now start your application:
-
-    rackup config.ru
-
-That's it! You can now create Resque jobs from within your app.
-
-To start a worker, create a Rakefile in your app's root (or add this
-to an existing Rakefile):
-
-``` ruby
-require 'your/app'
-require 'resque/tasks'
-```
-
-If you're using Rails 5.x, include the following in lib/tasks/resque.rake:
-
-```ruby
-require 'resque/tasks'
-task 'resque:setup' => :environment
-```
-
-Now:
-
-    $ QUEUE=* rake resque:work
-
-Alternately you can define a `resque:setup` hook in your Rakefile if you
-don't want to load your app every time rake runs.
-
-### In a Rails 3.x or 4.x app, as a gem
-
-First include it in your Gemfile.
-
-    $ cat Gemfile
-    ...
-    gem 'resque'
-    ...
-
-Next install it with Bundler.
-
-    $ bundle install
-
-Now start your application:
-
-    $ rails server
-
-That's it! You can now create Resque jobs from within your app.
-
-To start a worker, add this to a file in `lib/tasks` (ex:
-`lib/tasks/resque.rake`):
+Create a Rakefile in your app's root (or add this to an existing Rakefile):
 
 ``` ruby
 require 'resque/tasks'
 ```
 
-Now:
+You can define a `resque:setup` hook in your Rakefile if you want to load your app every time rake runs.
 
-    $ QUEUE=* rake environment resque:work
+### Rails 3+
 
-Don't forget you can define a `resque:setup` hook in
-`lib/tasks/whatever.rake` that loads the `environment` task every time.
+Add this to a file in `lib/tasks` (ex: `lib/tasks/resque.rake`):
 
+``` ruby
+require 'resque/tasks'
+```
 
 Configuration
 -------------


### PR DESCRIPTION
1) Remove antique Rails 2.x references
2) Simplifies/DRYs the Installation/Configuration sections.  There seemed to be a lot of redundant/overlapping configuration between the various rails versions and rack.  I attempted to clean all that up.
3) Ditto the "running workers" section.  The sections were not co-located, and various bits and pieces were spread throughout the Installation/Configure sections.  I pulled that all into its own section.
4) General re-ordering of the README. Added a Table of Contents and attempted to group like sections together.

I suspect the diff is hard to look at, so the current version is [here](https://github.com/resque/resque) and this PR's version from my fork is [here](https://github.com/josh-m-sharpe/resque/tree/readme_cleanup)
