### PR TITLE
Fix worker count in example on README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -202,7 +202,7 @@ Starting a worker is simple:
 
 Or, you can start multiple workers:
 
-    $ COUNT=2 QUEUE=* rake resque:workers
+    $ COUNT=5 QUEUE=* rake resque:workers
 
 This will spawn five Resque workers, each in its own process. Hitting
 ctrl-c should be sufficient to stop them all.


### PR DESCRIPTION
Now `count=5` correctly corresponds to `This will spawn five Resque workers`.

The inconsistency was generated at  https://github.com/resque/resque/commit/cda831c862195df25ec364b3a9c429b86eec744a.