### PR TITLE
feat: add `link` and `script` tag helpers

### DIFF
--- a/lib/resque/server/views/layout.erb
+++ b/lib/resque/server/views/layout.erb
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <title>Resque</title>
-  <link href="<%=u 'reset.css' %>" media="screen" rel="stylesheet" type="text/css">
-  <link href="<%=u 'style.css' %>" media="screen" rel="stylesheet" type="text/css">
-  <script src="<%=u 'jquery-3.6.0.min.js' %>" type="text/javascript"></script>
-  <script src="<%=u 'jquery.relatize_date.js' %>" type="text/javascript"></script>
-  <script src="<%=u 'ranger.js' %>" type="text/javascript"></script>
-  <script src="<%=u 'main.js' %>" type="text/javascript"></script>
+  <%= link_tag 'reset.css' %>
+  <%= link_tag 'style.css' %>
+  <%= script_tag 'jquery-3.6.0.min.js' %>
+  <%= script_tag 'jquery.relatize_date.js' %>
+  <%= script_tag 'ranger.js' %>
+  <%= script_tag 'main.js' %>
 </head>
 <body>
   <div class="header">

--- a/lib/resque/server_helper.rb
+++ b/lib/resque/server_helper.rb
@@ -19,7 +19,7 @@ module Resque
     alias_method :u, :url_path
 
     def script_tag(src)
-      "<script src=\"#{url_path(src)}\" type=\"text/javascript\"></script>"
+      %Q(<script src="#{url_path(src)}" type="text/javascript"></script>)
     end
 
     def link_tag(src)

--- a/lib/resque/server_helper.rb
+++ b/lib/resque/server_helper.rb
@@ -23,7 +23,7 @@ module Resque
     end
 
     def link_tag(src)
-      "<link href=\"#{url_path(src)}\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\">"
+      %Q(<link href="#{url_path(src)}" media="screen" rel="stylesheet" type="text/css">)
     end
 
     def path_prefix

--- a/lib/resque/server_helper.rb
+++ b/lib/resque/server_helper.rb
@@ -18,6 +18,14 @@ module Resque
     end
     alias_method :u, :url_path
 
+    def script_tag(src)
+      "<script src=\"#{url_path(src)}\" type=\"text/javascript\"></script>"
+    end
+
+    def link_tag(src)
+      "<link href=\"#{url_path(src)}\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\">"
+    end
+
     def path_prefix
       request.env['SCRIPT_NAME']
     end


### PR DESCRIPTION
These can be overridden by consumers to add e.g. `nonce`.

In our `config/resque.rb` I've added the following

```ruby
module Resque
  module ServerHelper
    def script_tag(src)
      base = "<script src=\"#{url_path(src)}\" type=\"text/javascript\"></script>"

      request = ActionDispatch::Request.new(env)

      nonce = request.content_security_policy_nonce

      return base unless nonce

      base.gsub(/><\/script>$/, " nonce=\"#{nonce}\"></script>")
    end

    def link_tag(src)
      base = "<link href=\"#{url_path(src)}\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\">"

      request = ActionDispatch::Request.new(env)

      nonce = request.content_security_policy_nonce

      return base unless nonce

      base.gsub(/">$/, "\" nonce=\"#{nonce}\">")
    end
  end
end
```

And with that, the CSP errors are gone 🥳 

<img width="791" alt="image" src="https://github.com/user-attachments/assets/86fa46de-0acf-4e78-94ff-f941b229f314" />

(Note that I am by no means a ruby/rails/sinatra/rack expert, but this _works_. Happy to change approach if there are better ways to go about this. I'd like to avoid having to maintain a fork, tho)

Fixes #1897