### PR TITLE
when retrieving queue name, check for 'queue_name' which is how ActiveJob defines queue names

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -502,8 +502,9 @@ module Resque
   # Given a class, try to extrapolate an appropriate queue based on a
   # class instance variable or `queue` method.
   def queue_from_class(klass)
-    (klass.instance_variable_defined?(:@queue) && klass.instance_variable_get(:@queue)) ||
-      (klass.respond_to?(:queue) and klass.queue)
+    klass.instance_variable_get(:@queue) ||
+    (klass.respond_to?(:queue) && klass.queue) ||
+    (klass.respond_to?(:queue_name) && klass.new.queue_name)
   end
 
   # This method will return a `Resque::Job` object or a non-true value


### PR DESCRIPTION
This fixes an issue when queueing jobs from resque-scheduler's Scheudle page.  Without this change, resque is unable to identify the queue to drop the job on.

ActiveJob details:

https://api.rubyonrails.org/classes/ActiveJob/QueueName/ClassMethods.html#method-i-queue_as
https://github.com/rails/rails/blob/157920aead96865e3135f496c09ace607d5620dc/activejob/lib/active_job/queue_name.rb#L41
https://github.com/rails/rails/blob/157920aead96865e3135f496c09ace607d5620dc/activejob/lib/active_job/queue_name.rb#L62

