### PR TITLE
Pin redis version explicitly to <5

### DIFF
--- a/resque.gemspec
+++ b/resque.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3.0"
 
   s.add_dependency "redis-namespace", "~> 1.6"
+  s.add_dependency "redis", ">= 4", "<5"
   s.add_dependency "sinatra", ">= 0.9.2"
   s.add_dependency "multi_json", "~> 1.0"
   s.add_dependency "mono_logger", "~> 1.0"


### PR DESCRIPTION
As an alternative to https://github.com/resque/resque/pull/1822, just pin the redis version to avoid the new breaking changes.
Fixes #1821 