### PR TITLE
Add devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+FROM ruby:3.4
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    build-essential \
+    redis-tools \
+    redis-server \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG USERNAME=dev
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+USER $USERNAME
+
+WORKDIR /workspaces/resque
+
+RUN gem install bundler
+
+ENV REDIS_VERSION=latest
+ENV RACK_VERSION=3
+ENV COVERAGE=1

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,95 @@
+# Dev Container for Resque
+
+This dev container is configured to match the GitHub Actions test matrix with the following configuration:
+
+- **Ruby version**: 3.4
+- **Redis version**: latest
+- **Rack version**: 3
+
+## Getting Started
+
+1. Open this repository in your editor (Cursor, VS Code, etc.)
+2. When prompted, click "Reopen in Container" (or run the command "Dev Containers: Reopen in Container")
+3. Wait for the container to build and start
+4. Once inside the container, dependencies will be automatically installed via `bundle install`
+
+## Running Tests
+
+To run the full test suite:
+
+```bash
+bundle exec rake
+```
+
+To run a specific test file:
+
+```bash
+bundle exec ruby test/resque_test.rb
+```
+
+To run tests with verbose output:
+
+```bash
+VERBOSE=1 bundle exec rake
+```
+
+## Testing with Different Configurations
+
+If you want to test with different versions, you can modify the environment variables and reinstall dependencies:
+
+```bash
+# Example: Test with rack 2
+export RACK_VERSION=2
+bundle install
+
+# Run tests
+bundle exec rake
+
+# Reset to original configuration
+export RACK_VERSION=3
+bundle install
+```
+
+## Available Environment Variables
+
+The following environment variables are set to match the test matrix:
+
+- `REDIS_VERSION`: latest
+- `RACK_VERSION`: 3
+- `COVERAGE`: 1
+
+## Services
+
+### Redis
+
+A Redis container runs as a sidecar service. From inside the container it is reachable at `redis://redis:6379`. The devcontainer also forwards port 6379 to your local machine, so you can connect via `localhost:6379` from outside the container (e.g. with a Redis GUI).
+
+To connect to Redis CLI from inside the container:
+
+```bash
+redis-cli -h redis
+```
+
+Note: the test suite spins up its own Redis instance on port 9736 — that is separate from this service.
+
+## Troubleshooting
+
+### Redis Connection Issues
+
+Make sure the Redis container is running:
+
+```bash
+redis-cli -h redis ping
+```
+
+Should return `PONG`.
+
+### Rebuilding the Container
+
+If you need to rebuild the container from scratch:
+
+1. Run "Dev Containers: Rebuild Container" from the command palette
+2. Or delete the container and volume manually:
+   ```bash
+   docker compose -f .devcontainer/docker-compose.yml down -v
+   ```

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+
+services:
+  app:
+    build: 
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+      - ../.bundle:/bundle:cached
+    environment:
+      - BUNDLE_PATH=/bundle
+      - REDIS_URL=redis://redis:6379
+    command: sleep infinity
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    command: redis-server --appendonly yes
+
+volumes:
+  redis-data: 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "Resque Dev Container",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/resque",
+
+  // Features to add to the dev container
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+
+  // Configure tool-specific properties
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      }
+    }
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally
+  "forwardPorts": [6379],
+
+  // Use 'postCreateCommand' to run commands after the container is created
+  "postCreateCommand": "bundle install",
+
+  // Set environment variables for the test matrix
+  "containerEnv": {
+    "REDIS_VERSION": "latest",
+    "RACK_VERSION": "3",
+    "COVERAGE": "1"
+  },
+
+  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root
+  "remoteUser": "dev"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ../..:/workspaces:cached
+    working_dir: /workspaces/resque
+    command: sleep infinity
+    environment:
+      REDIS_VERSION: "latest"
+      RACK_VERSION: "3"
+      COVERAGE: "1"
+      REDIS_URL: "redis://redis:6379"
+    depends_on:
+      - redis
+    # Runs app on the same network as the redis container, allows "forwardPorts" in devcontainer.json function
+    network_mode: service:redis
+
+  redis:
+    image: redis:latest
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
+
+volumes:
+  redis-data:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pkg
 *.sw?
 vendor/bundle
 test/gemfiles/*.lock
+.bundle


### PR DESCRIPTION
Adds a `.devcontainer` configuration for developing Resque in a containerized environment.

- Ruby 3.4 base image
- Redis sidecar service (also installs `redis-server` in the image for the test suite, which spins up its own instance on port 9736)
- Runs `bundle install` on container creation
- Environment variables set to match the CI test matrix (`REDIS_VERSION`, `RACK_VERSION`, `COVERAGE`)