### PR TITLE
fix pipeline deprecations for redis-rb 4.6+

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -584,9 +584,9 @@ module Resque
   def queue_sizes
     queue_names = queues
 
-    sizes = redis.pipelined do
+    sizes = redis.pipelined do |pipeline|
       queue_names.each do |name|
-        redis.llen("queue:#{name}")
+        pipeline.llen("queue:#{name}")
       end
     end
 
@@ -597,11 +597,11 @@ module Resque
   def sample_queues(sample_size = 1000)
     queue_names = queues
 
-    samples = redis.pipelined do
+    samples = redis.pipelined do |pipeline|
       queue_names.each do |name|
         key = "queue:#{name}"
-        redis.llen(key)
-        redis.lrange(key, 0, sample_size - 1)
+        pipeline.llen(key)
+        pipeline.lrange(key, 0, sample_size - 1)
       end
     end
 


### PR DESCRIPTION
Ref #1794 

This is by no means a complete fix of all the warnings (yet), but I figured I could knock out some of the obvious ones and start a discussion about the less obvious ones