### PR TITLE
Add Ruby syntax highlighting to rest of markdown docs

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -14,15 +14,19 @@ Worker Hooks
 If you wish to have a Proc called before the worker forks for the
 first time, you can add it in the initializer like so:
 
-    Resque.before_first_fork do
-      puts "Call me once before the worker forks the first time"
-    end
+``` ruby
+Resque.before_first_fork do
+  puts "Call me once before the worker forks the first time"
+end
+```
 
 You can also run a hook before _every_ fork:
 
-    Resque.before_fork do |job|
-      puts "Call me before the worker forks"
-    end
+``` ruby
+Resque.before_fork do |job|
+  puts "Call me before the worker forks"
+end
+```
 
 The `before_fork` hook will be run in the **parent** process. So, be
 careful - any changes you make will be permanent for the lifespan of
@@ -30,9 +34,11 @@ the worker.
 
 And after forking:
 
-    Resque.after_fork do |job|
-      puts "Call me after the worker forks"
-    end
+``` ruby
+Resque.after_fork do |job|
+  puts "Call me after the worker forks"
+end
+```
 
 The `after_fork` hook will be run in the child process and is passed
 the current job. Any changes you make, therefore, will only live as
@@ -40,21 +46,27 @@ long as the job currently being processes.
 
 All worker hooks can also be set using a setter, e.g.
 
-    Resque.after_fork = proc { puts "called" }
+``` ruby
+Resque.after_fork = proc { puts "called" }
+```
 
 When the worker finds no more jobs in the queue:
 
-    Resque.queue_empty do
-      puts "Call me whenever the worker becomes idle"
-    end
+``` ruby
+Resque.queue_empty do
+  puts "Call me whenever the worker becomes idle"
+end
+```
 
 The `queue_empty` hook will be run in the **parent** process.
 
 When the worker exits:
 
-    Resque.worker_exit do
-      puts "Call me when the work is about to terminate"
-    end
+``` ruby
+Resque.worker_exit do
+  puts "Call me when the work is about to terminate"
+end
+```
 
 The `worker_exit` hook will be run in the **parent** process.
 
@@ -73,9 +85,11 @@ hook is a method name in the following format:
 For example, a `before_perform` hook which adds locking may be defined
 like this:
 
-    def before_perform_with_lock(*args)
-      set_lock!
-    end
+``` ruby
+def before_perform_with_lock(*args)
+  set_lock!
+end
+```
 
 Once this hook is made available to your job (either by way of
 inheritence or `extend`), it will be run before the job's `perform`
@@ -116,45 +130,49 @@ The available hooks are:
 Hooks are easily implemented with superclasses or modules. A superclass could
 look something like this.
 
-    class LoggedJob
-      def self.before_perform_log_job(*args)
-        Logger.info "About to perform #{self} with #{args.inspect}"
-      end
-    end
+``` ruby
+class LoggedJob
+  def self.before_perform_log_job(*args)
+    Logger.info "About to perform #{self} with #{args.inspect}"
+  end
+end
 
-    class MyJob < LoggedJob
-      def self.perform(*args)
-        ...
-      end
-    end
+class MyJob < LoggedJob
+  def self.perform(*args)
+    ...
+  end
+end
+```
 
 Modules are even better because jobs can use many of them.
 
-    module ScaledJob
-      def after_enqueue_scale_workers(*args)
-        Logger.info "Scaling worker count up"
-        Scaler.up! if Resque.info[:pending].to_i > 25
-      end
-    end
+``` ruby
+module ScaledJob
+  def after_enqueue_scale_workers(*args)
+    Logger.info "Scaling worker count up"
+    Scaler.up! if Resque.info[:pending].to_i > 25
+  end
+end
 
-    module LoggedJob
-      def before_perform_log_job(*args)
-        Logger.info "About to perform #{self} with #{args.inspect}"
-      end
-    end
+module LoggedJob
+  def before_perform_log_job(*args)
+    Logger.info "About to perform #{self} with #{args.inspect}"
+  end
+end
 
-    module RetriedJob
-      def on_failure_retry(e, *args)
-        Logger.info "Performing #{self} caused an exception (#{e}). Retrying..."
-        Resque.enqueue self, *args
-      end
-    end
+module RetriedJob
+  def on_failure_retry(e, *args)
+    Logger.info "Performing #{self} caused an exception (#{e}). Retrying..."
+    Resque.enqueue self, *args
+  end
+end
 
-    class MyJob
-      extend LoggedJob
-      extend RetriedJob
-      extend ScaledJob
-      def self.perform(*args)
-        ...
-      end
-    end
+class MyJob
+  extend LoggedJob
+  extend RetriedJob
+  extend ScaledJob
+  def self.perform(*args)
+    ...
+  end
+end
+```

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -86,8 +86,10 @@ Plugins should test compliance to this document using the
 
 For example:
 
-    assert_nothing_raised do
-      Resque::Plugin.lint(Resque::Plugins::Lock)
-    end
+``` ruby
+assert_nothing_raised do
+  Resque::Plugin.lint(Resque::Plugins::Lock)
+end
+```
 
 [sv]: http://semver.org/


### PR DESCRIPTION
For consistency with README.markdown, and because it's easier to read IMO.