### PR TITLE
Add Ruby 3.3 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - "3.0"
           - 3.1
           - 3.2
+          - 3.3
           - head
         exclude:
           - { ruby-version: 2.3, redis-version: 4.5 }
@@ -58,6 +59,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
           bundler-cache: true
       - run: bundle exec rubocop


### PR DESCRIPTION
This PR adds Ruby 3.3 to the CI matrix.