### PR TITLE
Version 3.0.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,12 @@
+## 3.0.1
+
+### Fixed
+
+* resque-web: Fix reflected XSS in the key sets endpoint (#1942)
+* Address multi_json class name deprecation warning (#1940)
+* Update the Rails initializer docs to load Redis config with `config_for` (#1936)
+* Add tests covering queue priority ordering with wildcards (#1930)
+
 ## 3.0.0
 
 ### Breaking Changes

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end


### PR DESCRIPTION
- Changelog for 3.0.1
- Version 3.0.1

Patch release covering the reflected XSS fix in resque-web (#1942) and the `multi_json` constant deprecation warning (#1940).

---
Changelog and version bump prepared with Claude Code (Opus 5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the version to 3.0.1.

- **Bug Fixes**
  - Fixed a reflected cross-site scripting issue in the web interface.
  - Resolved a deprecation warning related to JSON handling.
  - Updated Rails initializer guidance for loading Redis configuration.

- **Tests**
  - Added coverage for queue priority ordering with wildcard patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->