### PR TITLE
Add rel attribute in anchor link to mitigate reverse tabnabbing

### DIFF
--- a/lib/resque/server/views/job_class.erb
+++ b/lib/resque/server/views/job_class.erb
@@ -1,6 +1,8 @@
 <% if job['class'] == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper' %>
   <code><%= job['args'].first['job_class'] %></code>
-  <small><a href="http://edgeguides.rubyonrails.org/active_job_basics.html" target="_blank">(via ActiveJob)</a></small>
+  <small>
+    <a href="http://edgeguides.rubyonrails.org/active_job_basics.html" rel="noopener noreferrer" target="_blank">(via ActiveJob)</a>
+  </small>
 <% else %>
   <code><%= job['class'] %></code>
 <% end %>


### PR DESCRIPTION
We use RubyGem-resque as a dependency for one of our services. 

Our company's InfoSec org has called out a reverse tabnabbing attack in "job_class.erb" and in order to use it, we have to add "rel" attribute to value "noopener noreferrer".

Here's a demo and example explaining how this change will fix the issue: https://mathiasbynens.github.io/rel-noopener/