### PR TITLE
Add ipv6 support for resque web url

### DIFF
--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -85,7 +85,8 @@ module Resque
     end
 
     def url
-      "http://#{host}:#{port}"
+      h = host.include?(':') ? "[#{host}]" : host
+      "http://#{h}:#{port}"
     end
 
     def before_run


### PR DESCRIPTION
Solves error you can't set host with this way `bundle exec resque-web --host :: --port 5678`