### PR TITLE
Escape HTML from the params to avoid XSS

### DIFF
--- a/lib/resque/server/views/error.erb
+++ b/lib/resque/server/views/error.erb
@@ -1,1 +1,1 @@
-<h1 style="font-size:110%;font-family:Arial, sans-serif;"><%= error %></h1>
+<h1 style="font-size:110%;font-family:Arial, sans-serif;"><%= escape_html(error) %></h1>

--- a/lib/resque/server/views/failed.erb
+++ b/lib/resque/server/views/failed.erb
@@ -1,12 +1,12 @@
 <% if failed_multiple_queues? && !params[:queue] %>
 <h1>All Failed Queues: <%= Resque::Failure.queues.size %> total</h1>
 <% else %>
-<h1>Failed Jobs <%= "on '#{params[:queue]}'" if params[:queue] %> <%= "with class '#{params[:class]}'" if params[:class] %></h1>
+<h1>Failed Jobs <%= "on '#{escape_html(params[:queue])}'" if params[:queue] %> <%= "with class '#{escape_html(params[:class])}'" if params[:class] %></h1>
 <% end %>
 
 <% unless failed_size.zero? %>
 <form method="POST" action="<%= u "failed#{'/' + params[:queue] if params[:queue]}/clear" %>">
-  <input type="submit" name="" value="Clear <%= params[:queue] ? "'#{params[:queue]}'" : 'Failed' %> Jobs" class="confirmSubmission" />
+  <input type="submit" name="" value="Clear <%= params[:queue] ? "'#{escape_html(params[:queue])}'" : 'Failed' %> Jobs" class="confirmSubmission" />
 </form>
 
 <% unless params[:queue] %>
@@ -15,7 +15,7 @@
   </form>
 <% end %>
 <form method="POST" action="<%= u "failed#{'/' + params[:queue] if params[:queue]}/requeue/all" %>">
-  <input type="submit" name="" value="Retry <%= params[:queue] ? "'#{params[:queue]}'" : 'Failed' %> Jobs" class="confirmSubmission" />
+  <input type="submit" name="" value="Retry <%= params[:queue] ? "'#{escape_html(params[:queue])}'" : 'Failed' %> Jobs" class="confirmSubmission" />
 </form>
 <% end %>
 

--- a/lib/resque/server/views/key_string.erb
+++ b/lib/resque/server/views/key_string.erb
@@ -1,5 +1,5 @@
 <% if key = params[:key] %>
-  <h1>Key "<%= key %>" is a <%= resque.redis.type key %></h1>
+  <h1>Key "<%= escape_html(key) %>" is a <%= resque.redis.type key %></h1>
   <h2>size: <%= redis_get_size(key) %></h2>
   <table>
     <tr>

--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -1,6 +1,6 @@
 <% @subtabs = resque.queues unless partial? || params[:id].nil? %>
 
-<% if current_queue = params[:id] %>
+<% if current_queue = escape_html(params[:id]) %>
 
   <h1>Pending jobs on <span class='hl'><%= h current_queue %></span></h1>
   <form method="POST" action="<%=u "/queues/#{current_queue}/remove" %>" class='remove-queue'>

--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -1,8 +1,8 @@
 <% @subtabs = resque.queues unless partial? || params[:id].nil? %>
 
-<% if current_queue = escape_html(params[:id]) %>
+<% if current_queue = params[:id] %>
 
-  <h1>Pending jobs on <span class='hl'><%= h current_queue %></span></h1>
+  <h1>Pending jobs on <span class='hl'><%= h escape_html(current_queue) %></span></h1>
   <form method="POST" action="<%=u "/queues/#{current_queue}/remove" %>" class='remove-queue'>
     <input type='submit' name='' value='Remove Queue' class="confirmSubmission" />
   </form>


### PR DESCRIPTION
After a penetration test, there were multiple Reflected XSS vulnerabilities found in the the web interface.

The following paths has been found vulnerable:
- `/failed/?class=<script>alert(document.cookie)</script>`
- `/queues/><img src=a onerror=alert(document.cookie)>`

I have look through the other views, and found other places where HTML wasn't escaped from the params.