### PR TITLE
Update peek documentation to better represent type variance based on count

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -364,8 +364,8 @@ module Resque
     data_store.queue_size(queue)
   end
 
-  # Returns an array of items currently queued. Queue name should be
-  # a string.
+  # Returns an array of items currently queued, or the item itself
+  # if count = 1. Queue name should be a string.
   #
   # start and count should be integer and can be used for pagination.
   # start is the item to begin, count is how many items to return.


### PR DESCRIPTION
# Update peek documentation to better represent type variance based on count

Just a small doc change to mention that the item itself is returned when count is 1, as opposed to an array of 1 item