### PR TITLE
Let Rails eager load the application

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -37,15 +37,8 @@ namespace :resque do
     threads.each { |thread| thread.join }
   end
 
-  # Preload app files if this is Rails
-  task :preload => :setup do
-    if defined?(Rails) && Rails.respond_to?(:application)
-      if Rails.application.config.eager_load
-        ActiveSupport.run_load_hooks(:before_eager_load, Rails.application)
-        Rails.application.config.eager_load_namespaces.each(&:eager_load!)
-      end
-    end
-  end
+  # Defined for backwards compatibility.
+  task :preload => :setup
 
   namespace :failures do
     desc "Sort the 'failed' queue for the redis_multi_queue failure backend"


### PR DESCRIPTION
I may be missing something, so please consider this patch a conversation starter :).

When `Rails.application.config.eager_load` is true, Rails already executes

```ruby
ActiveSupport.run_load_hooks(:before_eager_load, Rails.application)
Rails.application.config.eager_load_namespaces.each(&:eager_load!)
```

among other things.

You can check this in [`main`](https://github.com/rails/rails/blob/bb6eb87be22bb3f9c27457921d794aa58653e7de/railties/lib/rails/application/finisher.rb#L77-L89), [`7.0`](https://github.com/rails/rails/blob/7-0-stable/railties/lib/rails/application/finisher.rb#L71-L83), [`6.1`](https://github.com/rails/rails/blob/6-1-stable/railties/lib/rails/application/finisher.rb#L127-L136), [`6.0`](https://github.com/rails/rails/blob/6-0-stable/railties/lib/rails/application/finisher.rb#L116-L125), ..., all the way back to [`3.0`](https://github.com/rails/rails/blob/3-0-stable/railties/lib/rails/application/finisher.rb#L38-L43) (slightly different by then).

Therefore, if `config.eager_load` is `true`, not only is this task doing unnecessary work, but it could potentially trigger code execution twice, since idempotence is not a requirement of those hooks.

For example, if you test an application with these settings:

```ruby
config.before_eager_load { p :CALLED }
config.rake_eager_load = true # config.eager_load is overridden with this one for Rake tasks
```

you'll see `:CALLED` twice.

So, I suspect this might be a leftover from old Resque versions and can be entirely removed.