### PR TITLE
Fix - 'before_run': undefined local variable or method 'runner'

### DIFF
--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -86,7 +86,7 @@ module Resque
 
     def before_run
       if (namespace = options[:redis_namespace])
-        runner.logger.info "Using Redis namespace '#{namespace}'"
+        logger.info "Using Redis namespace '#{namespace}'"
         Resque.redis.namespace = namespace
       end
       if (redis_conf = options[:redis_conf])


### PR DESCRIPTION
resque-2.2.1/lib/resque/web_runner.rb:89:in 'before_run': undefined local variable or method 'runner' for #<Resque::WebRunner:0x00007fd73dacb270> (NameError)

There is an leftover `runner.` in lib/resque/web_runner.rb from this commit:

https://github.com/resque/resque/commit/59f151d715639b9917effb9550e0f008927352c8