### PR TITLE
Make server safe to use with Content Security Policies that don't allow 'unsafe-inline'.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@
 ### Fixed
 * Prune workers which haven't been registered but have set a heartbeat
 * `Resque::Failure::Multiple.remove` did not pass on the queue parameter
+* Replace onclick handlers in server code to support Content Security Policies that don't allow 'unsafe-inline'
 
 ## 2.0.0 (2018-11-06)
 

--- a/lib/resque/server/public/main.js
+++ b/lib/resque/server/public/main.js
@@ -1,0 +1,3 @@
+$(document).on('click', '.confirmSubmission', function() {
+  return confirm("Are you absolutely sure? This cannot be undone.");
+});

--- a/lib/resque/server/views/failed.erb
+++ b/lib/resque/server/views/failed.erb
@@ -6,10 +6,10 @@
 
 <% unless failed_size.zero? %>
 <form method="POST" action="<%= u "failed#{'/' + params[:queue] if params[:queue]}/clear" %>">
-  <input type="submit" name="" value="Clear <%= params[:queue] ? "'#{params[:queue]}'" : 'Failed' %> Jobs" onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
+  <input type="submit" name="" value="Clear <%= params[:queue] ? "'#{params[:queue]}'" : 'Failed' %> Jobs" class="confirmSubmission" />
 </form>
 <form method="POST" action="<%= u "failed#{'/' + params[:queue] if params[:queue]}/requeue/all" %>">
-  <input type="submit" name="" value="Retry <%= params[:queue] ? "'#{params[:queue]}'" : 'Failed' %> Jobs" onclick='return confirm("Are you absolutely sure? This cannot be undone."); />
+  <input type="submit" name="" value="Retry <%= params[:queue] ? "'#{params[:queue]}'" : 'Failed' %> Jobs" class="confirmSubmission" />
 </form>
 <% end %>
 

--- a/lib/resque/server/views/layout.erb
+++ b/lib/resque/server/views/layout.erb
@@ -8,6 +8,7 @@
   <script src="<%=u 'jquery-1.12.4.min.js' %>" type="text/javascript"></script>
   <script src="<%=u 'jquery.relatize_date.js' %>" type="text/javascript"></script>
   <script src="<%=u 'ranger.js' %>" type="text/javascript"></script>
+  <script src="<%=u 'main.js' %>" type="text/javascript"></script>
 </head>
 <body>
   <div class="header">

--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -4,7 +4,7 @@
 
   <h1>Pending jobs on <span class='hl'><%= h current_queue %></span></h1>
   <form method="POST" action="<%=u "/queues/#{current_queue}/remove" %>" class='remove-queue'>
-    <input type='submit' name='' value='Remove Queue' onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
+    <input type='submit' name='' value='Remove Queue' class="confirmSubmission" />
   </form>
   <p class='sub'><%= page_entries_info start = params[:start].to_i, start + 19, size = resque.size(current_queue), 'job' %></p>
   <table class='jobs'>


### PR DESCRIPTION
Replace inline onclick handlers with a jQuery click handler registered
on a new class 'confirmSubmission'.

Fixes #1756.