### PR TITLE
Fix pagination

### DIFF
--- a/lib/resque/server/views/next_more.erb
+++ b/lib/resque/server/views/next_more.erb
@@ -7,7 +7,7 @@
       <a href="<%= current_page %>?start=<%= start - per_page %>" class='less'>&laquo; Previous</a>
     <% end %>
 
-    <% (size / per_page.to_f - 1).ceil.times do |page_num| %>
+    <% (size / per_page.to_f).ceil.times do |page_num| %>
       <% if start == page_num * per_page %>
         <span><%= page_num + 1 %></span>
       <% else %>
@@ -15,7 +15,7 @@
       <% end %>
     <% end %>
 
-    <% if start + per_page <= size %>
+    <% if start + per_page < size %>
       <a href="<%= current_page %>?start=<%= start + per_page %>" class='more'>Next &raquo;</a>
     <% end %>
   </div>


### PR DESCRIPTION
Two problems were found in the pagination section and have been corrected.

## When there are 21 jobs (per_page = 20)
Page 2 was not displayed.

### before
![21_before](https://user-images.githubusercontent.com/12048864/176886628-455beb14-2eab-47ce-92ca-600f60758970.png)

### after
![21_after](https://user-images.githubusercontent.com/12048864/176886632-05ad762a-0d2e-4ddd-80c8-0086aa8ae4f2.png)


## When there are 40 jobs (per_page = 20)
The "Next" button was displayed.

### before
![40_before](https://user-images.githubusercontent.com/12048864/176886624-0a45ac27-3eba-459d-b62a-342998e814ce.png)

### after
![40_after](https://user-images.githubusercontent.com/12048864/176886630-d2124a59-82d2-49b7-80e3-9f3eef3fb108.png)

