### PR TITLE
Support a dynamic sleep INTERVAL

### DIFF
--- a/lib/resque/tasks.rb
+++ b/lib/resque/tasks.rb
@@ -17,7 +17,11 @@ namespace :resque do
 
     worker.prepare
     worker.log "Starting worker #{worker}"
-    worker.work(ENV['INTERVAL'] || ENV['MAX_INTERVAL'] || 5, ENV['MIN_INTERVAL'] || 5, ENV['BACKOFF_INTERVAL'] || 0.1) # interval, will block
+    # will block until a shutdown signal is received
+    worker.work(ENV["INTERVAL"],
+                max_interval:     ENV['MAX_INTERVAL'],
+                min_interval:     ENV['MIN_INTERVAL'],
+                backoff_interval: ENV['BACKOFF_INTERVAL'])
   end
 
   desc "Start multiple Resque workers. Should only be used in dev mode."


### PR DESCRIPTION
We run a large resque (resque-pool) installation with ~1100 workers per site. These use a low INTERVAL of 100ms to pickup new work. Something we've noted is that the workers with empty queues pummel the redis server endlessly trying to find the next batch of work. This seems a bit wasteful on the CPU side, and is impacting the quick pickup by workers that are actually busy.

This change adds a dynamic sleep interval that backs off to a maximum value. This gives us the quick pickup we need, while the more idle workers can chill a bit.

This cut a good 15k/sec of redis commands:
<img width="1117" height="251" alt="Screenshot 2025-09-26 at 2 42 44 PM" src="https://github.com/user-attachments/assets/95ca504f-3bfb-4cba-b7f1-a8a4d37b6b7d" />

and 20Mbit/s of network traffic
<img width="970" height="254" alt="Screenshot 2025-09-26 at 2 43 26 PM" src="https://github.com/user-attachments/assets/bc8aed39-4074-44ad-a58c-40901a629b4f" />

See https://github.com/resque/resque-pool/pull/251 for the resque-pool side.