### PR TITLE
Escape resque info values (#1785)

### DIFF
--- a/lib/resque/server/views/stats.erb
+++ b/lib/resque/server/views/stats.erb
@@ -14,7 +14,7 @@
         <%= key %>
       </th>
       <td>
-        <%= value %>
+        <%= h value %>
       </td>
     </tr>
   <% end %>


### PR DESCRIPTION
**After Change 👇**

<img width="1220" alt="Screen Shot 2022-09-18 at 12 49 04 PM" src="https://user-images.githubusercontent.com/6352760/190919194-ac64911c-c8e1-449c-8430-835b6b1d294b.png">

I saw this issue and figured it may be a quick fix.  I chose to escape all the resque.info values for the redis tab only but can update the other tabs if you feel it's required.  I understand the output of the servers value isn't exactly as it was before as reported in #1785 but this feels good enough as it gets the info back into view.