### PR TITLE
Fix failing build due to rubocop change

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
     - 'vendor/**/*'
 
 # Detect hard tabs, no hard tabs.
-Layout/Tab:
+Layout/IndentationStyle:
   Enabled: true
 
 # Blank lines should not have any spaces.

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ before_install:
 script: bundle exec rake
 
 rvm:
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
-  - 2.7.0
+  - 2.4.10
+  - 2.5.9
+  - 2.6.7
+  - 2.7.3
   - ruby-head
 
 matrix:
@@ -19,5 +19,5 @@ matrix:
     - rvm: ruby-head
   fast_finish: true
   include:
-    - rvm: 2.4.9
+    - rvm: 2.7.3
       script: bundle exec rubocop


### PR DESCRIPTION
* Bump all tested ruby versions to last minor version
* Sets rubocop execution version to `2.7.3`

@rafaelfranca could you take a look at this one and merge? This is causing all PR builds to fail.