### PR TITLE
Update obsolete indentation setting in rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,8 +11,10 @@ AllCops:
     - 'vendor/**/*'
 
 # Detect hard tabs, no hard tabs.
-Layout/Tab:
+Layout/IndentationStyle:
   Enabled: true
+  IndentationWidth: 2
+  EnforcedStyle: spaces
 
 # Blank lines should not have any spaces.
 Layout/TrailingEmptyLines:


### PR DESCRIPTION
I recently rebased a branch and noticed that travis is [failing](https://travis-ci.org/github/resque/resque/jobs/679167616) on a rubocop config error.

```
Error: The `Layout/Tab` cop has been renamed to `Layout/IndentationStyle`.
```

This updates the config to use the new cop.
