### PR TITLE
Added support for pausing the queue by setting a Redis key

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 * Fix NoMethodError: undefined method 'application' for Rails:Module when Rails module is defined but not a full Rails app (#1799)
 * Fix pagination section (#1809)
+* Added support for pausing all workers by setting the Redis key `pause-all-workers` to string value "true" (#1803)
 
 ### Added
 

--- a/README.markdown
+++ b/README.markdown
@@ -716,7 +716,7 @@ If you want to kill a stale or stuck child and shutdown, use `TERM`
 
 If you want to stop processing jobs, but want to leave the worker running
 (for example, to temporarily alleviate load), use `USR2` to stop processing,
-then `CONT` to start it again.
+then `CONT` to start it again. It's also possible to [pause all workers](#pausing-all-workers).
 
 #### Heroku
 
@@ -739,6 +739,22 @@ time to complete before being forced to die.
 * `TERM_CHILD` - Must be set for `RESQUE_PRE_SHUTDOWN_TIMEOUT` to be used. After the timeout, if the child is still running it will raise a `Resque::TermException` and exit.
 
 * `RESQUE_TERM_TIMEOUT` - By default you have a few seconds to handle `Resque::TermException` in your job. `RESQUE_TERM_TIMEOUT` and `RESQUE_PRE_SHUTDOWN_TIMEOUT` must be lower than the [heroku dyno timeout](https://devcenter.heroku.com/articles/limits#exit-timeout).
+
+#### Pausing all workers
+
+Workers will not process pending jobs if the Redis key `pause-all-workers` is set with the string value "true".
+
+``` ruby
+Resque.redis.set('pause-all-workers', 'true')
+```
+
+Nothing happens to jobs that are already being processed by workers.
+
+Unpause by removing the Redis key `pause-all-workers`.
+
+``` ruby
+Resque.redis.del('pause-all-workers')
+```
 
 #### Monitoring
 

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -579,7 +579,7 @@ module Resque
 
     # are we paused?
     def paused?
-      @paused
+      @paused || redis.get('paused') == 'true'
     end
 
     # Stop processing jobs after the current one has completed (if we're

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -579,7 +579,7 @@ module Resque
 
     # are we paused?
     def paused?
-      @paused || redis.get('paused') == 'true'
+      @paused || redis.get('pause-all-workers').to_s.strip.downcase == 'true'
     end
 
     # Stop processing jobs after the current one has completed (if we're

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -34,6 +34,7 @@ describe "Resque::Worker" do
   end
 
   it 'worker is not paused' do
+    assert_equal false, @worker.paused?
     Resque.redis.set('pause-all-workers', 'false')
     assert_equal false, @worker.paused?
     Resque.redis.del('pause-all-workers')

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -24,6 +24,22 @@ describe "Resque::Worker" do
     Resque::Job.create(:jobs, SomeJob, 20, '/tmp')
   end
 
+  it 'worker is paused' do
+    Resque.redis.set('pause-all-workers', 'true')
+    assert_equal true, @worker.paused?
+    Resque.redis.set('pause-all-workers', 'TRUE')
+    assert_equal true, @worker.paused?
+    Resque.redis.set('pause-all-workers', 'True')
+    assert_equal true, @worker.paused?
+  end
+
+  it 'worker is not paused' do
+    Resque.redis.set('pause-all-workers', 'false')
+    assert_equal false, @worker.paused?
+    Resque.redis.del('pause-all-workers')
+    assert_equal false, @worker.paused?
+  end
+
   it "can fail jobs" do
     Resque::Job.create(:jobs, BadJob)
     @worker.work(0)


### PR DESCRIPTION
At the moment it is only possible to pause a specific worker with a signal. It would be nice to pause all queue workers, so that they finish their current job, but don't pickup a new job. This pull request makes it possible to pause all queue workers by setting a Redis key:
```
Resque.redis.set('paused', 'true')
```
This way a deployment of new workers (from a deployment pipeline) can easily be done without aborting running jobs.
When the deployment or other maintenance is finished the queue workers can be unpaused by deleting the Redis key:
```
Resque.redis.del('paused')
```