### PR TITLE
Version 2.7.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,11 @@
+## 2.7.0
+
+### Fixed
+* Update README.markdown (#1891)
+* Ruby does not allow logging within trap handlers (#1729)
+* Fix typo in stat.rb warning: data_strore -> data_store (#1904)
+* Ensure ruby 3.3 compatibility (#1907)
+
 ## 2.6.0
 
 ### Fixed

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  VERSION = '2.6.0'
+  VERSION = '2.7.0'
 end


### PR DESCRIPTION
This pull request includes updates to the `HISTORY.md` file and the version number in `lib/resque/version.rb` to reflect the new version 2.7.0. The most important changes include updating the version number and documenting the fixes in the new version.

Version update:

* [`lib/resque/version.rb`](diffhunk://#diff-4fb8d48fd985b3b0c290a07aa673918a237a77935b7341388b159be7fb1171c6L2-R2): Updated the version number from 2.6.0 to 2.7.0.

Documentation updates:

* [`HISTORY.md`](diffhunk://#diff-648afe3d986261d8f2015b2b131b0e4a448d4dc6946cfde1a7a836876cee255eR1-R8): Added a new section for version 2.7.0, documenting fixes such as updating the README, ensuring Ruby 3.3 compatibility, and correcting a typo in `stat.rb`.