### PR TITLE
WebRunner

### DIFF
--- a/bin/resque-web
+++ b/bin/resque-web
@@ -1,16 +1,19 @@
 #!/usr/bin/env ruby
 
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
-begin
-  require 'vegas'
-rescue LoadError
-  require 'rubygems'
-  require 'vegas'
+
+if !!(RUBY_PLATFORM =~ /(mingw|bccwin|wince|mswin32)/i)
+  begin
+    require 'win32/process'
+  rescue
+    puts "Sorry, in order to use resque-web on Windows you need the win32-process gem:",
+         "gem install win32-process"
+  end
 end
 require 'resque/server'
+require 'resque/web_runner'
 
-
-Vegas::Runner.new(Resque::Server, 'resque-web', {
+Resque::WebRunner.new(Resque::Server, 'resque-web', {
   :before_run => lambda {|v|
     path = (ENV['RESQUECONFIG'] || v.args.first)
     load path.to_s.strip if path

--- a/bin/resque-web
+++ b/bin/resque-web
@@ -18,17 +18,4 @@ Resque::WebRunner.new(Resque::Server, 'resque-web', {
     path = (ENV['RESQUECONFIG'] || v.args.first)
     load path.to_s.strip if path
   }
-}) do |runner, opts, app|
-  opts.on('-N NAMESPACE', "--namespace NAMESPACE", "set the Redis namespace") {|namespace|
-    runner.logger.info "Using Redis namespace '#{namespace}'"
-    Resque.redis.namespace = namespace
-  }
-  opts.on('-r redis-connection', "--redis redis-connection", "set the Redis connection string") {|redis_conf|
-    runner.logger.info "Using Redis connection '#{redis_conf}'"
-    Resque.redis = redis_conf
-  }
-  opts.on('-a url-prefix', "--append url-prefix", "set reverse_proxy friendly prefix to links") {|url_prefix|
-    runner.logger.info "Using URL Prefix '#{url_prefix}'"
-    Resque::Server.url_prefix = url_prefix
-  }
-end
+})

--- a/bin/resque-web
+++ b/bin/resque-web
@@ -13,9 +13,4 @@ end
 require 'resque/server'
 require 'resque/web_runner'
 
-Resque::WebRunner.new(Resque::Server, 'resque-web', {
-  :before_run => lambda {|v|
-    path = (ENV['RESQUECONFIG'] || v.args.first)
-    load path.to_s.strip if path
-  }
-})
+Resque::WebRunner.new(Resque::Server, 'resque-web')

--- a/bin/resque-web
+++ b/bin/resque-web
@@ -10,7 +10,6 @@ if !!(RUBY_PLATFORM =~ /(mingw|bccwin|wince|mswin32)/i)
          "gem install win32-process"
   end
 end
-require 'resque/server'
 require 'resque/web_runner'
 
-Resque::WebRunner.new(Resque::Server, 'resque-web')
+Resque::WebRunner.new(*ARGV)

--- a/examples/resque_config.rb
+++ b/examples/resque_config.rb
@@ -1,0 +1,1 @@
+# puts "evaluating code loaded from config_path in context #{inspect}"

--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -35,10 +35,7 @@ module Resque
         exit!(0)
       end
 
-      # Handle :before_run hook
-      if (before_run = options.delete(:before_run)).respond_to?(:call)
-        before_run.call(self)
-      end
+      before_run
 
       # Set app options
       @host = options[:host] || HOST
@@ -82,6 +79,11 @@ module Resque
 
     def url
       "http://#{host}:#{port}"
+    end
+
+    def before_run
+      path = (ENV['RESQUECONFIG'] || args.first)
+      load_config_file(path.to_s.strip) if path
     end
 
     def start(path = nil)

--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -11,7 +11,7 @@ module Resque
 
   class WebRunner
     attr_reader :app, :app_name, :filesystem_friendly_app_name, :quoted_app_name,
-      :rack_handler, :port, :host, :options, :args
+      :rack_handler, :port, :options, :args
 
     PORT       = 5678
     HOST       = WINDOWS ? 'localhost' : '0.0.0.0'
@@ -39,8 +39,6 @@ module Resque
       before_run
 
       # Set app options
-      @host = options[:host] || HOST
-
       app.set(options)
       app.set(:web_runner, self)
 
@@ -72,6 +70,10 @@ module Resque
 
     def log_file
       options[:log_file] || File.join(app_dir, "#{filesystem_friendly_app_name}.log")
+    end
+
+    def host
+      options.fetch(:host) { HOST }
     end
 
     def url

--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -44,9 +44,6 @@ module Resque
       app.set(options)
       app.set(:web_runner, self)
 
-      # Make sure app dir is setup
-      FileUtils.mkdir_p(app_dir)
-
       start unless options[:start] == false
     end
 
@@ -140,6 +137,8 @@ module Resque
     end
 
     def write_url
+      # Make sure app dir is setup
+      FileUtils.mkdir_p(app_dir)
       File.open(url_file, 'w') {|f| f << url }
     end
 

--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -10,7 +10,7 @@ module Resque
   JRUBY = !!(RbConfig::CONFIG["RUBY_INSTALL_NAME"] =~ /^jruby/i)
 
   class WebRunner
-    attr_reader :app, :app_name, :filesystem_friendly_app_name, :quoted_app_name,
+    attr_reader :app, :app_name, :filesystem_friendly_app_name,
       :rack_handler, :port, :options, :args
 
     PORT       = 5678
@@ -23,9 +23,7 @@ module Resque
 
       @app      = Resque::Server
       @app_name = 'resque-web'
-
       @filesystem_friendly_app_name = @app_name.gsub(/\W+/, "_")
-      @quoted_app_name = "'#{app_name}'"
 
       @rack_handler = setup_rack_handler
 
@@ -85,7 +83,7 @@ module Resque
     def start(path = launch_path)
       logger.info "Running with Windows Settings" if WINDOWS
       logger.info "Running with JRuby" if JRUBY
-      logger.info "Starting #{quoted_app_name}..."
+      logger.info "Starting '#{app_name}'..."
 
       check_for_running(path)
       find_port
@@ -94,7 +92,7 @@ module Resque
       daemonize! unless options[:foreground]
       run!
     rescue RuntimeError => e
-      logger.warn "There was an error starting #{quoted_app_name}: #{e}"
+      logger.warn "There was an error starting '#{app_name}': #{e}"
       exit
     end
 
@@ -145,7 +143,7 @@ module Resque
       if File.exist?(pid_file) && File.exist?(url_file)
         running_url = File.read(url_file)
         if !port_open?(running_url)
-          logger.warn "#{quoted_app_name} is already running at #{running_url}"
+          logger.warn "'#{app_name}' is already running at #{running_url}"
           launch!(running_url, path)
           exit!(1)
         end
@@ -160,7 +158,7 @@ module Resque
           trap(command) do
             ## Use thins' hard #stop! if available, otherwise just #stop
             server.respond_to?(:stop!) ? server.stop! : server.stop
-            logger.info "#{quoted_app_name} received INT ... stopping"
+            logger.info "'#{app_name}' received INT ... stopping"
             delete_pid!
           end
         end
@@ -215,11 +213,11 @@ module Resque
 
     def status
       if File.exists?(pid_file)
-        logger.info "#{quoted_app_name} running"
+        logger.info "'#{app_name}' running"
         logger.info "PID #{File.read(pid_file)}"
         logger.info "URL #{File.read(url_file)}" if File.exists?(url_file)
       else
-        logger.info "#{quoted_app_name} not running!"
+        logger.info "'#{app_name}' not running!"
       end
     end
 

--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -5,6 +5,9 @@ require 'fileutils'
 require 'rack'
 require 'resque/server'
 
+# only used with `bin/resque-web`
+# https://github.com/resque/resque/pull/1780
+
 module Resque
   WINDOWS = !!(RUBY_PLATFORM =~ /(mingw|bccwin|wince|mswin32)/i)
   JRUBY = !!(RbConfig::CONFIG["RUBY_INSTALL_NAME"] =~ /^jruby/i)

--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -134,11 +134,15 @@ module Resque
     def port_open?(check_url = nil)
       begin
         check_url ||= url
-        options[:no_proxy] ? URI.open(check_url, :proxy => nil) : URI.open(check_url)
+        options[:no_proxy] ? uri_open(check_url, :proxy => nil) : uri_open(check_url)
         false
       rescue Errno::ECONNREFUSED, Errno::EPERM, Errno::ETIMEDOUT
         true
       end
+    end
+
+    def uri_open(*args)
+      (RbConfig::CONFIG['ruby_version'] < '2.7') ? open(*args) : URI.open(*args)
     end
 
     def write_url

--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -1,0 +1,379 @@
+require 'open-uri'
+require 'logger'
+require 'optparse'
+require 'fileutils'
+require 'rack'
+
+module Resque
+  WINDOWS = !!(RUBY_PLATFORM =~ /(mingw|bccwin|wince|mswin32)/i)
+  JRUBY = !!(RbConfig::CONFIG["RUBY_INSTALL_NAME"] =~ /^jruby/i)
+
+  class WebRunner
+    attr_reader :app, :app_name, :filesystem_friendly_app_name, :quoted_app_name,
+      :rack_handler, :port, :host, :options, :args
+
+    PORT       = 5678
+    HOST       = WINDOWS ? 'localhost' : '0.0.0.0'
+
+    def initialize(app, app_name, set_options = {}, runtime_args = ARGV, &block)
+      @options = set_options || {}
+
+      self.class.logger.level = options[:debug] ? Logger::DEBUG : Logger::INFO
+
+      @app      = app
+      @app_name = app_name
+
+      @filesystem_friendly_app_name = @app_name.gsub(/\W+/, "_")
+      @quoted_app_name = "'#{app_name}'"
+
+      @runtime_args = runtime_args
+      @rack_handler = setup_rack_handler
+
+      # load options from opt parser
+      @args = define_options do |opts|
+        if block_given?
+          opts.separator ''
+          opts.separator "#{quoted_app_name} options:"
+          yield(self, opts, app)
+        end
+      end
+
+      if @should_kill
+        kill!
+        exit!(0)
+      end
+
+      # Handle :before_run hook
+      if (before_run = options.delete(:before_run)).respond_to?(:call)
+        before_run.call(self)
+      end
+
+      # Set app options
+      @host = options[:host] || HOST
+
+        app.set(options)
+      app.set(:web_runner, self)
+
+      # Make sure app dir is setup
+      FileUtils.mkdir_p(app_dir)
+
+      return if options[:start] == false
+
+      # evaluate the launch_path
+      path = if options[:launch_path].respond_to?(:call)
+        options[:launch_path].call(self)
+      else
+        options[:launch_path]
+      end
+
+      start(path)
+    end
+
+    def app_dir
+      if !options[:app_dir] && !ENV['HOME']
+        raise ArgumentError.new("nor --app-dir neither ENV['HOME'] defined")
+      end
+      options[:app_dir] || File.join(ENV['HOME'], filesystem_friendly_app_name)
+    end
+
+    def pid_file
+      options[:pid_file] || File.join(app_dir, "#{filesystem_friendly_app_name}.pid")
+    end
+
+    def url_file
+      options[:url_file] || File.join(app_dir, "#{filesystem_friendly_app_name}.url")
+    end
+
+    def log_file
+      options[:log_file] || File.join(app_dir, "#{filesystem_friendly_app_name}.log")
+    end
+
+    def url
+      "http://#{host}:#{port}"
+    end
+
+    def start(path = nil)
+      logger.info "Running with Windows Settings" if WINDOWS
+      logger.info "Running with JRuby" if JRUBY
+      logger.info "Starting #{quoted_app_name}..."
+
+      check_for_running(path)
+      find_port
+      write_url
+      launch!(url, path)
+      daemonize! unless options[:foreground]
+      run!
+    rescue RuntimeError => e
+      logger.warn "There was an error starting #{quoted_app_name}: #{e}"
+      exit
+    end
+
+    def find_port
+      if @port = options[:port]
+        announce_port_attempted
+
+        unless port_open?
+          logger.warn "Port #{port} is already in use. Please try another. " +
+                      "You can also omit the port flag, and we'll find one for you."
+        end
+      else
+        @port = PORT
+        announce_port_attempted
+
+        until port_open?
+          @port += 1
+          announce_port_attempted
+        end
+      end
+    end
+
+    def announce_port_attempted
+      logger.info "trying port #{port}..."
+    end
+
+    def port_open?(check_url = nil)
+      begin
+        check_url ||= url
+        options[:no_proxy] ? URI.open(check_url, :proxy => nil) : URI.open(check_url)
+        false
+      rescue Errno::ECONNREFUSED, Errno::EPERM, Errno::ETIMEDOUT
+        true
+      end
+    end
+
+    def write_url
+      File.open(url_file, 'w') {|f| f << url }
+    end
+
+    def check_for_running(path = nil)
+      if File.exist?(pid_file) && File.exist?(url_file)
+        running_url = File.read(url_file)
+        if !port_open?(running_url)
+          logger.warn "#{quoted_app_name} is already running at #{running_url}"
+          launch!(running_url, path)
+          exit!(1)
+        end
+      end
+    end
+
+    def run!
+      logger.info "Running with Rack handler: #{@rack_handler.inspect}"
+
+      rack_handler.run app, :Host => host, :Port => port do |server|
+        kill_commands.each do |command|
+          trap(command) do
+            ## Use thins' hard #stop! if available, otherwise just #stop
+            server.respond_to?(:stop!) ? server.stop! : server.stop
+            logger.info "#{quoted_app_name} received INT ... stopping"
+            delete_pid!
+          end
+        end
+      end
+    end
+
+    # Adapted from Rackup
+    def daemonize!
+      if JRUBY
+        # It's not a true daemon but when executed with & works like one
+        thread = Thread.new {daemon_execute}
+        thread.join
+
+      elsif RUBY_VERSION < "1.9"
+        logger.debug "Parent Process: #{Process.pid}"
+        exit!(0) if fork
+        logger.debug "Child Process: #{Process.pid}"
+        daemon_execute
+
+      else
+        Process.daemon(true, true)
+        daemon_execute
+      end
+    end
+
+    def daemon_execute
+      File.umask 0000
+      FileUtils.touch log_file
+      STDIN.reopen    log_file
+      STDOUT.reopen   log_file, "a"
+      STDERR.reopen   log_file, "a"
+
+      logger.debug "Child Process: #{Process.pid}"
+
+      File.open(pid_file, 'w') {|f| f.write("#{Process.pid}") }
+      at_exit { delete_pid! }
+    end
+
+    def launch!(specific_url = nil, path = nil)
+      return if options[:skip_launch]
+      cmd = WINDOWS ? "start" : "open"
+      system "#{cmd} #{specific_url || url}#{path}"
+    end
+
+    def kill!
+      pid = File.read(pid_file)
+      logger.warn "Sending #{kill_command} to #{pid.to_i}"
+      Process.kill(kill_command, pid.to_i)
+    rescue => e
+      logger.warn "pid not found at #{pid_file} : #{e}"
+    end
+
+    def status
+      if File.exists?(pid_file)
+        logger.info "#{quoted_app_name} running"
+        logger.info "PID #{File.read(pid_file)}"
+        logger.info "URL #{File.read(url_file)}" if File.exists?(url_file)
+      else
+        logger.info "#{quoted_app_name} not running!"
+      end
+    end
+
+    # Loads a config file at config_path and evals it in the context of the @app.
+    def load_config_file(config_path)
+      abort "Can not find config file at #{config_path}" if !File.readable?(config_path)
+      config = File.read(config_path)
+      # trim off anything after __END__
+      config.sub!(/^__END__\n.*/, '')
+      @app.module_eval(config)
+    end
+
+    def self.logger=(logger)
+      @logger = logger
+    end
+
+    def self.logger
+      @logger ||= LOGGER if defined?(LOGGER)
+      if !@logger
+        @logger           = Logger.new(STDOUT)
+        @logger.formatter = Proc.new {|s, t, n, msg| "[#{t}] #{msg}\n"}
+        @logger
+      end
+      @logger
+    end
+
+    def logger
+      self.class.logger
+    end
+
+  private
+    def setup_rack_handler
+      # First try to set Rack handler via a special hook we honor
+      @rack_handler = if @app.respond_to?(:detect_rack_handler)
+        @app.detect_rack_handler
+
+      # If they aren't using our hook, try to use their @app.server settings
+      elsif @app.respond_to?(:server) and @app.server
+        # If :server isn't set, it returns an array of possibilities,
+        # sorted from most to least preferable.
+        if @app.server.is_a?(Array)
+          handler = nil
+          @app.server.each do |server|
+            begin
+              handler = Rack::Handler.get(server)
+              break
+            rescue LoadError, NameError => e
+              next
+            end
+          end
+          handler
+
+        # :server might be set explicitly to a single option like "mongrel"
+        else
+          Rack::Handler.get(@app.server)
+        end
+
+      # If all else fails, we'll use Thin
+      else
+        JRUBY ? Rack::Handler::WEBrick : Rack::Handler::Thin
+      end
+    end
+
+    def define_options
+      OptionParser.new("", 24, '  ') do |opts|
+        # TODO instead of app_name, we should determine the name of the script
+        # used to invoke Vegas and use that here
+        opts.banner = "Usage: #{$0 || app_name} [options]"
+
+        opts.separator ""
+        opts.separator "Vegas options:"
+
+        opts.on('-K', "--kill", "kill the running process and exit") {|k|
+          @should_kill = true
+        }
+        opts.on('-S', "--status", "display the current running PID and URL then quit") {|s|
+          status
+          exit!(0)
+        }
+        opts.on("-s", "--server SERVER", "serve using SERVER (thin/mongrel/webrick)") { |s|
+          @rack_handler = Rack::Handler.get(s)
+        }
+        opts.on("-o", "--host HOST", "listen on HOST (default: #{HOST})") { |host|
+          @options[:host] = host
+        }
+        opts.on("-p", "--port PORT", "use PORT (default: #{PORT})") { |port|
+          @options[:port] = port
+        }
+        opts.on("-x", "--no-proxy", "ignore env proxy settings (e.g. http_proxy)") { |p|
+          @options[:no_proxy] = true
+        }
+        opts.on("-e", "--env ENVIRONMENT", "use ENVIRONMENT for defaults (default: development)") { |e|
+          @options[:environment] = e
+        }
+        opts.on("-F", "--foreground", "don't daemonize, run in the foreground") { |f|
+          @options[:foreground] = true
+        }
+        opts.on("-L", "--no-launch", "don't launch the browser") { |f|
+          @options[:skip_launch] = true
+        }
+        opts.on('-d', "--debug", "raise the log level to :debug (default: :info)") {|s|
+          @options[:debug] = true
+        }
+        opts.on("--app-dir APP_DIR", "set the app dir where files are stored (default: ~/#{filesystem_friendly_app_name})/)") {|app_dir|
+          @options[:app_dir] = app_dir
+        }
+        opts.on("-P", "--pid-file PID_FILE", "set the path to the pid file (default: app_dir/#{filesystem_friendly_app_name}.pid)") {|pid_file|
+          @options[:pid_file] = pid_file
+        }
+        opts.on("--log-file LOG_FILE", "set the path to the log file (default: app_dir/#{filesystem_friendly_app_name}.log)") {|log_file|
+          @options[:log_file] = log_file
+        }
+        opts.on("--url-file URL_FILE", "set the path to the URL file (default: app_dir/#{filesystem_friendly_app_name}.url)") {|url_file|
+          @options[:url_file] = url_file
+        }
+
+        yield opts if block_given?
+
+        opts.separator ""
+        opts.separator "Common options:"
+
+        opts.on_tail("-h", "--help", "Show this message") do
+          puts opts
+          exit
+        end
+
+        opts.on_tail("--version", "Show version") do
+          puts "resque #{Resque::VERSION}"
+          puts "rack #{Rack::VERSION.join('.')}"
+          puts "sinatra #{Sinatra::VERSION}" if defined?(Sinatra)
+          exit
+        end
+
+      end.parse! @runtime_args
+    rescue OptionParser::MissingArgument => e
+      logger.warn "#{e}, run -h for options"
+      exit
+    end
+
+    def kill_commands
+      WINDOWS ? [1] : [:INT, :TERM]
+    end
+
+    def kill_command
+      kill_commands[0]
+    end
+
+    def delete_pid!
+      File.delete(pid_file) if File.exist?(pid_file)
+    end
+  end
+
+end

--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -41,22 +41,21 @@ module Resque
       # Set app options
       @host = options[:host] || HOST
 
-        app.set(options)
+      app.set(options)
       app.set(:web_runner, self)
 
       # Make sure app dir is setup
       FileUtils.mkdir_p(app_dir)
 
-      return if options[:start] == false
+      start unless options[:start] == false
+    end
 
-      # evaluate the launch_path
-      path = if options[:launch_path].respond_to?(:call)
+    def launch_path
+      if options[:launch_path].respond_to?(:call)
         options[:launch_path].call(self)
       else
         options[:launch_path]
       end
-
-      start(path)
     end
 
     def app_dir
@@ -87,7 +86,7 @@ module Resque
       load_config_file(path.to_s.strip) if path
     end
 
-    def start(path = nil)
+    def start(path = launch_path)
       logger.info "Running with Windows Settings" if WINDOWS
       logger.info "Running with JRuby" if JRUBY
       logger.info "Starting #{quoted_app_name}..."

--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -38,10 +38,6 @@ module Resque
 
       before_run
 
-      # Set app options
-      app.set(options)
-      app.set(:web_runner, self)
-
       start unless options[:start] == false
     end
 
@@ -81,6 +77,7 @@ module Resque
     end
 
     def before_run
+      app.set(options.merge web_runner: self)
       path = (ENV['RESQUECONFIG'] || args.first)
       load_config_file(path.to_s.strip) if path
     end

--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -3,6 +3,7 @@ require 'logger'
 require 'optparse'
 require 'fileutils'
 require 'rack'
+require 'resque/server'
 
 module Resque
   WINDOWS = !!(RUBY_PLATFORM =~ /(mingw|bccwin|wince|mswin32)/i)
@@ -15,13 +16,13 @@ module Resque
     PORT       = 5678
     HOST       = WINDOWS ? 'localhost' : '0.0.0.0'
 
-    def initialize(app, app_name, set_options = {}, runtime_args = ARGV)
-      @options = set_options || {}
+    def initialize(*runtime_args)
+      @options = runtime_args.last.is_a?(Hash) ? runtime_args.pop : {}
 
       self.class.logger.level = options[:debug] ? Logger::DEBUG : Logger::INFO
 
-      @app      = app
-      @app_name = app_name
+      @app      = Resque::Server
+      @app_name = 'resque-web'
 
       @filesystem_friendly_app_name = @app_name.gsub(/\W+/, "_")
       @quoted_app_name = "'#{app_name}'"

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3.0"
 
   s.add_dependency "redis-namespace", "~> 1.6"
-  s.add_dependency "vegas", "~> 0.1.2"
   s.add_dependency "sinatra", ">= 0.9.2"
   s.add_dependency "multi_json", "~> 1.0"
   s.add_dependency "mono_logger", "~> 1.0"
@@ -44,6 +43,9 @@ Gem::Specification.new do |s|
     * A Rake task for starting a worker which processes jobs
     * A Sinatra app for monitoring queues, jobs, and workers.
 description
+
+  s.add_development_dependency "thin"
+  s.add_development_dependency "webrick"
 
   s.metadata['changelog_uri'] = 'https://github.com/resque/resque/blob/master/HISTORY.md'
 end

--- a/test/resque-web_runner_test.rb
+++ b/test/resque-web_runner_test.rb
@@ -13,6 +13,8 @@ describe 'Resque::WebRunner' do
   end
 
   before do
+    ENV['RESQUECONFIG'] = 'examples/resque_config.rb'
+
     FileUtils.rm_rf(File.join(File.dirname(__FILE__), 'tmp'))
     @log = StringIO.new
     Resque::WebRunner.logger = Logger.new(@log)

--- a/test/resque-web_runner_test.rb
+++ b/test/resque-web_runner_test.rb
@@ -4,12 +4,12 @@ require 'resque/server'
 require 'resque/web_runner'
 
 describe 'Resque::WebRunner' do
-  def web_runner(*args, &block)
+  def web_runner(*args)
     Resque::WebRunner.any_instance.stubs(:daemonize!).once
 
     Resque::JRUBY ? Rack::Handler::WEBrick.stubs(:run).once : Rack::Handler::Thin.stubs(:run).once
 
-    @runner = Resque::WebRunner.new(*args, &block)
+    @runner = Resque::WebRunner.new(*args)
   end
 
   before do

--- a/test/resque-web_runner_test.rb
+++ b/test/resque-web_runner_test.rb
@@ -34,7 +34,6 @@ describe 'Resque::WebRunner' do
 
       it "sets app name" do
         assert_equal @runner.app_name, 'resque-web'
-        assert_equal @runner.quoted_app_name, "'resque-web'"
         assert_equal @runner.filesystem_friendly_app_name, 'resque_web'
       end
 

--- a/test/resque-web_runner_test.rb
+++ b/test/resque-web_runner_test.rb
@@ -1,0 +1,208 @@
+require 'test_helper'
+require 'rack/test'
+require 'resque/server'
+require 'resque/web_runner'
+
+describe 'Resque::WebRunner' do
+  def web_runner(*args, &block)
+    Resque::WebRunner.any_instance.stubs(:daemonize!).once
+
+    Resque::JRUBY ? Rack::Handler::WEBrick.stubs(:run).once : Rack::Handler::Thin.stubs(:run).once
+
+    @runner = Resque::WebRunner.new(*args, &block)
+  end
+
+  before do
+    FileUtils.rm_rf(File.join(File.dirname(__FILE__), 'tmp'))
+    @log = StringIO.new
+    Resque::WebRunner.logger = Logger.new(@log)
+  end
+
+  describe 'creating an instance' do
+
+    describe 'basic usage' do
+      before do
+        Resque::WebRunner.any_instance.expects(:system).once
+        web_runner(Resque::Server, 'test_app_1', {:sessions => true}, ["route","--debug"])
+      end
+
+      it "sets app" do
+        assert_equal @runner.app, Resque::Server
+      end
+
+      it "sets app name" do
+        assert_equal @runner.app_name, 'test_app_1'
+      end
+
+      it "sets quoted app name" do
+        assert_equal @runner.quoted_app_name, "'test_app_1'"
+      end
+
+      it "sets filesystem friendly app name" do
+        assert_equal @runner.filesystem_friendly_app_name, 'test_app_1'
+      end
+
+      it "stores options" do
+        assert @runner.options[:sessions]
+      end
+
+      it "puts unparsed args into args" do
+        assert_equal @runner.args, ["route"]
+      end
+
+      it "parses options into @options" do
+        assert @runner.options[:debug]
+      end
+
+      it "writes the app dir" do
+        assert File.exist?(@runner.app_dir)
+      end
+
+      it "writes a url with the port" do
+        assert File.exist?(@runner.url_file)
+        assert File.read(@runner.url_file).match(/0.0.0.0\:#{@runner.port}/)
+      end
+
+      it "knows where to find the pid file" do
+        assert_equal @runner.pid_file, \
+          File.join(@runner.app_dir, @runner.filesystem_friendly_app_name + ".pid")
+        # assert File.exist?(@runner.pid_file), "#{@runner.pid_file} not found."
+      end
+    end
+
+    describe 'basic usage with a funky app name' do
+      before do
+        Resque::WebRunner.any_instance.expects(:system).once
+        web_runner(Resque::Server, 'Funky YEAH!1!', {:sessions => true}, ["route","--debug"])
+      end
+
+      it "sets app" do
+        assert_equal @runner.app, Resque::Server
+      end
+
+      it "sets app name" do
+        assert_equal @runner.app_name, 'Funky YEAH!1!'
+      end
+
+      it "sets quoted app name" do
+        assert_equal @runner.quoted_app_name, "'Funky YEAH!1!'"
+      end
+
+      it "sets filesystem friendly app name" do
+        assert_equal @runner.filesystem_friendly_app_name, 'Funky_YEAH_1_'
+      end
+
+      it "stores options" do
+        assert @runner.options[:sessions]
+      end
+
+      it "puts unparsed args into args" do
+        assert_equal @runner.args, ["route"]
+      end
+
+      it "parses options into @options" do
+        assert @runner.options[:debug]
+      end
+
+      it "writes the app dir" do
+        assert File.exist?(@runner.app_dir)
+      end
+
+      it "writes a url with the port" do
+        assert File.exist?(@runner.url_file)
+        assert File.read(@runner.url_file).match(/0.0.0.0\:#{@runner.port}/)
+      end
+
+      it "knows where to find the pid file" do
+        assert_equal @runner.pid_file, \
+          File.join(@runner.app_dir, @runner.filesystem_friendly_app_name + ".pid")
+        # assert File.exist?(@runner.pid_file), "#{@runner.pid_file} not found."
+      end
+    end
+
+    describe 'with a sinatra app using an explicit server setting' do
+      def web_runner(*args)
+        Resque::WebRunner.any_instance.stubs(:daemonize!).once
+        Rack::Handler::WEBrick.stubs(:run).once
+        @runner = Resque::WebRunner.new(*args)
+      end
+
+      before do
+        Resque::Server.set :server, "webrick"
+        Rack::Handler::WEBrick.stubs(:run)
+        web_runner(Resque::Server, 'test_app_1', {:skip_launch => true, :sessions => true}, ["route","--debug"])
+      end
+      after do
+        Resque::Server.set :server, false
+      end
+
+      it 'sets the rack handler automaticaly' do
+        assert_equal @runner.rack_handler, Rack::Handler::WEBrick
+      end
+    end
+
+    describe 'with a simple rack app' do
+      before do
+        web_runner(Resque::Server, 'rack_app_1', {:skip_launch => true, :sessions => true})
+      end
+
+      it "sets default rack handler to thin when in ruby and WEBrick when in jruby" do
+        if Resque::JRUBY
+          assert_equal @runner.rack_handler, Rack::Handler::WEBrick
+        else
+          assert_equal @runner.rack_handler, Rack::Handler::Thin
+        end
+      end
+    end
+
+    describe 'with a launch path specified as a proc' do
+      it 'evaluates the proc in the context of the runner' do
+        Resque::WebRunner.any_instance.expects(:system).once.with {|s| s =~ /\?search\=blah$/ }
+        web_runner(Resque::Server,
+              'test_app_2',
+              {:launch_path => Proc.new {|r| "?search=#{r.args.first}" }},
+              ["--debug", "blah"])
+        assert @runner.options[:launch_path].is_a?(Proc)
+      end
+    end
+
+    describe 'with a launch path specified as string' do
+      it 'launches to the specific path' do
+        Resque::WebRunner.any_instance.expects(:system).once.with {|s| s =~ /\?search\=blah$/ }
+        web_runner(Resque::Server,
+              'test_app_2',
+              {:launch_path => "?search=blah"},
+              ["--debug", "blah"])
+        assert_equal @runner.options[:launch_path], "?search=blah"
+      end
+    end
+
+    describe 'without environment' do
+
+      before do
+        @home = ENV.delete('HOME')
+        @app_dir = './test/tmp'
+      end
+
+      after { ENV['HOME'] = @home }
+
+      it 'should be ok with --app-dir' do
+        web_runner(Resque::Server, 'rack_app_1', {:skip_launch => true, :app_dir => @app_dir})
+        assert_equal @runner.app_dir, @app_dir
+      end
+
+      it 'should raise an exception without --app-dir' do
+        success = false
+        begin
+          Resque::WebRunner.new(Resque::Server, 'rack_app_1', {:skip_launch => true})
+        rescue ArgumentError
+          success = true
+        end
+        assert success, "ArgumentError not raised."
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
Closes #1706 
Fixes #1746

I'm not sure this is what you expected, but I copied Vegas::Runner as Resque::WebRunner and simplified as far as I could.  This approach preserves all the options including Windows/JRuby support, foreground/daemon, status/kill, version/help, etc.
