### PR TITLE
Add: confirmation prompt before submitting the retry of all failed jobs

### DIFF
--- a/lib/resque/server/views/failed.erb
+++ b/lib/resque/server/views/failed.erb
@@ -9,7 +9,7 @@
   <input type="submit" name="" value="Clear <%= params[:queue] ? "'#{params[:queue]}'" : 'Failed' %> Jobs" onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
 </form>
 <form method="POST" action="<%= u "failed#{'/' + params[:queue] if params[:queue]}/requeue/all" %>">
-  <input type="submit" name="" value="Retry <%= params[:queue] ? "'#{params[:queue]}'" : 'Failed' %> Jobs" />
+  <input type="submit" name="" value="Retry <%= params[:queue] ? "'#{params[:queue]}'" : 'Failed' %> Jobs" onclick='return confirm("Are you absolutely sure? This cannot be undone."); />
 </form>
 <% end %>
 


### PR DESCRIPTION
The "retry all" form on the failed job view is missing a confirmation prompt before being submitted.
I feel that it would be safer for users to be warned before actually retrying all of the failed jobs. 
This is already done for the "clear all" form.

![1](https://user-images.githubusercontent.com/3199791/124938540-ab1b8600-e008-11eb-88a3-ac005d856003.png)

Tests should be passing:
```
Finished in 4.286434s, 56.2239 runs/s, 132.7444 assertions/s.
241 runs, 569 assertions, 0 failures, 0 errors, 0 skips
```