### PR TITLE
Update wiki link to the list of plugins

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -5,7 +5,7 @@ You can customize Resque or write plugins using its hook API. In many
 cases you can use a hook rather than mess with Resque's internals.
 
 For a list of available plugins see
-<http://wiki.github.com/resque/resque/plugins>.
+<https://github.com/resque/resque/wiki/plugins>.
 
 
 Worker Hooks


### PR DESCRIPTION
I noticed that the link to the wiki page for the plugins returns a 404.
I found a working link in the README, so updated the link in the
HOOKS.md docs to that one.