### PR TITLE
Update Redis#pipelined for redis-rb 4.6.

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -584,9 +584,9 @@ module Resque
   def queue_sizes
     queue_names = queues
 
-    sizes = redis.pipelined do
+    sizes = redis.pipelined do |piped|
       queue_names.each do |name|
-        redis.llen("queue:#{name}")
+        piped.llen("queue:#{name}")
       end
     end
 
@@ -597,11 +597,11 @@ module Resque
   def sample_queues(sample_size = 1000)
     queue_names = queues
 
-    samples = redis.pipelined do
+    samples = redis.pipelined do |piped|
       queue_names.each do |name|
         key = "queue:#{name}"
-        redis.llen(key)
-        redis.lrange(key, 0, sample_size - 1)
+        piped.llen(key)
+        piped.lrange(key, 0, sample_size - 1)
       end
     end
 

--- a/lib/resque/stat.rb
+++ b/lib/resque/stat.rb
@@ -35,8 +35,8 @@ module Resque
     #
     # Can optionally accept a second int parameter. The stat is then
     # incremented by that amount.
-    def incr(stat, by = 1)
-      data_store.increment_stat(stat,by)
+    def incr(stat, by = 1, **opts)
+      data_store.increment_stat(stat, by, **opts)
     end
 
     # Increments a stat by one.
@@ -58,8 +58,8 @@ module Resque
     end
 
     # Removes a stat from Redis, effectively setting it to 0.
-    def clear(stat)
-      data_store.clear_stat(stat)
+    def clear(stat, **opts)
+      data_store.clear_stat(stat, **opts)
     end
   end
 end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -697,9 +697,9 @@ module Resque
 
       kill_background_threads
 
-      data_store.unregister_worker(self) do
-        Stat.clear("processed:#{self}")
-        Stat.clear("failed:#{self}")
+      data_store.unregister_worker(self) do |**opts|
+        Stat.clear("processed:#{self}", **opts)
+        Stat.clear("failed:#{self}",    **opts)
       end
     rescue Exception => exception_while_unregistering
       message = exception_while_unregistering.message
@@ -726,8 +726,8 @@ module Resque
     # Called when we are done working - clears our `working_on` state
     # and tells Redis we processed a job.
     def done_working
-      data_store.worker_done_working(self) do
-        processed!
+      data_store.worker_done_working(self) do |**opts|
+        processed!(**opts)
       end
     end
 
@@ -745,9 +745,9 @@ module Resque
     end
 
     # Tell Redis we've processed a job.
-    def processed!
-      Stat << "processed"
-      Stat << "processed:#{self}"
+    def processed!(**opts)
+      Stat.incr("processed",         1, **opts)
+      Stat.incr("processed:#{self}", 1, **opts)
     end
 
     # How many failed jobs has this worker seen? Returns an int.

--- a/test/stat_test.rb
+++ b/test/stat_test.rb
@@ -10,7 +10,7 @@ describe "Resque::Stat" do
       @stat[stat]
     end
 
-    def increment_stat(stat, by)
+    def increment_stat(stat, by = 1, redis: nil)
       @stat[stat] += by
     end
 
@@ -18,7 +18,7 @@ describe "Resque::Stat" do
       @stat[stat] -= by
     end
 
-    def clear_stat(stat)
+    def clear_stat(stat, redis: nil)
       @stat[stat] = 0
     end
   end


### PR DESCRIPTION
Re-using the connection is no longer supported.  Instead, the block var
must be used.