### PR TITLE
format args in YAML

### DIFF
--- a/lib/resque/server/views/working.erb
+++ b/lib/resque/server/views/working.erb
@@ -21,7 +21,7 @@
         <td>
           <code><%= payload.key?('class') ? payload['class'] : "—" %></code>
         </td>
-        <td><%=h payload.key?('args') ? payload['args'].inspect : "—" %></td>
+        <td><pre><%=h payload.key?('args') ? show_args(payload['args']) : "—" %></pre></td>
       </tr>
   </table>
 


### PR DESCRIPTION
Hi,

It's easier to look `args` in YAML format than ruby Hash format, so I changed it.

In `failed_job`, `args` is already formatted in YAML.
https://github.com/resque/resque/blob/7623b8dfbdd0a07eb04b19fb25b16a8d6f087f9a/lib/resque/server/views/failed_job.erb#L34

If I miss something, please feel free to point out!