### PR TITLE
Remove thread_safe arg in Redis instantiations

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -115,12 +115,11 @@ module Resque
     case server
     when String
       if server =~ /rediss?\:\/\//
-        redis = Redis.new(:url => server, :thread_safe => true)
+        redis = Redis.new(:url => server)
       else
         server, namespace = server.split('/', 2)
         host, port, db = server.split(':')
-        redis = Redis.new(:host => host, :port => port,
-          :thread_safe => true, :db => db)
+        redis = Redis.new(:host => host, :port => port, :db => db)
       end
       namespace ||= :resque
 


### PR DESCRIPTION
The new redis gem 5.0.x checks for valid args and throws on this call.

Fixes #1821 