### PR TITLE
CI against Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - 2.6
           - 2.7
           - "3.0"
+          - 3.1
           - head
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Now that Ruby 3.1 has been released, this PR adds it to the CI matrix.