### PR TITLE
Handle when Rails is partially loaded as a Gem

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ### Fixed
 
+* Fix NoMethodError: undefined method 'application' for Rails:Module when Rails module is defined but not a full Rails app (#1799)
+
 ### Added
 
 ## 2.2.1

--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -39,7 +39,7 @@ namespace :resque do
 
   # Preload app files if this is Rails
   task :preload => :setup do
-    if defined?(Rails)
+    if defined?(Rails) && Rails.respond_to?(:application)
       if Rails.application.config.eager_load
         ActiveSupport.run_load_hooks(:before_eager_load, Rails.application)
         Rails.application.config.eager_load_namespaces.each(&:eager_load!)


### PR DESCRIPTION
and not an application

```
NoMethodError: undefined method `application' for Rails:Module
    /bundle/ruby/3.0.0/gems/resque-2.0.0/lib/resque/tasks.rb:43:in `block (2 levels) in <main>'
```