### PR TITLE
Documents how to make the worker shutdown when the queue is empty

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -258,6 +258,9 @@ The default is 5 seconds, but for a semi-active app you may want to use a smalle
 
     $ INTERVAL=0.1 QUEUE=file_serve rake resque:work
 
+When INTERVAL is set to 0 it will run until the queue is empty and then
+shutdown the worker, instead of waiting for new jobs.
+
 The Front End
 -------------
 


### PR DESCRIPTION
I was looking for a way to automatically have the worker exit when the queue was empty and I didn't find anything in the docs about it. As I was looking through the code if it was possible to monkey-path / contribute an easy solution to pass a flag to term on empty queue I found out it was already possible, so I thought it might be helpful for a future user to document it in the readme.