### PR TITLE
Prevent child process disconnecting parent connection to Redis

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Fixed
+* Fix closing parent Redis connection in child process after fork
+
 ### Added
 * Added two new hooks.
   - `queue_empty` when the job queue empties and the worker becomes idle

--- a/lib/resque/data_store.rb
+++ b/lib/resque/data_store.rb
@@ -76,9 +76,10 @@ module Resque
       @redis.inspect
     end
 
-    # Force a reconnect to Redis.
+    # Force a reconnect to Redis without closing the connection in the parent
+    # process after a fork.
     def reconnect
-      @redis._client.reconnect
+      @redis._client.connect
     end
 
     # Returns an array of all known Resque keys in Redis. Redis' KEYS operation

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -1237,11 +1237,12 @@ describe "Resque::Worker" do
       new_connection = run_in_job do
         Resque.redis._client.connection.instance_variable_get("@sock").object_id
       end
+      assert Resque.redis._client.connected?
       refute_equal original_connection, new_connection
     end
 
     it "tries to reconnect three times before giving up and the failure does not unregister the parent" do
-      @worker.redis._client.stubs(:reconnect).raises(Redis::BaseConnectionError)
+      @worker.data_store.stubs(:reconnect).raises(Redis::BaseConnectionError)
       @worker.stubs(:sleep)
 
       Resque.logger = DummyLogger.new
@@ -1255,7 +1256,7 @@ describe "Resque::Worker" do
     end
 
     it "tries to reconnect three times before giving up" do
-      @worker.redis._client.stubs(:reconnect).raises(Redis::BaseConnectionError)
+      @worker.data_store.stubs(:reconnect).raises(Redis::BaseConnectionError)
       @worker.stubs(:sleep)
 
       Resque.logger = DummyLogger.new


### PR DESCRIPTION
When a new task is started it is forked to run in its own process (to
protect the coordinator process from crashing if something goes wrong
in a task). In the child process the task reconnects to Redis (to avoid
sharing the connection with the parent process) but this reconnect is
implemented as a disconnect followed by a connect.

The disconnect here is not appropriate because the parent process might
be currently using that connection. When connecting to Redis using SSL
(which is becoming more common now Redis itself supports TLS natively)
this matters and causes the following error:

```
SSL_read: sslv3 alert bad record mac (OpenSSL::SSL::SSLError)
```

By calling "connect" here rather than "reconnect" we leave the parent
connection to Redis intact and create a new one for child processes if
they run with fork_per_job = true.