### PR TITLE
Escape `Resque.redis_id` for stats page

### DIFF
--- a/lib/resque/server/views/layout.erb
+++ b/lib/resque/server/views/layout.erb
@@ -38,7 +38,7 @@
 
 <div id="footer">
   <p>Powered by <a href="http://github.com/resque/resque">Resque</a> v<%=Resque::VERSION%></p>
-  <p>Connected to Redis namespace <%= Resque.redis.namespace %> on <%=Resque.redis_id%></p>
+  <p>Connected to Redis namespace <%= Resque.redis.namespace %> on <%= h Resque.redis_id %></p>
 </div>
 
 </body>

--- a/lib/resque/server/views/stats.erb
+++ b/lib/resque/server/views/stats.erb
@@ -6,7 +6,7 @@
 
 <% elsif params[:id] == "resque" %>
 
-  <h1><%= resque %></h1>
+  <h1><%= h resque %></h1>
   <table class='stats'>
   <% for key, value in resque.info.to_a.sort_by { |i| i[0].to_s } %>
     <tr>

--- a/lib/resque/server/views/stats.erb
+++ b/lib/resque/server/views/stats.erb
@@ -22,7 +22,7 @@
 
 <% elsif params[:id] == 'redis' %>
 
-  <h1><%= resque.redis_id %></h1>
+  <h1><%= h resque.redis_id %></h1>
   <table class='stats'>
   <% for key, value in resque.redis.redis.info.to_a.sort_by { |i| i[0].to_s } %>
     <tr>
@@ -38,7 +38,7 @@
 
 <% elsif params[:id] == 'keys' %>
 
-  <h1>Keys owned by <%= resque %></h1>
+  <h1>Keys owned by <%= h resque.redis_id %></h1>
   <p class='sub'>(All keys are actually prefixed with "<%= Resque.redis.namespace %>:")</p>
   <table class='stats'>
     <tr>


### PR DESCRIPTION
Fix a part of #1785
Refs #1832

This PR escapes `Resque.redis_id` to properly display information of redis server.

After this change:
- resque tab
  ![stats2](https://user-images.githubusercontent.com/32959831/190997169-d70bbe4c-a04e-4e79-85f3-312e60c32637.png)
- redis tab
  ![redis_tab](https://user-images.githubusercontent.com/32959831/194335814-735d0944-4633-4c99-97b7-fb5e2809d94f.png)
- keys tab
  ![keys_tab](https://user-images.githubusercontent.com/32959831/194335818-b1fcff59-f5d6-4ec2-8df4-3802f1e6b807.png)


It includes extra stuff other than connection information, but I think that more information is better, so I just escaped the value.