### PR TITLE
Add shutdown hooks

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -60,6 +60,19 @@ end
 
 The `queue_empty` hook will be run in the **parent** process.
 
+
+When the worker is shutdown. If the worker is terminating
+gracefully it may still complete jobs in progress.
+
+``` ruby
+Resque.shutdown do
+  puts "Call me when the worker is shutdown"
+end
+```
+
+The `shutdown` hook will be run in the **parent** process.
+
+
 When the worker exits:
 
 ``` ruby

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -316,6 +316,20 @@ module Resque
     register_hook(:worker_exit, block)
   end
 
+  # The `shutdown` hook will be run in the **child** process
+  # when the worker has received a signal to stop processing
+  #
+  # Call with a block to register a hook.
+  # Call with no arguments to return all registered hooks.
+  def shutdown(&block)
+    block ? register_hook(:shutdown, block) : hooks(:shutdown)
+  end
+
+  # Register a shutdown proc.
+  def shutdown=(block)
+    register_hook(:shutdown, block)
+  end
+
   def to_s
     "Resque Client connected to #{redis_id}"
   end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -260,6 +260,7 @@ module Resque
     rescue Exception => exception
       return if exception.class == SystemExit && !@child && run_at_exit_hooks
       log_with_severity :error, "Failed to start worker : #{exception.inspect}"
+      log_with_severity :error, exception.backtrace.join("\n")
       unregister_worker(exception)
       run_hook :worker_exit
     end
@@ -441,6 +442,8 @@ module Resque
     def shutdown
       log_with_severity :info, 'Exiting...'
       @shutdown = true
+      run_hook :shutdown
+      true
     end
 
     # Kill the child and shutdown immediately.

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -1094,6 +1094,20 @@ describe "Resque::Worker" do
     end
   end
 
+  describe "Resque::Job shutdown" do
+    before { Resque.send(:clear_hooks, :shutdown) }
+
+    it "will call the shutdown hook when the shutdown is called" do
+      shutdown_called = false
+      Resque.shutdown = Proc.new { shutdown_called = true }
+      workerA = Resque::Worker.new(:jobs)
+
+      assert !shutdown_called
+      workerA.shutdown
+      assert shutdown_called
+    end
+  end
+
   it "setting verbose to true" do
     @worker.verbose = true
 


### PR DESCRIPTION
Rails is getting a new feature called
[Active Job Continuations](https://github.com/rails/rails/pull/55127), which will allow jobs to be interrupted and resumed.

For this to be integrated with Resque, we need to know when a worker is shutting down.

There's a new `stopping?` method on the Rails queue adapter. Add a `shutdown` hook to Resque to allow us to implement that method.