### PR TITLE
Update CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         redis-version:
-          - 4.0
+          - "4.0"
           - 4.1
           - 4.2
           - 4.3
@@ -31,6 +31,7 @@ jobs:
           - 2.7
           - "3.0"
           - 3.1
+          - 3.2
           - head
         exclude:
           - { ruby-version: 2.3, redis-version: 4.5 }
@@ -57,6 +58,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.2
           bundler-cache: true
       - run: bundle exec rubocop


### PR DESCRIPTION
- Add Ruby 3.2 to the CI matrix
- Enclose 4.0 in quotes
  - Without quotes, `4.0` is interpreted as `4`.
    - Before: 
![image](https://user-images.githubusercontent.com/32959831/209954217-65f7159d-e774-4492-899c-7f743f59d93d.png)
    - After: 
![image](https://user-images.githubusercontent.com/32959831/209954209-dc25b4dd-56dc-4a3a-86f4-8ccf2cb5fc0e.png)
