### PR TITLE
Remove obsolete enqueue_front option

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -207,19 +207,6 @@ module Resque
     end
   end
 
-  # By default, jobs are pushed to the back of the queue and popped from
-  # the front, resulting in "first in, first out" (FIFO) execution order.
-  # Set to true to push jobs to the front of the queue instead, resulting
-  # in "last in, first out" (LIFO) execution order.
-  attr_writer :enqueue_front
-  def enqueue_front
-    if defined? @enqueue_front
-      @enqueue_front
-    else
-      @enqueue_front = false
-    end
-  end
-
   # The `before_first_fork` hook will be run in the **parent** process
   # only once, before forking to run the first job. Be careful- any
   # changes you make will be permanent for the lifespan of the


### PR DESCRIPTION
b45a6852fe7139286fc8f2733c6b4753e5a7e463 had introduced a `enqueue_front` option which enabled LIFO job execution instead of FIFO.

But a refactoring in 4bb44413a045fca78d25e22ad535b3f5ea97fab8 ignored that change.

This is a proposal to remove this unused property to avoid confusion about it not being functional.