### PR TITLE
Fix re-queued job timezone data

### DIFF
--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -78,7 +78,7 @@ module Resque
       def self.requeue(id, queue = nil)
         check_queue(queue)
         item = all(id)
-        item['retried_at'] = Time.now.strftime("%Y/%m/%d %H:%M:%S")
+        item['retried_at'] = UTF8Util.clean(Time.now.strftime("%Y/%m/%d %H:%M:%S %Z"))
         data_store.update_item_in_failed_queue(id,Resque.encode(item))
         Job.create(item['queue'], item['payload']['class'], *item['payload']['args'])
       end


### PR DESCRIPTION
#### Origin

At our timezone (`-03`), immediately after retry a job on _reque web_, the `retried_at` information displayed is wrong:

> <img width="831" height="59" alt="image" src="https://github.com/user-attachments/assets/6ec91edb-bf90-4625-9371-cd87cb921fc3" />

> <img width="831" height="59" alt="image" src="https://github.com/user-attachments/assets/0aefb416-c944-477c-b6fa-a781854a5b65" />

#### Fix

Add timezone information to the field.
Seems that `retried_at` deserves same respect as `failed_at`.
