### PR TITLE
Added flexible eager load configuration for Resque when used in Rails application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .ruby-version
+.ruby-gemset
 coverage
 .rbx
 Gemfile.lock
@@ -7,7 +8,5 @@ test/dump-cluster.rdb
 test/stdout
 *.swp
 pkg
-.ruby-version
-.ruby-gemset
 *.sw?
 vendor/bundle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,6 @@ helpful.
 Help
 ----
 
-If you have a question or want to discuss something, the Resque mailng list
+If you have a question or want to discuss something, the Resque mailing list
 might just be the place. [resque@librelist.com](mailto:resque@librelist.com)
 is the address you want, send an email there and it'll take care of you.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,17 @@
+## Unreleased
+
+### Fixed
+
+* Fix - Run `eager_load!` only if `Rails.application.config.eager_load` is true - from 2.0.0 version release
+  by adding flexible configuration. (#1818)
+
+### Added
+
+* `Resque::Railtie::EagerLoad` and `Resque::Railtie::EagerLoad::Configuration` classes for flexible eager load
+  configuration for Resque when used in a Rails application (#1818)
+
+*
+
 ## 2.5.0
 
 ### Fixed
@@ -82,7 +96,7 @@
 
 ### Fixed
 
-* live poller shouldn't restart itself until it successds or fails. #1740
+* live poller shouldn't restart itself until it succeeds or fails. #1740
 * Fix parsing worker_id when queue name includes colon. #1691
 * Prune workers which haven't been registered but have set a heartbeat. #1751
 * `Resque::Failure::Multiple.remove` did not pass on the queue parameter

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -180,6 +180,21 @@ module Resque
     Resque::Stat.data_store
   end
 
+  def rails_eager_load_enabled
+    return @rails_eager_load_enabled if defined?(@rails_eager_load_enabled)
+
+    @rails_eager_load_enabled = Resque::Railtie::EagerLoad.enabled?
+  end
+  alias rails_eager_load_enabled? rails_eager_load_enabled
+
+  def rails_eager_load_enabled=(value)
+    Resque::Railtie::EagerLoad.configure.enabled = value
+  end
+
+  def rails_eager_load_configure(&block)
+    Resque::Railtie::EagerLoad.configure_for_environments(&block)
+  end
+
   # Set or retrieve the current logger object
   attr_accessor :logger
 
@@ -561,7 +576,7 @@ module Resque
 
   # Returns a hash, similar to redis-rb's #info, of interesting stats.
   def info
-    return {
+    {
       :pending   => queue_sizes.inject(0) { |sum, (_queue_name, queue_size)| sum + queue_size },
       :processed => Stat[:processed],
       :queues    => queues.size,

--- a/lib/resque/errors.rb
+++ b/lib/resque/errors.rb
@@ -24,4 +24,26 @@ module Resque
 
   # Raised when child process is TERM'd so job can rescue this to do shutdown work.
   class TermException < SignalException; end
+
+  class EagerLoadConfigurationError < StandardError
+    def initialize
+      super(with_message)
+    end
+
+    private
+
+    def with_message
+      <<~MSG
+        Eager load for environments is not configured correctly.
+        You need to specify a block with boolean values set for each
+        of your project environments. For example:
+        
+          Resque.rails_eager_load_configure do |environment|
+            environment.development = false
+            environment.staging = true
+            environment.production = true
+          end
+      MSG
+    end
+  end
 end

--- a/lib/resque/railtie.rb
+++ b/lib/resque/railtie.rb
@@ -1,10 +1,77 @@
+# frozen_string_literal: true
+
 module Resque
   class Railtie < Rails::Railtie
     rake_tasks do
       require 'resque/tasks'
 
-      # redefine ths task to load the rails env
+      # redefine the task to load the rails env
       task "resque:setup" => :environment
+    end
+
+    # Describes the flexible `eager_load` configuration process for Resque when used in a Rails application.
+    class EagerLoad
+      class << self
+        def configuration
+          @_configuration ||= Configuration.new
+        end
+
+        def configure
+          yield(configuration) if block_given?
+
+          configuration
+        end
+        alias configure_for_environments configure
+
+        def enabled?
+          return configuration.enabled if configuration.for_environments.empty?
+
+          validate_environment!
+
+          configuration.for_environments.fetch(current_environment, false)
+        end
+
+        def validate_environment!
+          return if configuration.for_environments.keys.include?(current_environment)
+
+          raise ::Resque::EagerLoadConfigurationError.new
+        end
+
+        def current_environment
+          @current_environment ||= ::Resque.info[:environment]
+        end
+      end
+
+      private_class_method :validate_environment!
+      private_class_method :current_environment
+
+      class Configuration
+        attr_accessor :enabled
+
+        attr_accessor :environment_configuration
+        alias for_environments environment_configuration
+
+        def initialize
+          @enabled = false
+          @environment_configuration = {}
+        end
+
+        private
+
+        def method_missing(symbol, arg)
+          string_method_name = symbol.to_s
+
+          if string_method_name.end_with?('=') && (arg.is_a?(TrueClass) || arg.is_a?(FalseClass))
+            environment_configuration[string_method_name.chop] = arg
+          else
+            raise ::Resque::EagerLoadConfigurationError.new
+          end
+        end
+
+        def respond_to_missing?(_method_name, _include_private = false)
+          false
+        end
+      end
     end
   end
 end

--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -1,7 +1,6 @@
 # require 'resque/tasks'
 # will give you the resque tasks
 
-
 namespace :resque do
   task :setup
 
@@ -40,7 +39,7 @@ namespace :resque do
   # Preload app files if this is Rails
   task :preload => :setup do
     if defined?(Rails) && Rails.respond_to?(:application)
-      if Rails.application.config.eager_load
+      if Resque.rails_eager_load_enabled?
         ActiveSupport.run_load_hooks(:before_eager_load, Rails.application)
         Rails.application.config.eager_load_namespaces.each(&:eager_load!)
       end

--- a/lib/resque/vendor/utf8_util.rb
+++ b/lib/resque/vendor/utf8_util.rb
@@ -1,5 +1,5 @@
 module UTF8Util
-  # use '?' intsead of the unicode replace char, since that is 3 bytes
+  # use '?' instead of the unicode replace char, since that is 3 bytes
   # and can increase the string size if it's done a lot
   REPLACEMENT_CHAR = "?"
 

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -886,7 +886,7 @@ module Resque
 
     attr_reader :verbose, :very_verbose
 
-    def verbose=(value);
+    def verbose=(value)
       if value && !very_verbose
         Resque.logger.formatter = VerboseFormatter.new
         Resque.logger.level = Logger::INFO

--- a/test/lib/resque/railtie_test.rb
+++ b/test/lib/resque/railtie_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+require 'resque/railtie'
+
+describe Resque::Railtie::EagerLoad do
+  before { EagerLoadTestHelper.reset_config! }
+  after { ENV['RAILS_ENV'] = nil }
+
+  describe '.enabled?' do
+    it 'returns eager load config value set to false by default when configuration has not been set ' do
+      refute Resque::Railtie::EagerLoad.enabled?
+    end
+
+    it 'returns eager load config value when configuration has been set for all environments' do
+      Resque::Railtie::EagerLoad.configure { |configuration| configuration.enabled = true }
+
+      assert Resque::Railtie::EagerLoad.enabled?
+    end
+
+    it 'returns eager load config value when configuration has been set for all environments' do
+      Resque::Railtie::EagerLoad.configure_for_environments do |environment|
+        environment.development = false
+        environment.staging = true
+        environment.production = true
+      end
+
+      refute Resque::Railtie::EagerLoad.enabled?
+    end
+
+    it 'returns eager load config value when configuration has been set for all environments' do
+      ENV['RAILS_ENV'] = 'staging'
+
+      Resque::Railtie::EagerLoad.configure_for_environments do |environment|
+        environment.development = false
+        environment.staging = true
+        environment.production = true
+      end
+
+      assert Resque::Railtie::EagerLoad.enabled?
+    end
+
+    it 'returns eager load config value when configuration has been set for all environments' do
+      ENV['RAILS_ENV'] = 'production'
+
+      Resque::Railtie::EagerLoad.configure_for_environments do |environment|
+        environment.development = true
+        environment.staging = false
+        environment.production = true
+      end
+
+      assert Resque::Railtie::EagerLoad.enabled?
+
+      environment_configuration = { 'development' => true, 'staging' => false, 'production' => true }
+
+      assert_equal environment_configuration, Resque::Railtie::EagerLoad.configuration.for_environments
+    end
+  end
+
+  describe 'invalid configuration' do
+    it 'raises a ConfigurationError with the explanation' do
+      Resque::Railtie::EagerLoad.configure_for_environments do |environment|
+        environment.invalid = true
+      end
+
+      error = _ { Resque::Railtie::EagerLoad.enabled? }.must_raise ::Resque::EagerLoadConfigurationError
+
+      assert_match EagerLoadTestHelper.configuration_error_message, error.message
+    end
+
+    it 'raises a ConfigurationError with the explanation when the configuration value for environments is not correct' do
+      error = assert_raises ::Resque::EagerLoadConfigurationError do
+        Resque::Railtie::EagerLoad.configure_for_environments do |environment|
+          environment.development = 'invalid'
+        end
+      end
+
+      assert_match EagerLoadTestHelper.configuration_error_message, error.message
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -188,6 +188,38 @@ ensure
   Resque::Failure.backend = previous_backend
 end
 
+class Rails
+  class Rails::Railtie
+    def self.rake_tasks; end
+  end
+end
+
+class EagerLoadTestHelper
+  class << self
+    def reset_config!
+      Resque.remove_instance_variable(:@rails_eager_load_enabled) if Resque.instance_variable_defined?(:@rails_eager_load_enabled)
+      Resque::Railtie::EagerLoad.instance_variable_set(:@_configuration, nil)
+      Resque::Railtie::EagerLoad.instance_variable_set(:@current_environment, nil)
+
+      ENV['RAILS_ENV'] = 'development'
+    end
+
+    def configuration_error_message
+      <<~MSG
+        Eager load for environments is not configured correctly.
+        You need to specify a block with boolean values set for each
+        of your project environments. For example:
+    
+          Resque.rails_eager_load_configure do |environment|
+            environment.development = false
+            environment.staging = true
+            environment.production = true
+          end
+      MSG
+    end
+  end
+end
+
 require 'time'
 
 class Time


### PR DESCRIPTION
Hi!

We faced a problem when upgraded from Resque `1.27.4` to `> 2.0.0` version (using Resque gem as a dependency in Rails 6.0.4 application with Ruby 2.7.5) and lost many important events silently. The eager load for Resque task did not work was the reason.

Our production configuration for `eager_load` is set to `true`:
```ruby
# config/environments/production.rb

Rails.application.configure do
  ...
  config.eager_load = true
  ...
end
```

Changes documentation between versions says the following:

![image](https://user-images.githubusercontent.com/22988869/185508821-6ad9fa4e-afe7-48b5-9466-02e53201d5e1.png)

![image](https://user-images.githubusercontent.com/22988869/185510397-9b556bde-01f9-494a-9a81-599490ba9be7.png)

However, the `eager_load` will never be `true`. Since `Resque` starts from Rake task, the `eager_load` option configuration is set to `false` permanently by default starting from [this commit](https://github.com/rails/rails/pull/11389/files#diff-84292fcaae327f1a70e7c3b1ebb55b193dea016c1118a8566930bc5cd2a51ba5) at Rails.

Only if your Rails application is `6.1.0` version or above, you are able to configure eager loading for Rake tasks environment by using `rake_eager_load` option that was added in [this commit](https://github.com/rails/rails/pull/28209/files#diff-84292fcaae327f1a70e7c3b1ebb55b193dea016c1118a8566930bc5cd2a51ba5) to provide the ability to override the default `false` value **for every rake task of the environment**.

### Based on the above, I propose to add flexible configuration for `eager_load`:

To configure `eager_load` option using `Resque` interface you are able to add in `config/initializers/resque.rb`
the following:
```ruby
Resque.rails_eager_load_enabled = true # one configuration for any of your application environments
```

Or if you would like to configure the `eager_load` option depends on your Rails application environment, for example:
```ruby
Resque.rails_eager_load_configure do |env|
  env.development = false
  env.staging = true
  env.production = true
end
```