### PR TITLE
Mention `at_exit` and `RUN_AT_EXIT_HOOKS` env var in the readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -687,6 +687,12 @@ complicated.
 
 Workers instead handle their own state.
 
+#### `at_exit` Callbacks
+
+Resque uses `Kernel#exit!` for exiting its workers' child processes. So any `at_exit` callback defined in your application won't be executed when the job is finished and the child process exits.
+
+You can alter this behavior by setting the `RUN_AT_EXIT_HOOKS` environment variable.
+
 #### Parents and Children
 
 Here's a parent / child pair doing some work:


### PR DESCRIPTION
As reported in https://github.com/resque/resque/issues/1664, the default behavior of using `exit!` can cause issues that are hard to debug. So even if it's not a subject to change, this gotcha and the related option should be mentioned in an obvious place.
