### PR TITLE
Ruby does not allow logging within trap handlers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
     - 'vendor/**/*'
 
 # Detect hard tabs, no hard tabs.
-Layout/Tab:
+Layout/IndentationStyle:
   Enabled: true
 
 # Blank lines should not have any spaces.

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -574,14 +574,16 @@ module Resque
     # Stop processing jobs after the current one has completed (if we're
     # currently running one).
     def pause_processing
-      log_with_severity :info, "USR2 received; pausing job processing"
+      _, self_write = IO.pipe
+      self_write.puts "USR2 received; pausing job processing"
       run_hook :before_pause, self
       @paused = true
     end
 
     # Start processing jobs again after a pause
     def unpause_processing
-      log_with_severity :info, "CONT received; resuming job processing"
+      _, self_write = IO.pipe
+      self_write.puts "CONT received; resuming job processing"
       @paused = false
       run_hook :after_pause, self
     end


### PR DESCRIPTION
If I kill -USR2, I see "log writing failed. can't be called from trap context".  Delete these logging lines until a better fix can be found (Sidekiq for instance rewrites to IO.pipes - https://github.com/mperham/sidekiq/blob/b6de0bae6b86d5abae25852141768d8ecc8ddedf/lib/sidekiq/cli.rb#L53)