### PR TITLE
Fix MiniTest undefined errors

### DIFF
--- a/test/logging_test.rb
+++ b/test/logging_test.rb
@@ -12,7 +12,7 @@ describe "Resque::Logging" do
   %w(debug info error fatal).each do |severity|
     it "logs #{severity} messages" do
       message       = "test message"
-      mock_logger   = MiniTest::Mock.new
+      mock_logger   = Minitest::Mock.new
       mock_logger.expect severity.to_sym, nil, [message]
       Resque.logger = mock_logger
 

--- a/test/resque_failure_multiple_test.rb
+++ b/test/resque_failure_multiple_test.rb
@@ -15,7 +15,7 @@ describe 'Resque::Failure::Multiple' do
 
   it 'requeue_queue delegates to the first class and returns a mapped queue name' do
     with_failure_backend(Resque::Failure::Multiple) do
-      mock_class = MiniTest::Mock.new
+      mock_class = Minitest::Mock.new
       mock_class.expect(:requeue_queue, 'mapped_queue', ['queue'])
       Resque::Failure::Multiple.classes = [mock_class]
       assert_equal 'mapped_queue', Resque::Failure::Multiple.requeue_queue('queue')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,7 +33,7 @@ end
 # kill it when they end
 #
 
-MiniTest.after_run do
+Minitest.after_run do
   if Process.pid == $TEST_PID
     processes = `ps -A -o pid,command | grep [r]edis-test`.split("\n")
     pids = processes.map { |process| process.split(" ")[0] }
@@ -43,7 +43,7 @@ MiniTest.after_run do
   end
 end
 
-class GlobalSpecHooks < MiniTest::Spec
+class GlobalSpecHooks < Minitest::Spec
   def setup
     super
     reset_logger
@@ -101,7 +101,7 @@ module AssertInWorkBlock
         begin
           block_called = true
           block.call(*bargs)
-        rescue MiniTest::Assertion => ex
+        rescue Minitest::Assertion => ex
           throw :exception_in_block, ex
         end
       end


### PR DESCRIPTION
Not sure why this changed, but apparently MiniTest is actually Minitest. Only recently noticed this start crashing in CI.
