### PR TITLE
Fix reflected XSS in queue

### DIFF
--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -3,7 +3,7 @@
 <% if current_queue = params[:id] %>
 
   <h1>Pending jobs on <span class='hl'><%= h escape_html(current_queue) %></span></h1>
-  <form method="POST" action="<%=u "/queues/#{current_queue}/remove" %>" class='remove-queue'>
+  <form method="POST" action="<%=u "/queues/#{escape_html(current_queue)}/remove" %>" class='remove-queue'>
     <input type='submit' name='' value='Remove Queue' class="confirmSubmission" />
   </form>
   <p class='sub'><%= page_entries_info start = params[:start].to_i, start + 19, size = resque.size(current_queue), 'job' %></p>


### PR DESCRIPTION
Reflected XSS issue occurs when `/queues` is appended with `/"><svg%20onload=alert(domain)>`. Added fix to `escape_html`

Please find below reproduction of issue:

![image](https://user-images.githubusercontent.com/55310891/223394434-92ef356d-3285-45dc-8108-cd4e30172454.png)
