### PR TITLE
typo:Log the worker name when starting the task

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -16,7 +16,7 @@ namespace :resque do
     end
 
     worker.prepare
-    worker.log "Starting worker #{self}"
+    worker.log "Starting worker #{worker}"
     worker.work(ENV['INTERVAL'] || 5) # interval, will block
   end
 


### PR DESCRIPTION
in https://github.com/resque/resque/commit/7d0b20ee00986b749b03d4407af199039b504cc2 the code was refactored to move the startup of workers into the worker class. As part of this, most of the references were changed from 'worker' to 'self'. This also happened to the line logging worker startup, but that line did not move into the worker, so now it just logs "Starting worker main", taking the name main from `rake`. You can still see the old behaviour in the documentation: https://github.com/resque/resque/blob/7f6b88404dd18698f6f4023e18fdc1ae8318e5e5/examples/demo/README.markdown#L29

There was no explanation for this change so it just looks like a typo to me? It came up for us reading logs and trying to understand where the 'Starting worker main' came from, since it didn't match up to the workers we had crashing.