### PR TITLE
Generate a unique failure_id for each failure

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -431,6 +431,11 @@ Resque::Failure::Multiple.classes = [Resque::Failure::Redis, Resque::Failure::Ai
 Resque::Failure.backend = Resque::Failure::Multiple
 ```
 
+Each failure is recorded with a unique `failure_id` shared by every backend that
+accepts one, so the same failure can be correlated across them. Failures are
+still addressed by index; the id is additive metadata. See
+[docs/FAILURE_IDS.md](https://github.com/resque/resque/blob/master/docs/FAILURE_IDS.md).
+
 Keep this in mind when writing your jobs: you may want to throw
 exceptions you would not normally throw in order to assist debugging.
 

--- a/docs/FAILURE_IDS.md
+++ b/docs/FAILURE_IDS.md
@@ -1,0 +1,138 @@
+Failure IDs
+===========
+
+By default, every failure Resque records is assigned a `failure_id`: a UUID
+generated once, at failure time, and shared by every configured failure backend
+that accepts one.
+
+Why
+---
+
+Failures are usually recorded in more than one place - the Redis failed list
+plus whatever exception tracking service you use:
+
+``` ruby
+Resque::Failure::Multiple.classes = [Resque::Failure::Redis, MyExceptionTracker]
+Resque::Failure.backend = Resque::Failure::Multiple
+```
+
+Before `failure_id` there was no way to tell that the record in the failed list
+and the event in the other service were the *same* failure. Each backend
+recorded it independently, with no shared handle. `failure_id` is that handle.
+
+
+What it is not
+--------------
+
+**`failure_id` is not an index, and it does not give you O(1) lookup.** The
+failed list is still a list; resolving an id to a position still means scanning
+it. Index based addressing is unchanged - `all`, `each`, `requeue` and `remove`
+all still take positions, and mean exactly what they meant before.
+
+What the id buys you is a *check*. A tool that lets an operator select a failure
+and then act on it can re-read the element immediately before mutating it and
+confirm it is still the record that was selected, rather than a different one
+that shifted into that position in the meantime:
+
+``` ruby
+selected_id = params[:failure_id]
+
+current = Resque::Failure.all(index)
+if current && current['failure_id'] == selected_id
+  Resque::Failure.remove(index)
+else
+  # the list moved under us - re-resolve before acting
+end
+```
+
+This is a read followed by a write, not an atomic operation. The list can still
+shift between the two, so the check narrows the window rather than closing it -
+it turns "silently acted on the wrong record" into "usually caught it". If you
+need a real guarantee, take a lock around your read and write, or do the
+compare and the mutation in a single Lua script.
+
+
+Consuming it
+------------
+
+Check for the field **per record** and degrade when it is absent. Failures
+recorded before you upgraded do not have one, and neither do failures recorded
+by an older Resque, so there is no version check that will save you from this:
+
+``` ruby
+Resque::Failure.each do |index, failure|
+  if failure['failure_id']
+    # correlate, check, whatever you need
+  else
+    # older record - fall back to index-only behaviour
+  end
+end
+```
+
+
+Supplying your own
+------------------
+
+If you already have an id you would rather use - a trace id, for instance -
+pass it to `Resque::Failure.create`:
+
+``` ruby
+Resque::Failure.create(
+  :exception  => exception,
+  :worker     => worker,
+  :queue      => queue,
+  :payload    => payload,
+  :failure_id => current_trace_id
+)
+```
+
+
+Turning it off
+--------------
+
+Generation is on by default. With it off, `failure_id` is `nil` everywhere and
+the payload Resque stores is identical to what it stored before the feature
+existed - the key is left out entirely, not set to `nil`:
+
+``` ruby
+Resque::Failure.generate_failure_ids = false
+```
+
+An explicit `:failure_id` passed to `create` is still assigned, since you asked
+for that one by name.
+
+The realistic reason to turn it off is a schema validator somewhere in your
+stack that rejects unknown keys in the failure payload.
+
+
+Writing a backend
+-----------------
+
+Backends inherit `failure_id` from `Resque::Failure::Base`, so there is nothing
+to add unless you want to report it to your service:
+
+``` ruby
+class MyFailure < Resque::Failure::Base
+  def save
+    MyService.notify(exception, :context => { :failure_id => failure_id })
+  end
+end
+```
+
+`Base` is what generates the id, in `initialize`, so it is available for the
+whole life of the object - `save` included. It is `nil` only when generation is
+turned off, so guard with `if failure_id` if you support that.
+
+A backend that does not subclass `Base` owns its own id. Defining `failure_id=`
+does not get you one generated; the writer is how a backend *receives* an id
+that something else already made. Concretely, such a backend is handed an id
+when it runs under `Resque::Failure::Multiple`, which is a `Base` and pushes its
+own id down into every child that has a writer, or when the caller passes
+`:failure_id` to `create`. As the only backend, with no id named by the caller,
+it gets nothing - generate one in your own `initialize` if you want it. A
+backend with no writer at all is simply skipped, and keeps working.
+
+Since the id exists to tie one failure to its records in other backends, this
+mostly does not come up: the case where correlation is the point is the
+`Multiple` case, which is covered. Subclassing `Base` is the easy way out
+either way.

--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -1,6 +1,7 @@
 require 'mono_logger'
 require 'redis/namespace'
 require 'forwardable'
+require 'securerandom'
 
 require 'resque/version'
 

--- a/lib/resque/failure.rb
+++ b/lib/resque/failure.rb
@@ -9,12 +9,33 @@ module Resque
     # Creates a new failure, which is delegated to the appropriate backend.
     #
     # Expects a hash with the following keys:
-    #   :exception - The Exception object
-    #   :worker    - The Worker object who is reporting the failure
-    #   :queue     - The string name of the queue from which the job was pulled
-    #   :payload   - The job's payload
+    #   :exception  - The Exception object
+    #   :worker     - The Worker object who is reporting the failure
+    #   :queue      - The string name of the queue from which the job was pulled
+    #   :payload    - The job's payload
+    #   :failure_id - Optional id to record this failure under, in place of the
+    #                 one the backend generates for itself.
     def self.create(options = {})
-      backend.new(*options.values_at(:exception, :worker, :queue, :payload)).save
+      failure = backend.new(*options.values_at(:exception, :worker, :queue, :payload))
+
+      # Backends are not required to accept an id.
+      if options[:failure_id] && failure.respond_to?(:failure_id=)
+        failure.failure_id = options[:failure_id]
+      end
+
+      failure.save
+    end
+
+    class << self
+      attr_writer :generate_failure_ids
+
+      # Whether failures are given a `failure_id` when they are built.
+      # Defaults to true. An explicit `:failure_id` passed to `create` sets the
+      # `failure_id` even if automatic generation is disabled.
+      def generate_failure_ids?
+        return true if @generate_failure_ids.nil?
+        !!@generate_failure_ids
+      end
     end
 
     #

--- a/lib/resque/failure/base.rb
+++ b/lib/resque/failure/base.rb
@@ -17,11 +17,16 @@ module Resque
       # The payload object associated with the failed job
       attr_accessor :payload
 
+      # A unique identifier for this failure, shared by every backend that
+      # accepts one. Nil when generation is turned off.
+      attr_accessor :failure_id
+
       def initialize(exception, worker, queue, payload)
         @exception = exception
         @worker    = worker
         @queue     = queue
         @payload   = payload
+        @failure_id = SecureRandom.uuid if Resque::Failure.generate_failure_ids?
       end
 
       # When a job fails, a new instance of your Failure backend is created

--- a/lib/resque/failure/multiple.rb
+++ b/lib/resque/failure/multiple.rb
@@ -19,7 +19,10 @@ module Resque
       end
 
       def save
-        @backends.each(&:save)
+        @backends.each do |backend|
+          backend.failure_id = failure_id if backend.respond_to?(:failure_id=)
+          backend.save
+        end
       end
 
       # The number of failures.

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -22,6 +22,7 @@ module Resque
           :worker    => worker.to_s,
           :queue     => queue
         }
+        data[:failure_id] = failure_id if failure_id
         data = Resque.encode(data)
         data_store.push_to_failed_queue(data)
       end

--- a/lib/resque/failure/redis_multi_queue.rb
+++ b/lib/resque/failure/redis_multi_queue.rb
@@ -22,6 +22,7 @@ module Resque
           :worker    => worker.to_s,
           :queue     => queue
         }
+        data[:failure_id] = failure_id if failure_id
         data = Resque.encode(data)
         data_store.push_to_failed_queue(data,Resque::Failure.failure_queue_name(queue))
       end

--- a/test/failure_base_test.rb
+++ b/test/failure_base_test.rb
@@ -6,10 +6,125 @@ require 'resque/failure/base'
 class TestFailure < Resque::Failure::Base
 end
 
+# The shape third-party backends ship: four positional arguments, bare super.
+class ThirdPartyFailure < Resque::Failure::Base
+  class << self
+    attr_accessor :last_saved
+  end
+
+  def initialize(exception, worker, queue, payload)
+    super
+  end
+
+  def save
+    self.class.last_saved = self
+  end
+end
+
+class BackendWithoutBase
+  class << self
+    attr_accessor :saved
+  end
+
+  def initialize(exception, worker, queue, payload)
+  end
+
+  def save
+    self.class.saved = true
+  end
+end
+
 describe "Base failure class" do
+  let(:exception) { StandardError.exception('some error') }
+  let(:worker)    { Resque::Worker.new(:test) }
+  let(:queue)     { 'queue' }
+  let(:payload)   { { 'class' => 'Object', 'args' => 3 } }
+
   it "allows calling all without throwing" do
     with_failure_backend TestFailure do
       assert_empty Resque::Failure.all
     end
+  end
+
+  it "takes four positional arguments" do
+    assert_equal 4, Resque::Failure::Base.instance_method(:initialize).arity
+  end
+
+  it "generates a failure_id when it is built" do
+    failure = TestFailure.new(exception, worker, queue, payload)
+    assert_match(/\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/, failure.failure_id)
+  end
+
+  it "gives each failure its own failure_id" do
+    first  = TestFailure.new(exception, worker, queue, payload)
+    second = TestFailure.new(exception, worker, queue, payload)
+    refute_equal first.failure_id, second.failure_id
+  end
+
+  it "accepts an assigned failure_id" do
+    failure = TestFailure.new(exception, worker, queue, payload)
+    failure.failure_id = 'assigned-id'
+    assert_equal 'assigned-id', failure.failure_id
+  end
+
+  it "has no failure_id when generation is disabled" do
+    failure = with_failure_id_generation false do
+      TestFailure.new(exception, worker, queue, payload)
+    end
+
+    assert_nil failure.failure_id
+  end
+
+  it "assigns a failure_id to backends created through Resque::Failure.create" do
+    with_failure_backend ThirdPartyFailure do
+      Resque::Failure.create(:exception => exception, :worker => worker,
+                             :queue => queue, :payload => payload)
+    end
+
+    saved = ThirdPartyFailure.last_saved
+    refute_nil saved.failure_id
+    assert_equal payload, saved.payload
+  end
+
+  it "honours a caller supplied failure_id" do
+    with_failure_backend ThirdPartyFailure do
+      Resque::Failure.create(:exception => exception, :worker => worker,
+                             :queue => queue, :payload => payload,
+                             :failure_id => 'caller-supplied-id')
+    end
+
+    assert_equal 'caller-supplied-id', ThirdPartyFailure.last_saved.failure_id
+  end
+
+  it "creates failures on backends that do not subclass Base" do
+    with_failure_backend BackendWithoutBase do
+      Resque::Failure.create(:exception => exception, :worker => worker,
+                             :queue => queue, :payload => payload)
+    end
+
+    assert BackendWithoutBase.saved
+  end
+
+  it "does not assign a failure_id when generation is disabled" do
+    with_failure_id_generation false do
+      with_failure_backend ThirdPartyFailure do
+        Resque::Failure.create(:exception => exception, :worker => worker,
+                               :queue => queue, :payload => payload)
+      end
+    end
+
+    assert_nil ThirdPartyFailure.last_saved.failure_id
+  end
+
+  it "honours a caller supplied failure_id when generation is disabled" do
+    with_failure_id_generation false do
+      with_failure_backend ThirdPartyFailure do
+        Resque::Failure.create(:exception => exception, :worker => worker,
+                               :queue => queue, :payload => payload,
+                               :failure_id => 'caller-supplied-id')
+      end
+    end
+
+    assert_equal 'caller-supplied-id', ThirdPartyFailure.last_saved.failure_id
   end
 end

--- a/test/resque_failure_multi_queue_test.rb
+++ b/test/resque_failure_multi_queue_test.rb
@@ -183,4 +183,27 @@ describe "Resque::Failure::RedisMultiQueue" do
 
     assert_equal expected_ids, ids
   end
+
+  it 'stores the failure_id assigned by Resque::Failure.create' do
+    with_failure_backend Resque::Failure::RedisMultiQueue do
+      Resque::Failure.create(:exception => exception, :worker => worker,
+                             :queue => queue, :payload => payload)
+    end
+
+    failure = Resque::Failure::RedisMultiQueue.all(0, 1, Resque::Failure.failure_queue_name(queue))
+    refute_nil failure['failure_id']
+    assert_match(/\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/, failure['failure_id'])
+  end
+
+  it 'stores no failure_id at all when generation is disabled' do
+    with_failure_id_generation false do
+      with_failure_backend Resque::Failure::RedisMultiQueue do
+        Resque::Failure.create(:exception => exception, :worker => worker,
+                               :queue => queue, :payload => payload)
+      end
+    end
+
+    failure = Resque::Failure::RedisMultiQueue.all(0, 1, Resque::Failure.failure_queue_name(queue))
+    assert_equal %w(failed_at payload exception error backtrace worker queue), failure.keys
+  end
 end

--- a/test/resque_failure_multiple_test.rb
+++ b/test/resque_failure_multiple_test.rb
@@ -1,7 +1,61 @@
 require 'test_helper'
 require 'resque/failure/multiple'
+require 'resque/failure/redis'
+require 'resque/failure/redis_multi_queue'
 
 describe 'Resque::Failure::Multiple' do
+  let(:exception) { StandardError.exception('some error') }
+  let(:worker)    { Resque::Worker.new(:test) }
+  let(:payload)   { { 'class' => 'Object', 'args' => 3 } }
+
+  it 'saves every backend under an assigned failure_id' do
+    Resque::Failure::Multiple.classes = [Resque::Failure::Redis, Resque::Failure::RedisMultiQueue]
+    multiple = Resque::Failure::Multiple.new(exception, worker, 'queue', payload)
+    multiple.failure_id = 'shared-id'
+    multiple.save
+
+    backends = multiple.instance_variable_get(:@backends)
+    assert_equal ['shared-id', 'shared-id'], backends.map(&:failure_id)
+  end
+
+  it 'saves every backend under its own generated failure_id' do
+    Resque::Failure::Multiple.classes = [Resque::Failure::Redis, Resque::Failure::RedisMultiQueue]
+    multiple = Resque::Failure::Multiple.new(exception, worker, 'queue', payload)
+    multiple.save
+
+    generated = multiple.failure_id
+    backends = multiple.instance_variable_get(:@backends)
+    assert_equal [generated, generated], backends.map(&:failure_id)
+  end
+
+  it 'records the same failure_id in every backend' do
+    with_failure_backend(Resque::Failure::Multiple) do
+      Resque::Failure::Multiple.classes = [Resque::Failure::Redis, Resque::Failure::RedisMultiQueue]
+      Resque::Failure.create(:exception => exception, :worker => worker,
+                             :queue => 'queue', :payload => payload)
+
+      from_redis = Resque::Failure::Redis.all(0)
+      from_multi_queue = Resque::Failure::RedisMultiQueue.all(0, 1, Resque::Failure.failure_queue_name('queue'))
+
+      refute_nil from_redis['failure_id']
+      assert_equal from_redis['failure_id'], from_multi_queue['failure_id']
+    end
+  end
+
+  it 'does not require its backends to accept a failure_id' do
+    backend_class = Class.new do
+      def initialize(exception, worker, queue, payload); end
+      def save; end
+    end
+
+    Resque::Failure::Multiple.classes = [backend_class]
+    multiple = Resque::Failure::Multiple.new(exception, worker, 'queue', payload)
+    multiple.failure_id = 'shared-id'
+    multiple.save # should not raise
+
+    assert_equal 'shared-id', multiple.failure_id
+  end
+
   it 'requeue_all and does not raise an exception' do
     with_failure_backend(Resque::Failure::Multiple) do
       Resque::Failure::Multiple.classes = [Resque::Failure::Redis]

--- a/test/resque_failure_redis_test.rb
+++ b/test/resque_failure_redis_test.rb
@@ -98,4 +98,55 @@ describe "Resque::Failure::Redis" do
     assert_equal 5, num_iterations
   end
 
+  it 'stores the failure_id assigned by Resque::Failure.create' do
+    with_failure_backend Resque::Failure::Redis do
+      Resque::Failure.create(:exception => exception, :worker => worker,
+                             :queue => queue, :payload => payload)
+    end
+
+    failure = Resque::Failure::Redis.all(0)
+    refute_nil failure['failure_id']
+    assert_match(/\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/, failure['failure_id'])
+  end
+
+  it 'stores a failure_id for backends built outside Resque::Failure.create' do
+    Resque::Failure::Redis.new(exception, worker, queue, payload).save
+
+    assert_match(/\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/,
+                 Resque::Failure::Redis.all(0)['failure_id'])
+  end
+
+  it 'stores a caller supplied failure_id' do
+    with_failure_backend Resque::Failure::Redis do
+      Resque::Failure.create(:exception => exception, :worker => worker,
+                             :queue => queue, :payload => payload,
+                             :failure_id => 'caller-supplied-id')
+    end
+
+    assert_equal 'caller-supplied-id', Resque::Failure::Redis.all(0)['failure_id']
+  end
+
+  it 'gives each failure its own failure_id' do
+    with_failure_backend Resque::Failure::Redis do
+      2.times do
+        Resque::Failure.create(:exception => exception, :worker => worker,
+                               :queue => queue, :payload => payload)
+      end
+    end
+
+    ids = Resque::Failure::Redis.all(0, 2).map { |failure| failure['failure_id'] }
+    assert_equal 2, ids.compact.uniq.size
+  end
+
+  it 'stores no failure_id at all when generation is disabled' do
+    with_failure_id_generation false do
+      with_failure_backend Resque::Failure::Redis do
+        Resque::Failure.create(:exception => exception, :worker => worker,
+                               :queue => queue, :payload => payload)
+      end
+    end
+
+    assert_equal %w(failed_at payload exception error backtrace worker queue),
+                 Resque::Failure::Redis.all(0).keys
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -193,6 +193,14 @@ ensure
   Resque::Failure.backend = previous_backend
 end
 
+def with_failure_id_generation(generate, &block)
+  previous = Resque::Failure.generate_failure_ids?
+  Resque::Failure.generate_failure_ids = generate
+  yield block
+ensure
+  Resque::Failure.generate_failure_ids = previous
+end
+
 require 'time'
 
 class Time


### PR DESCRIPTION
When you're dealing with a ton of failures in your resque error queue, sometimes cleanup can get messy. There's tools that handle this but many people just write a script and run it in the console. One thing that can happen when doing this is you accidentally clear the wrong failure or you wind up clearing two different failures with the same inputs accidentally.

This change aims to track a `failure_id` by default that you can leverage when doing triage and cleanup. It can also be hooked into by various error reporting tools if desired and help to provide a clean mapping back to the actual error stored in resque.

The PR description isn't the best place to document all of this so I've provided a doc for it in the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failures now receive unique IDs by default for easier correlation across compatible backends.
  * Caller-provided failure IDs are supported.
  * ID generation can be disabled when needed.
  * IDs are synchronized across compatible backends.
  * Redis-stored failure records include the failure ID when available.

* **Documentation**
  * Added guidance on failure ID behavior, backend compatibility, legacy records, and Redis migration considerations.
  * Updated the changelog and README with the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->