### PR TITLE
Add button for deleting jobs from queue

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
 ### Added
+
+* Added button to the Queues page to remove all jobs of a given class
+* Added button to the Queues page to remove a specific job
 * Added two new hooks.
   - `queue_empty` when the job queue empties and the worker becomes idle
   - `worker_exit` when the worker exits

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -128,7 +128,10 @@ module Resque
         data_store.everything_in_queue(queue).each do |string|
           job = decode(string)
           job_klass = job['class']
-          job_klass = job.dig('args', 0, 'job_class') if job_klass == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper'
+
+          if job_klass == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper'
+            job_klass = job.dig('args', 0, 'job_class')
+          end
 
           if job_klass == klass
             destroyed += data_store.remove_from_queue(queue,string).to_i
@@ -155,7 +158,10 @@ module Resque
       data_store.everything_in_queue(queue).each do |string|
         job = decode(string)
         klass = job['class']
-        klass = job.dig('args', 0, 'job_class') if klass == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper'
+
+        if klass == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper'
+          klass = job.dig('args', 0, 'job_class')
+        end
 
         klasses[klass] ||= 0
         klasses[klass] += 1

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -127,7 +127,10 @@ module Resque
       if args.empty?
         data_store.everything_in_queue(queue).each do |string|
           job = decode(string)
-          if job['class'] == klass || job.dig('args', 0, 'job_class') == klass
+          job_klass = job['class']
+          job_klass = job.dig('args', 0, 'job_class') if job_klass == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper'
+
+          if job_klass == klass
             destroyed += data_store.remove_from_queue(queue,string).to_i
           end
         end

--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -185,7 +185,11 @@ module Resque
     end
 
     post "/queues/:queue/remove-jobs" do
-      Resque::Job.destroy(params[:queue], params[:job_class])
+      if params[:job_args].present?
+        Resque::Job.destroy(params[:queue], params[:job_class], *JSON.parse(params[:job_args]))
+      else
+        Resque::Job.destroy(params[:queue], params[:job_class])
+      end
       redirect url_path("/queues/#{params[:queue]}")
     end
 

--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -184,6 +184,11 @@ module Resque
       redirect u('queues')
     end
 
+    post "/queues/:queue/remove-jobs" do
+      Resque::Job.destroy(params[:queue], params[:job_class])
+      redirect url_path("/queues/#{params[:queue]}")
+    end
+
     get "/failed/?" do
       if Resque::Failure.url
         redirect Resque::Failure.url

--- a/lib/resque/server/public/style.css
+++ b/lib/resque/server/public/style.css
@@ -83,6 +83,8 @@ body { padding:0; margin:0; }
 #main p.pagination a.more { float:right;}
 
 #main form {float:right; margin-top:-10px;margin-left:10px;}
+#main form.inline_form { float:none; margin-top:0px; margin-left:0px; display: inline }
+#main input.delete_job { color: red; background: transparent; border: none }
 
 #main .time a.toggle_format {text-decoration:none;}
 

--- a/lib/resque/server/views/job_class.erb
+++ b/lib/resque/server/views/job_class.erb
@@ -1,12 +1,12 @@
+<form method="POST" action="<%=u "/queues/#{current_queue}/remove-jobs" %>" class="inline_form">
+  <input id="job_class" name="job_class" type="hidden" value=<%=job['class']%> />
+  <input id="job_args" name="job_args" type="hidden" value=<%=job['args'].to_json%> />
+  <input title="Destroy Job" class="delete_job" type='submit' name='' value='X' onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
+</form>
+
 <% if job['class'] == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper' %>
   <code><%= job['args'].first['job_class'] %></code>
   <small><a href="http://edgeguides.rubyonrails.org/active_job_basics.html" target="_blank">(via ActiveJob)</a></small>
 <% else %>
   <code><%= job['class'] %></code>
 <% end %>
-
-<form method="POST" action="<%=u "/queues/#{current_queue}/remove-jobs" %>" class='remove-job'>
-  <input id="job_class" name="job_class" type="hidden" value=<%=job['class']%> />
-  <input id="job_args" name="job_args" type="hidden" value=<%=job['args'].to_json%> />
-  <input type='submit' name='' value='Remove Job' onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
-</form>

--- a/lib/resque/server/views/job_class.erb
+++ b/lib/resque/server/views/job_class.erb
@@ -4,3 +4,9 @@
 <% else %>
   <code><%= job['class'] %></code>
 <% end %>
+
+<form method="POST" action="<%=u "/queues/#{current_queue}/remove-jobs" %>" class='remove-job'>
+  <input id="job_class" name="job_class" type="hidden" value=<%=job['class']%> />
+  <input id="job_args" name="job_args" type="hidden" value=<%=job['args'].to_json%> />
+  <input type='submit' name='' value='Remove Job' onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
+</form>

--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -22,7 +22,7 @@
     </tr>
     <% for job in (jobs = resque.peek(current_queue, start, 20)) %>
     <tr>
-      <td class='class'><%= partial :job_class, :job => job %></td>
+      <td class='class'><%= partial :job_class, :job => job, :current_queue => current_queue %></td>
       <td class='args'><%=h job['args'].inspect %></td>
     </tr>
     <% end %>

--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -6,6 +6,14 @@
   <form method="POST" action="<%=u "/queues/#{current_queue}/remove" %>" class='remove-queue'>
     <input type='submit' name='' value='Remove Queue' onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
   </form>
+  <form method="POST" action="<%=u "/queues/#{current_queue}/remove-jobs" %>" class='remove-jobs'>
+    <select id="job_class" name="job_class">
+      <% Resque::Job.list_job_classes(current_queue).each do |job_class, _| %>
+        <option value="<%= job_class %>"><%= job_class %></option>
+      <% end %>
+    </select>
+    <input type='submit' name='' value='Remove Jobs'/>
+  </form>
   <p class='sub'><%= page_entries_info start = params[:start].to_i, start + 19, size = resque.size(current_queue), 'job' %></p>
   <table class='jobs'>
     <tr>


### PR DESCRIPTION
More than once I was required to either remove one pending job from Resque, or all jobs of a given class. For both cases I had to access the production server and run a custom script, which is not ideal. Based on that, this PR makes two changes:
1) Adds a dropdown with the list of all job classes in a queue and a button that removes all jobs of the selected class from the queue.
2) A button next to a pending job to delete that specific job

Here is a screenshot of how it looks:
![Resque](https://user-images.githubusercontent.com/7543345/97729213-3a9f8b00-1ab1-11eb-8de9-6f217827d556.png)

Some notes:
* To properly support `ActiveJob` jobs I had to add some checks to fetch the class from the payload
* The button to remove a job will delete all jobs matching class and args. I could not find a better way to do this. 
