### PR TITLE
fix typo in stat.rb warning: data_strore -> data_store

### DIFF
--- a/lib/resque/stat.rb
+++ b/lib/resque/stat.rb
@@ -9,7 +9,7 @@ module Resque
     extend self
 
     def redis
-      warn '[Resque] [Deprecation] Resque::Stat #redis method is deprecated (please use #data_strore)'
+      warn '[Resque] [Deprecation] Resque::Stat #redis method is deprecated (please use #data_store)'
       data_store
     end
 


### PR DESCRIPTION
the method name referenced by a deprecated method in stat.rb was misspelled, it should be `data_store` not `data_strore`