### PR TITLE
Address multi_json class name deprecation warning

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -49,7 +49,7 @@ module Resque
       else
         MultiJson.decode object
       end
-    rescue ::MultiJson::DecodeError => e
+    rescue MultiJson::DecodeError => e
       raise Helpers::DecodeException, e.message, e.backtrace
     end
   end

--- a/lib/resque/helpers.rb
+++ b/lib/resque/helpers.rb
@@ -1,14 +1,19 @@
 require 'multi_json'
 
-# OkJson won't work because it doesn't serialize symbols
-# in the same way yajl and json do.
-if MultiJson.respond_to?(:adapter)
-  raise "Please install the yajl-ruby or json gem" if MultiJson.adapter.to_s == 'MultiJson::Adapters::OkJson'
-elsif MultiJson.respond_to?(:engine)
-  raise "Please install the yajl-ruby or json gem" if MultiJson.engine.to_s == 'MultiJson::Engines::OkJson'
-end
-
 module Resque
+  # multi_json renamed it's top-level constant from MultiJson to MultiJSON,
+  # keeping MultiJson as a deprecated alias until v2.0. Reference whichever name the
+  # installed version exposes so we stay compatible with future versions of multi_json
+  MultiJson = defined?(::MultiJSON) ? ::MultiJSON : ::MultiJson
+
+  # OkJson won't work because it doesn't serialize symbols
+  # in the same way yajl and json do.
+  if MultiJson.respond_to?(:adapter)
+    raise "Please install the yajl-ruby or json gem" if MultiJson.adapter.to_s.end_with?('::OkJson')
+  elsif MultiJson.respond_to?(:engine)
+    raise "Please install the yajl-ruby or json gem" if MultiJson.engine.to_s.end_with?('::OkJson')
+  end
+
   # Methods used by various classes in Resque.
   module Helpers
     class DecodeException < StandardError; end


### PR DESCRIPTION
Currently users of `resque` will see the following deprecation warning: 
`The MultiJson constant is deprecated and will be removed in v2.0. Use MultiJSON instead.`. 

# Background: 
[MultiJSON 1.21.0](https://github.com/sferik/multi_json/blob/main/CHANGELOG.md#1210) renamed the MultiJson constant to MultiJSON (all-caps) to match the project name. The compatibility shim will be removed when they release a future 2.0.0 version. 

In the meantime the aforementioned deprecation warning is emitted. 

# Fix
Selectively reference MultiJSON if it's available, otherwise fall back to MultiJson for backwards compatibility. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with different JSON parsing library versions.
  * Fixed error handling so invalid JSON responses are handled more reliably.
  * Updated internal compatibility checks for JSON adapters to work with more setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->