### PR TITLE
Fix 'uninitialized constant Resque::Failure::RedisMultiQueue' on `/overview`

### DIFF
--- a/lib/resque/server/helpers.rb
+++ b/lib/resque/server/helpers.rb
@@ -11,7 +11,7 @@ Resque::Server.helpers do
     return @multiple_failed_queues if defined?(@multiple_failed_queues)
 
     @multiple_failed_queues = Resque::Failure.queues.size > 1 ||
-      Resque::Failure.backend == Resque::Failure::RedisMultiQueue
+      (defined?(Resque::Failure::RedisMultiQueue) && Resque::Failure.backend == Resque::Failure::RedisMultiQueue)
   end
 
   def failed_size


### PR DESCRIPTION
When the `Resque::Failure::RedisMultiQueue` backend is not used the resque-web page throws an exception.
I think this started happening with https://github.com/resque/resque/pull/1638.

Steps to reproduce:
```
cd resque/examples/demo
rackup config.ru
# Open http://localhost:9292/resque
```

Before:
<img width="1122" alt="overview 2021-09-24 02-07-21" src="https://user-images.githubusercontent.com/1948197/134580253-315cd941-0c42-4fc3-9e82-316baba9658d.png">

After:
<img width="1777" alt="Resque 2021-09-24 02-08-05" src="https://user-images.githubusercontent.com/1948197/134580387-d101a30d-c14f-4f9f-b8d7-042023639c36.png">

I'd like to write a spec to verify the fix but I can't find a way of **not** including the failure class in the resque-web test file. Tips if any would be appreciated :)

I found this problem when I began looking into why specs were failing in https://github.com/resque/resque-scheduler/pull/671#issuecomment-924974183.