### PR TITLE
Fix a double redis.get to pause-all-workers in each work loop

### DIFF
--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -143,6 +143,7 @@ module Resque
     def initialize(*queues)
       @shutdown = nil
       @paused = nil
+      @cached_pause_value = nil
       @before_first_fork_hook_ran = false
 
       @heartbeat_thread = nil
@@ -250,7 +251,7 @@ module Resque
           state_change
           break if interval.zero?
           log_with_severity :debug, "Sleeping for #{interval} seconds"
-          procline paused? ? "Paused" : "Waiting for #{queues.join(',')}"
+          procline @cached_pause_value ? "Paused" : "Waiting for #{queues.join(',')}"
           sleep interval
         end
       end
@@ -579,7 +580,7 @@ module Resque
 
     # are we paused?
     def paused?
-      @paused || redis.get('pause-all-workers').to_s.strip.downcase == 'true'
+      @cached_pause_value = @paused || redis.get('pause-all-workers').to_s.strip.downcase == 'true'
     end
 
     # Stop processing jobs after the current one has completed (if we're


### PR DESCRIPTION
While debugging some performance issues with a huge volume of workers I noticed that 
```
redis.get('pause-all-workers')
```
is being run twice for each interval. If you set the INTERVAL to 100ms and run a thousand workers, this adds up!

This change caches the paused state and uses it to set the procline.

Here's the impact for us:

<img width="557" height="247" alt="Screenshot 2025-09-24 at 11 15 34 PM" src="https://github.com/user-attachments/assets/09406301-f531-4707-80ac-03c190c4fc55" />