### PR TITLE
add always hooks

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+## 2.7.0
+
+### Added
+
+* `always` hooks that run regardless of the success or failure of the job(#1886)
+
 ## 2.6.0
 
 ### Fixed

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -127,6 +127,9 @@ The available hooks are:
 * `on_failure`: Called with the exception and job args if any exception occurs
   while performing the job (or hooks), this includes Resque::DirtyExit.
 
+* `always`: Called with the job args regardless of the success or failure of 
+  the job or any other hooks. Runs after `after_perform` and `on_failure` hooks. 
+
 Hooks are easily implemented with superclasses or modules. A superclass could
 look something like this.
 
@@ -167,10 +170,17 @@ module RetriedJob
   end
 end
 
+module CleanupJob
+  def always_cleanup(*_args)
+    cleanup!
+  end
+end
+
 class MyJob
   extend LoggedJob
   extend RetriedJob
   extend ScaledJob
+  extend CleanupJob
   def self.perform(*args)
     ...
   end

--- a/lib/resque/plugin.rb
+++ b/lib/resque/plugin.rb
@@ -55,6 +55,11 @@ module Resque
       get_hook_names(job, 'on_failure')
     end
 
+    # Given an object, returns a list of `always` hook names
+    def always_hooks(job)
+      get_hook_names(job, 'always')
+    end
+
     # Given an object, returns a list `after_enqueue` hook names.
     def after_enqueue_hooks(job)
       get_hook_names(job, 'after_enqueue')

--- a/test/plugin_test.rb
+++ b/test/plugin_test.rb
@@ -16,6 +16,9 @@ describe "Resque::Plugin finding hooks" do
     def on_failure1; end
     def on_failure; end
     def on_failure2; end
+    def always1; end
+    def always; end
+    def always2; end
   end
 
   module HookBlacklistJob
@@ -42,6 +45,10 @@ describe "Resque::Plugin finding hooks" do
 
   it "on_failure hooks are found and sorted" do
     assert_equal ["on_failure", "on_failure1", "on_failure2"], Resque::Plugin.failure_hooks(SimplePlugin).map {|m| m.to_s}
+  end
+
+  it "always hooks are found and sorted" do
+    assert_equal ["always", "always1", "always2"], Resque::Plugin.always_hooks(SimplePlugin).map(&:to_s)
   end
 
   it 'uses job.hooks if available get hook methods' do


### PR DESCRIPTION
Adds 'always' hooks which run in an ensure block in perform.

We found this feature useful for certain clean up tasks that we always want to run.
Often we would follow the pattern

```rb
def self.on_failure_zzz_cleanup(exception, *args)
  cleanup!
end

def self.after_perform_zzz_cleanup(*args)
  cleanup!
end
```

With an always hook this can be simplified to

```rb
def self.always_cleanup(*_args)
  cleanup!
end
```

There are test cases around what error messages are propagated when:
Just the code in the always hook raises an error
The code in perform and an always hook raise errors
The code in perform, on_failure hooks and always hooks raise errors

