### PR TITLE
minor/trivial: allow plugins to have spaces in their name

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -53,7 +53,7 @@ module Resque
       def tab(name)
         dname = name.to_s.downcase
         path = url_path(dname)
-        "<li #{class_if_current(path)}><a href='#{path}'>#{name}</a></li>"
+        "<li #{class_if_current(path)}><a href='#{path.gsub(" ", "_")}'>#{name}</a></li>"
       end
 
       def tabs


### PR DESCRIPTION
Truthfully, I didn't end up needing this, but it does tidy plugin names in the nav.  It allows plugins like "Job Stats" which currently register themselves as "Job_Stats" to do so without the underscore and still have functional nav links:

https://github.com/alanpeabody/resque-job-stats/blob/master/lib/resque-job-stats/server.rb#L62