### PR TITLE
Updates Resque::Job.destroy with a safer version

### DIFF
--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -110,6 +110,20 @@ describe "Resque" do
     assert_equal 2, Resque.size(:jobs)
   end
 
+  it "jobs can be destroyed (unsafely)" do
+    assert Resque::Job.create(:jobs, 'SomeJob', 20, '/tmp')
+    assert Resque::Job.create(:jobs, 'BadJob', 20, '/tmp')
+    assert Resque::Job.create(:jobs, 'SomeJob', 20, '/tmp')
+    assert Resque::Job.create(:jobs, 'BadJob', 30, '/tmp')
+    assert Resque::Job.create(:jobs, 'BadJob', 20, '/tmp')
+
+    assert_equal 5, Resque.size(:jobs)
+    assert_equal 2, Resque::Job.destroy!(:jobs, 'SomeJob')
+    assert_equal 3, Resque.size(:jobs)
+    assert_equal 1, Resque::Job.destroy!(:jobs, 'BadJob', 30, '/tmp')
+    assert_equal 2, Resque.size(:jobs)
+  end
+
   it "jobs can it for equality" do
     assert Resque::Job.create(:jobs, 'SomeJob', 20, '/tmp')
     assert Resque::Job.create(:jobs, 'some-job', 20, '/tmp')


### PR DESCRIPTION
I've used a version of this since ~ten years ago and I just pushed it to github so I can replace our monkeypatch with a fork.   And I've had the following comment above it for half that time:
`# TODO: send a patch back to resque`
So here is that patch.  🙂 

It is, in my opinion, superior to the original in every way.  Copying from the documentation I wrote:

    # This looks at only one job at a time, so it isn't fast.  Also, it will
    # temporarily drain the queue into a temporary queue, in order to check
    # every job safely.  However, it never runs any slow redis commands, and its
    # memory usage is bounded to a single job, and it uses an atomic rpoplpush
    # to ensure that jobs which should not be removed are never removed from
    # redis entirely.  If the method is interrupted or crashes, one or both of
    # the following queues will need to be moved back into the actual queue:
    #
    #  * Holds each individual job while it is being checked:
    #    "#{queue}:tmp:destroy:#{Time.now.to_i}"
    #
    #  * Holds all of the jobs which do not match and will be requeued:
    #    "#{queue}:tmp:requeue"
    #
    # This is safe to run multiple times concurrently, so long as it isn't
    # started more than once during a single second.

Although this isn't _fast_, it isn't necessarily slower than the original version.  The original will bring a redis server to its knees if the queue is too large; and the only time I ever need to run this command is when a queue is too large!.  Each LREM is `O(n)` so the overall operation is `O(n*m)` (m is number of deleted jobs) although (if I remember how this math works) it has an effective upper bound of `O(n log n)` if the queue gets smaller as you delete from it. 😉

However I have a few caveats (which should probably be considered before merging):

* I made some minor tweaks just now, to tidy it up for this PR.  I made sure it passed all of my local tests, but I haven't run this exact version in production yet.
* I actually haven't called this method in production _in years_.  I've been using a slightly more elaborate version several times a year, usually in semi-urgent maintenance situations (... or in emergencies).  I've used it on 8GB+ queues with no problems. That version provides progress feedback but it has a slightly different API (that can be changed).  And it doesn't use "rpoplpush" so it's less safe than the version I've posted here.  I've posted a gist of that one here: https://gist.github.com/nevans/30025e2538762b9318d47960ef0e77c5.  If there's interest, I can update this PR with the better parts of that implementation.
* I have a _far_ more elaborate version which also operates on the failure queue, has a DSL for automated rulesets, etc.  I run that version on my failure queue from a cronjob, several times a day.  But I need to get permission before I contribute that or convert it into an open source gem.  :)
* That "started multiple times per second" caveat mentioned in the rdoc for the method can be easily fixed by added microseconds, pid, thread id, and a random string.  Unless people are calling this automatically, which they shouldn't be, none of that is really necessary.  Neither the sweeper I posted in the above just nor my cron-job queue sweeper have this problem.

This also retains the original implementation as `Resque::Job.destroy!`, in case any one actually depended on the unsafe behavior... (oh god, I hope not!)  I'd be more than happy to just delete that version: It can use up all of your ruby process's available memory and create long pauses on the redis server and is thus completely unsuitable for a production environment, IMO.