### PR TITLE
Ensure PIDFILE has pids of all running workers

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -5,8 +5,8 @@
 namespace :resque do
   task :setup
 
-  desc "Start a Resque worker"
-  task :work => [ :preload, :setup ] do
+  desc "Run a Resque worker"
+  task :run => [ :preload, :setup ] do
     require 'resque'
 
     begin
@@ -20,6 +20,15 @@ namespace :resque do
     worker.work(ENV['INTERVAL'] || 5) # interval, will block
   end
 
+  desc "Start a Resque worker"
+  task :work do
+    if ENV['PIDFILE'] && File.file?(ENV['PIDFILE'])
+      File.truncate(ENV['PIDFILE'], 0)
+    end
+    Rake::Task['resque:run'].reenable
+    Rake::Task['resque:run'].invoke
+  end
+
   desc "Start multiple Resque workers. Should only be used in dev mode."
   task :workers do
     threads = []
@@ -28,9 +37,13 @@ namespace :resque do
       abort "set COUNT env var, e.g. $ COUNT=2 rake resque:workers"
     end
 
+    if ENV['PIDFILE'] && File.file?(ENV['PIDFILE'])
+      File.truncate(ENV['PIDFILE'], 0)
+    end
+
     ENV['COUNT'].to_i.times do
       threads << Thread.new do
-        system "rake resque:work"
+        system "rake resque:run"
       end
     end
 

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -171,7 +171,11 @@ module Resque
       end
 
       if ENV['PIDFILE']
-        File.open(ENV['PIDFILE'], 'w') { |f| f << pid }
+        File.open(ENV['PIDFILE'], 'a') { |f| 
+          f.flock(File::LOCK_EX)
+          f << pid << "\n"
+          f.flock(File::LOCK_UN)
+        }
       end
 
       self.reconnect if ENV['BACKGROUND']


### PR DESCRIPTION
The workers now append to the PIDFILE instead of overwriting it.
Adding file locking to handle race conditions when multiple
workers are started using resque:workers.

To clear any older data in the specified PIDFILE, it is now truncated
once when the rake tasks resque:work and resque:workers are called.
Created a proxy task resque:run to achive this.

Fixes #1721