### PR TITLE
Regression tests for the failure-drop bug + 1.27.4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,11 @@ source "https://rubygems.org"
 
 gemspec
 
+# production parity (pocketsmith Gemfile.lock): redis 5.x breaks resque 1.27's
+# client construction, and tests should exercise what production runs anyway.
+gem 'redis', '~> 4.2.0'
+gem 'redis-namespace', '~> 1.11.0'
+
 gem "activesupport", "~> 3.0"
 gem "i18n"
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Nothing yet!
+
+## 1.27.4 (2017-4-15)
+
 ### Fixed
 * Fix issue where removing a failure from Resque web didn't work when using `RedisMultiQueue` backend.
 

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.27.3'
+  Version = VERSION = '1.27.4'
 end

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.27.4.1'
+  Version = VERSION = '1.27.4.2'
 end

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.27.4'
+  Version = VERSION = '1.27.4.1'
 end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -280,7 +280,7 @@ module Resque
 
     # Reports the exception and marks the job as failed
     def report_failed_job(job,exception)
-      queue_name = job['queue'] if job
+      queue_name = job.queue if job
       log_with_severity :error, "#{job.inspect} failed: #{exception.inspect}"
       begin
         job.fail(exception)

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -280,6 +280,7 @@ module Resque
 
     # Reports the exception and marks the job as failed
     def report_failed_job(job,exception)
+      queue_name = job['queue'] if job
       log_with_severity :error, "#{job.inspect} failed: #{exception.inspect}"
       begin
         job.fail(exception)
@@ -287,7 +288,7 @@ module Resque
         log_with_severity :error, "Received exception when reporting failure: #{exception.inspect}"
       end
       begin
-        failed!
+        failed!(queue_name: queue_name)
       rescue Object => exception
         log_with_severity :error, "Received exception when increasing failed jobs counter (redis issue) : #{exception.inspect}"
       end
@@ -700,8 +701,9 @@ module Resque
     # Called when we are done working - clears our `working_on` state
     # and tells Redis we processed a job.
     def done_working
+      queue_name = job['queue'] if job
       data_store.worker_done_working(self) do
-        processed!
+        processed!(queue_name: queue_name)
       end
     end
 
@@ -711,8 +713,14 @@ module Resque
     end
 
     # Tell Redis we've processed a job.
-    def processed!
+    def processed!(queue_name: nil)
+      queue_name = @queues.join(",") unless queue_name
       Stat << "processed"
+
+      Stat << "processed:#{hostname}"
+      Stat << "processed:#{hostname}:#{queue_name}"
+      Stat << "processed:#{queue_name}"
+
       Stat << "processed:#{self}"
     end
 
@@ -722,8 +730,12 @@ module Resque
     end
 
     # Tells Redis we've failed a job.
-    def failed!
+    def failed!(queue_name: nil)
+      queue_name = @queues.join(",") unless queue_name
       Stat << "failed"
+      Stat << "failed:#{hostname}"
+      Stat << "failed:#{hostname}:#{queue_name}"
+      Stat << "failed:#{queue_name}"
       Stat << "failed:#{self}"
     end
 

--- a/test/report_failed_job_test.rb
+++ b/test/report_failed_job_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+# Regression coverage for the 1.27.4.1 fork bug where report_failed_job
+# crashed (NoMethodError: Resque::Job has no #[]) BEFORE job.fail ran, so no
+# failing job ever reached the failure backend, on_failure hooks (resque-retry)
+# never fired, and the failed stats never moved. report_failed_job receives a
+# real Resque::Job here — exactly the production call shape.
+describe "Worker#report_failed_job" do
+  before do
+    Resque.redis.flushall
+    @worker = Resque::Worker.new(:jobs)
+    @job = Resque::Job.new(:jobs, 'class' => 'SomeJob', 'args' => [])
+    @job.worker = @worker
+  end
+
+  it "records the failure in the failure backend" do
+    assert_equal 0, Resque::Failure.count
+    @worker.report_failed_job(@job, RuntimeError.new("boom"))
+    assert_equal 1, Resque::Failure.count
+  end
+
+  it "bumps the global, per-host, per-queue and per-host-per-queue failed stats" do
+    @worker.report_failed_job(@job, RuntimeError.new("boom"))
+    host = @worker.hostname
+    assert_equal 1, Resque::Stat["failed"]
+    assert_equal 1, Resque::Stat["failed:#{host}"]
+    assert_equal 1, Resque::Stat["failed:#{host}:jobs"]
+    assert_equal 1, Resque::Stat["failed:jobs"]
+  end
+
+  it "still counts the failure when there is no job (falls back to the worker's queues)" do
+    @worker.report_failed_job(nil, RuntimeError.new("boom"))
+    assert_equal 1, Resque::Stat["failed"]
+    assert_equal 1, Resque::Stat["failed:jobs"]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,11 +1,15 @@
-require 'coveralls'
-Coveralls.wear!
+# Coveralls only in CI: locally, .simplecov has already started SimpleCov by
+# the time wear! calls start again ('coverage measurement is already setup').
+if ENV['CI']
+  require 'coveralls'
+  Coveralls.wear!
+end
 
 require 'rubygems'
 require 'bundler/setup'
 require 'minitest/autorun'
 require 'redis/namespace'
-require 'mocha/setup'
+require 'mocha/minitest'
 
 $dir = File.dirname(File.expand_path(__FILE__))
 $LOAD_PATH.unshift $dir + '/../lib'


### PR DESCRIPTION
Follow-up to f4456be (the `report_failed_job` fix, verified live on ps-queue4 today): regression tests so this class of bug can't ship silently again, plus the version bump so the fixed code self-identifies (broken 1.27.4.1 is currently deployed; `ps | grep resque-1.27.4.2` will mark rollout progress host by host).

- **Tests**: a failing job must reach the failure backend; the per-host/per-queue `failed:` stat family (the fork's raison d'être) must move; the no-job fallback works. All exercise the real `Resque::Job` call shape that crashed.
- **Harness housekeeping** (first local run in years, evidently): `.ruby-version` 3.3.6, production-parity redis pin (5.x breaks 1.27's client construction), CI-only coveralls, `mocha/minitest`.
- Full suite: 218 tests — only pre-existing failures are `resque-web_test.rb` (sinatra/rack dep drift, untouched here).

Pairs with the pocketsmith lock bump `2dd1f3d` → this HEAD, which is the change that actually fixes queue0–3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved failure tracking with accurate global, host-specific, queue-specific, and host-and-queue statistics.
  - Ensured failed jobs are recorded even when job details are unavailable.
  - Improved processed-job statistics by queue and host.

- **Chores**
  - Updated Redis compatibility requirements.
  - Updated the release version to 1.27.4.2.

- **Documentation**
  - Added an Unreleased section to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->