### PR TITLE
redis-rb 5.0 compatiblity

### DIFF
--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -286,7 +286,7 @@ module Resque
             begin
               handler = Rack::Handler.get(server)
               break
-            rescue LoadError, NameError => e
+            rescue LoadError, NameError
               next
             end
           end

--- a/test/child_killing_test.rb
+++ b/test/child_killing_test.rb
@@ -7,7 +7,7 @@ describe "Resque::Worker" do
     @queue = :long_running_job
 
     def self.perform( sleep_time, rescue_time=nil )
-      Resque.redis.reconnect # get its own connection
+      Resque.redis.disconnect! # get its own connection
       Resque.redis.rpush( 'sigterm-test:start', Process.pid )
       sleep sleep_time
       Resque.redis.rpush( 'sigterm-test:result', 'Finished Normally' )
@@ -23,8 +23,8 @@ describe "Resque::Worker" do
     Resque.enqueue( LongRunningJob, 3, rescue_time )
 
     worker_pid = Kernel.fork do
-      # reconnect since we just forked
-      Resque.redis.reconnect
+      # disconnect since we just forked
+      Resque.redis.disconnect!
 
       worker = Resque::Worker.new(:long_running_job)
       worker.term_timeout = term_timeout


### PR DESCRIPTION
Fix: https://github.com/resque/resque/pull/1828
Fix: https://github.com/resque/resque/issues/1825
Fix: https://github.com/resque/resque/issues/1820
Close: https://github.com/resque/resque/pull/1823

There was two distinct issues.
    
The first one was that `Resque::Worker` instances were passed as argument to `sadd / srem` relying on the implicit call to `to_s`. This has been removed in redis-rb 5.0, you now must explictly cast to a String or another type understood by the redis client.
    
The other issue was with the reconnection after fork. When forking you must make sure to close the Redis connection, otherwise if you write in it, the responses of the parent and child will be mixed in.
    
Resque was using a private API to do this reconnection. I updated it to use the main public API.
    
There was also a bug in redis-rb 5.0.1 preventing from reconnecting after fork, I fixed it in 5.0.2 (https://github.com/redis/redis-rb/pull/1145).

NB: this is based on https://github.com/resque/resque/pull/1827 because the same lines are being edited so it avoid conflicts.