### PR TITLE
Show correctly the values of hash and none type on stats tab

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -67,7 +67,9 @@ module Resque
       def redis_get_size(key)
         case Resque.redis.type(key)
         when 'none'
-          []
+          0
+        when 'hash'
+          Resque.redis.hlen(key)
         when 'list'
           Resque.redis.llen(key)
         when 'set'
@@ -83,6 +85,8 @@ module Resque
         case Resque.redis.type(key)
         when 'none'
           []
+        when 'hash'
+          Resque.redis.hgetall(key).to_a[start..(start + 20)]
         when 'list'
           Resque.redis.lrange(key, start, start + 20)
         when 'set'


### PR DESCRIPTION
The keys and values of Redis can be checked in Resque Stats tab.
[resque-scheduler](https://github.com/resque/resque-scheduler) registers hash type value on Redis for persistent schedules data.
However, when I try to display the value, it raises an error.

- `persistent_schedules` is a hash. Its size is not shown.
![before_stats1](https://user-images.githubusercontent.com/32959831/192083061-9f958c84-0dae-4783-9766-e7949239bed8.png)
- Error after clicking the key
![before_stats2](https://user-images.githubusercontent.com/32959831/192083055-3c5637d7-a848-4371-8010-301caf57ca2e.png)

This PR will solve this problem.
- `persistent_schedules`' size is shown.
![after_stats1](https://user-images.githubusercontent.com/32959831/192083187-05b750b3-9b4d-4733-8e5b-1e21e646161e.png)
- After clicking, we can see the value.
![after_stats2](https://user-images.githubusercontent.com/32959831/192083185-a860463c-cb30-4d2f-80c6-6b005b85c763.png)

In addition, this PR corrected the case where the type is none.
`#redis_get_size` used to return an empty array(`[]`), but it should return `0` here.