### PR TITLE
Version 2.5.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,18 @@
+## 2.5.0
+
+### Fixed
+
+* Replace `File.exists?` with `File.exist?` (#1846)
+* Escape `Resque.redis_id` for stats page (#1834)
+* Escape resque info values (#1832)
+* Correctly show the values of hash and none type on stats tab (#1838)
+* Fix logging the worker name when starting the task (#1837)
+
+### Added
+
+* Raise an error when no available Rack server was found (#1836)
+* Move code in `Resque::Server.helpers` block into a module to make it testable (#1851)
+
 ## 2.4.0
 
 ### Fixed

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  VERSION = '2.4.0'
+  VERSION = '2.5.0'
 end


### PR DESCRIPTION
Changelog and version bump following the bundle of fixes we have had recently. I was originally going to make this 2.4.1, but since there is a change that moves the web helpers to a separate file, I thought it would be better to do 2.5.0