### PR TITLE
Update README with Rails example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -137,7 +137,7 @@ access to the Redis server.
 
 #### Rails example
 
-If you installed the Resque as a Rails gem, the above example will look like this:
+If you are using ActiveJob here's how your job definition will look:
 
 ``` ruby
 class ArchiveJob < ApplicationJob

--- a/README.markdown
+++ b/README.markdown
@@ -135,6 +135,34 @@ Workers can be given multiple queues (a "queue list") and run on
 multiple machines. In fact they can be run anywhere with network
 access to the Redis server.
 
+#### Rails example
+
+If you installed the Resque as a Rails gem, the above example will look like this:
+
+``` ruby
+class ArchiveJob < ApplicationJob
+  queue_as :file_serve
+
+  def perform(repo_id, branch = 'master')
+    repo = Repository.find(repo_id)
+    repo.create_archive(branch)
+  end
+end
+```
+
+``` ruby
+class Repository
+  def async_create_archive(branch)
+    ArchiveJob.perform_later(self.id, branch)
+  end
+end
+```
+
+It is important to run `ArchiveJob.perform_later(self.id, branch)` rather than `Resque.enqueue(Archive, self.id, branch)`.
+Otherwise the Resque will process the job without actually doing anything.
+Even if you put obviously buggy line like `0/0` in the `perform` method,
+the job will still succeed.
+
 Installation
 ------------
 

--- a/README.markdown
+++ b/README.markdown
@@ -467,8 +467,8 @@ end
 ```
 
 It is important to run `ArchiveJob.perform_later(self.id, branch)` rather than `Resque.enqueue(Archive, self.id, branch)`.
-Otherwise the Resque will process the job without actually doing anything.
-Even if you put obviously buggy line like `0/0` in the `perform` method,
+Otherwise Resque will process the job without actually doing anything.
+Even if you put an obviously buggy line like `0/0` in the `perform` method,
 the job will still succeed.
 
 

--- a/README.markdown
+++ b/README.markdown
@@ -135,34 +135,6 @@ Workers can be given multiple queues (a "queue list") and run on
 multiple machines. In fact they can be run anywhere with network
 access to the Redis server.
 
-#### Rails example
-
-If you are using ActiveJob here's how your job definition will look:
-
-``` ruby
-class ArchiveJob < ApplicationJob
-  queue_as :file_serve
-
-  def perform(repo_id, branch = 'master')
-    repo = Repository.find(repo_id)
-    repo.create_archive(branch)
-  end
-end
-```
-
-``` ruby
-class Repository
-  def async_create_archive(branch)
-    ArchiveJob.perform_later(self.id, branch)
-  end
-end
-```
-
-It is important to run `ArchiveJob.perform_later(self.id, branch)` rather than `Resque.enqueue(Archive, self.id, branch)`.
-Otherwise the Resque will process the job without actually doing anything.
-Even if you put obviously buggy line like `0/0` in the `perform` method,
-the job will still succeed.
-
 Installation
 ------------
 
@@ -469,6 +441,35 @@ Resque::Failure.backend = Resque::Failure::Multiple
 
 Keep this in mind when writing your jobs: you may want to throw
 exceptions you would not normally throw in order to assist debugging.
+
+
+#### Rails example
+
+If you are using ActiveJob here's how your job definition will look:
+
+``` ruby
+class ArchiveJob < ApplicationJob
+  queue_as :file_serve
+
+  def perform(repo_id, branch = 'master')
+    repo = Repository.find(repo_id)
+    repo.create_archive(branch)
+  end
+end
+```
+
+``` ruby
+class Repository
+  def async_create_archive(branch)
+    ArchiveJob.perform_later(self.id, branch)
+  end
+end
+```
+
+It is important to run `ArchiveJob.perform_later(self.id, branch)` rather than `Resque.enqueue(Archive, self.id, branch)`.
+Otherwise the Resque will process the job without actually doing anything.
+Even if you put obviously buggy line like `0/0` in the `perform` method,
+the job will still succeed.
 
 
 Configuration


### PR DESCRIPTION
I know the Rails case is in the wiki, but it took me awhile to figure this out, and in the meantime I was stuck. I even posted a question on stackoverflow:

https://stackoverflow.com/questions/65224796/resque-not-failing-an-obviously-buggy-job

And one of the users suggested I request this change, as the Rails is pretty popular case for the Resque gem.