### PR TITLE
Raise an error when no available Rack server was found

### DIFF
--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -290,6 +290,8 @@ module Resque
               next
             end
           end
+          raise 'No available Rack handler (e.g. WEBrick, Thin, Puma, etc.) was found.' if handler.nil?
+
           handler
 
         # :server might be set explicitly to a single option like "mongrel"


### PR DESCRIPTION
Fix #1835

This PR will display a message indicating that no available Rack server was found.

After this change:
- Gemfile:
  ```ruby
  source "https://rubygems.org"
  
  gem 'resque'
  ```
- Output:
  ```
  $ bundle exec resque-web --foreground
  bundler: failed to load command: resque-web (/home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bin/resque-web)
  /home/owner/git-repos/resque/lib/resque/web_runner.rb:296:in `setup_rack_handler': No available Rack handler (e.g. WEBrick, Thin, Puma, etc.) was found. (RuntimeError)
          from /home/owner/git-repos/resque/lib/resque/web_runner.rb:33:in `initialize'
          from /home/owner/git-repos/resque/bin/resque-web:15:in `new'
          from /home/owner/git-repos/resque/bin/resque-web:15:in `<top (required)>'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bin/resque-web:25:in `load'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bin/resque-web:25:in `<top (required)>'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/cli/exec.rb:58:in `load'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/cli/exec.rb:58:in `kernel_load'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/cli/exec.rb:23:in `run'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/cli.rb:486:in `exec'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/cli.rb:31:in `dispatch'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/cli.rb:25:in `start'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.22/exe/bundle:48:in `block in <top (required)>'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
          from /home/owner/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bundler-2.3.22/exe/bundle:36:in `<top (required)>'
          from /home/owner/.rbenv/versions/3.1.2/bin/bundle:25:in `load'
          from /home/owner/.rbenv/versions/3.1.2/bin/bundle:25:in `<main>'
  ```
- Error message:
  ```
  No available Rack handler (e.g. WEBrick, Thin, Puma, etc.) was found.
  ```