### PR TITLE
Patch reflected XSS in queue

### DIFF
--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -1,8 +1,8 @@
 <% @subtabs = resque.queues unless partial? || params[:id].nil? %>
 
-<% if current_queue = params[:id] %>
+<% if current_queue = escape_html(params[:id]) %>
 
-  <h1>Pending jobs on <span class='hl'><%= h escape_html(current_queue) %></span></h1>
+  <h1>Pending jobs on <span class='hl'><%= h current_queue %></span></h1>
   <form method="POST" action="<%=u "/queues/#{current_queue}/remove" %>" class='remove-queue'>
     <input type='submit' name='' value='Remove Queue' class="confirmSubmission" />
   </form>

--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -1,9 +1,9 @@
 <% @subtabs = resque.queues unless partial? || params[:id].nil? %>
 
-<% if current_queue = escape_html(params[:id]) %>
+<% if current_queue = params[:id] %>
 
-  <h1>Pending jobs on <span class='hl'><%= h current_queue %></span></h1>
-  <form method="POST" action="<%=u "/queues/#{current_queue}/remove" %>" class='remove-queue'>
+  <h1>Pending jobs on <span class='hl'><%= h escape_html(current_queue) %></span></h1>
+  <form method="POST" action="<%=u "/queues/#{escape_html(current_queue)}/remove" %>" class='remove-queue'>
     <input type='submit' name='' value='Remove Queue' class="confirmSubmission" />
   </form>
   <p class='sub'><%= page_entries_info start = params[:start].to_i, start + 19, size = resque.size(current_queue), 'job' %></p>


### PR DESCRIPTION
Reflected XSS issues occurs when `/queue` is appended with `/"><svg%20onload=alert(domain)>`. Added fix to `escape_html`

Please find below reproduction of issue:
![image](https://user-images.githubusercontent.com/55310891/223389905-06d2b66c-f4b1-449c-97f4-29bbf4284b54.png)

