### PR TITLE
Add datadog tag for worker_uuid so we can track number of workers, add datadog reporting heartbeat

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -352,9 +352,10 @@ module Resque
 
   # Pops a job off a queue. Queue name should be a string.
   #
-  # Returns a Ruby object.
-  def pop(queue)
-    decode(data_store.pop_from_queue(queue))
+  # Returns the queue and the Ruby object that was popped, or nil.
+  def pop(*queues, interval: 0)
+    queue, value = data_store.pop_from_queue(*queues, interval: interval)
+    return queue, decode(value)
   end
 
   # Returns an integer representing the size of a queue.
@@ -512,8 +513,8 @@ module Resque
   # precise name of a queue: case matters.
   #
   # This method is considered part of the `stable` API.
-  def reserve(queue)
-    Job.reserve(queue)
+  def reserve(*queues, interval: 0)
+    return Job.reserve(*queues, interval: interval)
   end
 
   # Validates if the given klass could be a valid Resque job

--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -139,9 +139,10 @@ module Resque
 
     # Given a string queue name, returns an instance of Resque::Job
     # if any jobs are available. If not, returns nil.
-    def self.reserve(queue)
-      return unless payload = Resque.pop(queue)
-      new(queue, payload)
+    def self.reserve(*queues, interval: 0)
+      queue, payload = Resque.pop(*queues, interval: interval)
+      return if !queue || !payload
+      return new(queue, payload)
     end
 
     # Attempts to perform the work represented by this job instance.


### PR DESCRIPTION
# Release Announcement

_Behind the Scenes_
* Resque fork: Add datadog tag for worker_uuid so we can track number of workers, add five second datadog reporting heartbeat [ticket](https://linear.app/branch/issue/PLAT-745/improve-accuracy-of-datadog-worker-logging) @<!-- -->mike

- [x] Release announcement note, Shortcut ticket and relevant stakeholders

# Summary

This adds a worker UUID and leverages the existing Resque heartbeat thread to report to datadog every five seconds. That helps to ensure an approximately five second resolution in the dashboards even for long-running jobs.

- [x] Set primary reviewer as assignee

# Monitoring plan

- Verify the updated dashboard in prod

# Testing

## Manual Tests

- [x] Verified local reporting to the dashboard using this code and the updated rails branch

## Unit Tests

- No changes
