### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -133,6 +133,15 @@ require 'your/app' # Include this line if you want your workers to have access t
 
 #### Rails
 
+##### Rails 7.1
+
+If you're using Rails 7.1.x, use [rack-session version 1.0.2](https://rubygems.org/gems/rack-session/versions/1.0.2). This is because resque-web's dependency, [Sinatra, isn't compatible with rack 3.0](https://github.com/sinatra/sinatra/issues/1797), which is [required by rack-session 2.0.0](https://rubygems.org/gems/rack-session/versions/2.0.0).
+
+```
+  gem 'rails', '~> 7.1'
+  gem 'rack-session', '~> 1.0', '>= 1.0.2'
+```
+
 To make resque specific changes, you can override the `resque:setup` job in `lib/tasks` (ex: `lib/tasks/resque.rake`). GitHub's setup task looks like this:
 
 ``` ruby


### PR DESCRIPTION
Added note about dependency requirement of rack-session 2.0.0 using Rack 3, which sinatra does not support.  Suggesting to user that they downgrade to rack-session 1.0.2