### PR TITLE
Fix XSS across resque-web

### DIFF
--- a/lib/resque/server.rb
+++ b/lib/resque/server.rb
@@ -168,7 +168,7 @@ module Resque
         stats << "queues.#{queue}=#{Resque.size(queue)}"
       end
 
-      content_type 'text/html'
+      content_type 'text/plain'
       stats.join "\n"
     end
 

--- a/lib/resque/server/views/failed.erb
+++ b/lib/resque/server/views/failed.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% unless failed_size.zero? %>
-<form method="POST" action="<%= u "failed#{'/' + params[:queue] if params[:queue]}/clear" %>">
+<form method="POST" action="<%= h u("failed#{'/' + params[:queue] if params[:queue]}/clear") %>">
   <input type="submit" name="" value="Clear <%= params[:queue] ? "'#{escape_html(params[:queue])}'" : 'Failed' %> Jobs" class="confirmSubmission" />
 </form>
 
@@ -14,7 +14,7 @@
     <input type="submit" name="" value="Clear Retried Jobs" onclick='return confirm("Are you absolutely sure? This cannot be undone.");' />
   </form>
 <% end %>
-<form method="POST" action="<%= u "failed#{'/' + params[:queue] if params[:queue]}/requeue/all" %>">
+<form method="POST" action="<%= h u("failed#{'/' + params[:queue] if params[:queue]}/requeue/all") %>">
   <input type="submit" name="" value="Retry <%= params[:queue] ? "'#{escape_html(params[:queue])}'" : 'Failed' %> Jobs" class="confirmSubmission" />
 </form>
 <% end %>

--- a/lib/resque/server/views/failed_job.erb
+++ b/lib/resque/server/views/failed_job.erb
@@ -2,28 +2,28 @@
   <dl>
     <% if job.nil? %>
     <dt>Error</dt>
-    <dd>Job <%= id %> could not be parsed; perhaps it contains invalid JSON?</dd>
+    <dd>Job <%= h id %> could not be parsed; perhaps it contains invalid JSON?</dd>
     <% else %>
     <dt>Worker</dt>
     <dd>
-      <a href="<%= u(:workers, job['worker']) %>"><%= job['worker'].split(':')[0...2].join(':') %></a> on <b class='queue-tag'><%= job['queue'] %></b > at <b><span class="time"><%= DateTime.parse(job['failed_at']).strftime(failed_date_format) %></span></b>
+      <a href="<%= h u(:workers, job['worker']) %>"><%= h job['worker'].split(':')[0...2].join(':') %></a> on <b class='queue-tag'><%= h job['queue'] %></b > at <b><span class="time"><%= DateTime.parse(job['failed_at']).strftime(failed_date_format) %></span></b>
       <% if job['retried_at'] %>
         <div class='retried'>
           Retried <b><span class="time"><%= DateTime.parse(job['retried_at']).strftime(failed_date_format) %></span></b>
-          <a href="<%= u "#{queue}/remove/#{id}" %>" class="remove" rel="remove">Remove</a>
+          <a href="<%= h u("#{queue}/remove/#{id}") %>" class="remove" rel="remove">Remove</a>
         </div>
       <% else %>
         <div class='controls'>
-          <a href="<%= u "#{queue}/requeue/#{id}" %>" rel="retry">Retry</a>
+          <a href="<%= h u("#{queue}/requeue/#{id}") %>" rel="retry">Retry</a>
           or
-          <a href="<%= u "#{queue}/remove/#{id}" %>" rel="remove">Remove</a>
+          <a href="<%= h u("#{queue}/remove/#{id}") %>" rel="remove">Remove</a>
         </div>
       <% end %>
     </dd>
     <dt>Class</dt>
     <dd>
       <% if job['payload'] && job['payload']['class'] %>
-        <a href="<%= u "#{queue}?class=#{job['payload']['class']}" %>">
+        <a href="<%= h u("#{queue}?class=#{job['payload']['class']}") %>">
           <%= partial :job_class, :job => job['payload'] %>
         </a>
       <% else %>
@@ -33,7 +33,7 @@
     <dt>Arguments</dt>
     <dd><pre><%=h job['payload'] ? show_args(job['payload']['args']) : 'nil' %></pre></dd>
     <dt>Exception</dt>
-    <dd><code><%= job['exception'] %></code></dd>
+    <dd><code><%= h job['exception'] %></code></dd>
     <dt>Error</dt>
     <dd class='error'>
       <% if job['backtrace'] %>

--- a/lib/resque/server/views/failed_queues_overview.erb
+++ b/lib/resque/server/views/failed_queues_overview.erb
@@ -7,14 +7,14 @@
 
   <% Resque::Failure.queues.sort.each do |queue| %>
 	  <tr>
-	    <th><b class="queue-tag"><a href="<%= u "/failed/#{queue}" %>"><%= queue %></a></b></th>
+	    <th><b class="queue-tag"><a href="<%= h u("/failed/#{queue}") %>"><%= h queue %></a></b></th>
 	    <th style="width:75px;" class="center"><%= Resque::Failure.count(queue) %></th>
 	  </tr>
 
     <% failed_class_counts(queue).sort_by { |name,_| name }.each do |k, v| %>
-    <tr id="<%= k %>">
+    <tr id="<%= h k %>">
       <td>
-        <a href="<%= u "/failed/#{queue}?class=#{k}" %>"><span class="failed failed_class"><%= k %></span></a>
+        <a href="<%= h u("/failed/#{queue}?class=#{k}") %>"><span class="failed failed_class"><%= h k %></span></a>
       </td>
       <td style="text-align: center;" class="failed<%= (v.to_i > 1000) ? '_many' : '' %>"><%= v %></td>
     </tr>

--- a/lib/resque/server/views/job_class.erb
+++ b/lib/resque/server/views/job_class.erb
@@ -1,8 +1,8 @@
 <% if job['class'] == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper' %>
-  <code><%= job['args'].first['job_class'] %></code>
+  <code><%= h job['args'].first['job_class'] %></code>
   <small>
     <a href="http://edgeguides.rubyonrails.org/active_job_basics.html" rel="noopener noreferrer" target="_blank">(via ActiveJob)</a>
   </small>
 <% else %>
-  <code><%= job['class'] %></code>
+  <code><%= h job['class'] %></code>
 <% end %>

--- a/lib/resque/server/views/key_sets.erb
+++ b/lib/resque/server/views/key_sets.erb
@@ -7,7 +7,7 @@
     <% for row in redis_get_value_as_array(key, start) %>
     <tr>
       <td>
-        <%= row %>
+        <%= h row %>
       </td>
     </tr>
     <% end %>

--- a/lib/resque/server/views/key_string.erb
+++ b/lib/resque/server/views/key_string.erb
@@ -4,7 +4,7 @@
   <table>
     <tr>
       <td>
-        <%= redis_get_value_as_array(key) %>
+        <%= h redis_get_value_as_array(key) %>
       </td>
     </tr>
   </table>

--- a/lib/resque/server/views/layout.erb
+++ b/lib/resque/server/views/layout.erb
@@ -19,7 +19,7 @@
     </ul>
     <% if Resque.redis.namespace != :resque %>
       <abbr class="namespace" title="Resque's Redis Namespace">
-       <%= Resque.redis.namespace %>
+       <%= h Resque.redis.namespace %>
       </abbr>
     <% end %>
   </div>
@@ -38,7 +38,7 @@
 
 <div id="footer">
   <p>Powered by <a href="http://github.com/resque/resque">Resque</a> v<%=Resque::VERSION%></p>
-  <p>Connected to Redis namespace <%= Resque.redis.namespace %> on <%= h Resque.redis_id %></p>
+  <p>Connected to Redis namespace <%= h Resque.redis.namespace %> on <%= h Resque.redis_id %></p>
 </div>
 
 </body>

--- a/lib/resque/server/views/layout.erb
+++ b/lib/resque/server/views/layout.erb
@@ -27,7 +27,7 @@
   <% if defined?(@subtabs) && @subtabs %>
     <ul class='subnav'>
       <% for subtab in @subtabs %>
-        <li <%= class_if_current "#{current_section}/#{subtab}" %>><a href="<%= current_section %>/<%= subtab %>"><span><%= subtab %></span></a></li>
+        <li <%= class_if_current "#{current_section}/#{subtab}" %>><a href="<%= h current_section %>/<%= h subtab %>"><span><%= h subtab %></span></a></li>
       <% end %>
     </ul>
   <% end %>

--- a/lib/resque/server/views/next_more.erb
+++ b/lib/resque/server/views/next_more.erb
@@ -4,19 +4,19 @@
 <%if  start - per_page >= 0 || start + per_page <= size%>
   <div class='pagination'>
     <% if start - per_page >= 0 %>
-      <a href="<%= current_page %>?start=<%= start - per_page %>" class='less'>&laquo; Previous</a>
+      <a href="<%= h current_page %>?start=<%= start - per_page %>" class='less'>&laquo; Previous</a>
     <% end %>
 
     <% (size / per_page.to_f).ceil.times do |page_num| %>
       <% if start == page_num * per_page %>
         <span><%= page_num + 1 %></span>
       <% else %>
-        <a href="<%= current_page %>?start=<%= page_num * per_page %>"> <%= page_num + 1 %></a>
+        <a href="<%= h current_page %>?start=<%= page_num * per_page %>"> <%= page_num + 1 %></a>
       <% end %>
     <% end %>
 
     <% if start + per_page < size %>
-      <a href="<%= current_page %>?start=<%= start + per_page %>" class='more'>Next &raquo;</a>
+      <a href="<%= h current_page %>?start=<%= start + per_page %>" class='more'>Next &raquo;</a>
     <% end %>
   </div>
 <%end%>

--- a/lib/resque/server/views/processing.erb
+++ b/lib/resque/server/views/processing.erb
@@ -1,2 +1,2 @@
 <%= partial :job_class, :job => job['payload'] %>
-<small><a class="queue time" href="<%=u "/working/#{worker}" %>"><%= job['run_at'] %></a></small>
+<small><a class="queue time" href="<%= h u("/working/#{worker}") %>"><%= job['run_at'] %></a></small>

--- a/lib/resque/server/views/processing.erb
+++ b/lib/resque/server/views/processing.erb
@@ -1,2 +1,2 @@
 <%= partial :job_class, :job => job['payload'] %>
-<small><a class="queue time" href="<%= h u("/working/#{worker}") %>"><%= job['run_at'] %></a></small>
+<small><a class="queue time" href="<%= h u("/working/#{worker}") %>"><%= h job['run_at'] %></a></small>

--- a/lib/resque/server/views/queues.erb
+++ b/lib/resque/server/views/queues.erb
@@ -2,8 +2,8 @@
 
 <% if current_queue = params[:id] %>
 
-  <h1>Pending jobs on <span class='hl'><%= h escape_html(current_queue) %></span></h1>
-  <form method="POST" action="<%=u "/queues/#{escape_html(current_queue)}/remove" %>" class='remove-queue'>
+  <h1>Pending jobs on <span class='hl'><%= h current_queue %></span></h1>
+  <form method="POST" action="<%= h u("/queues/#{current_queue}/remove") %>" class='remove-queue'>
     <input type='submit' name='' value='Remove Queue' class="confirmSubmission" />
   </form>
   <p class='sub'><%= page_entries_info start = params[:start].to_i, start + 19, size = resque.size(current_queue), 'job' %></p>
@@ -36,14 +36,14 @@
     </tr>
     <% resque.queues.sort_by { |q| q.to_s }.each do |queue| %>
     <tr>
-      <td class='queue'><a class="queue" href="<%= u "queues/#{queue}" %>"><%= queue %></a></td>
+      <td class='queue'><a class="queue" href="<%= h u("queues/#{queue}") %>"><%= h queue %></a></td>
       <td class='size'><%= resque.size queue %></td>
     </tr>
     <% end %>
     <% if failed_multiple_queues? %>
       <% Resque::Failure.queues.sort_by { |q| q.to_s }.each_with_index do |queue, i| %>
       <tr class="<%= Resque::Failure.count(queue).zero? ? "failed" : "failure" %><%= " first_failure" if i.zero? %>">
-        <td class='queue failed'><a class="queue" href="<%= u "failed/#{queue}" %>"><%= queue %></a></td>
+        <td class='queue failed'><a class="queue" href="<%= h u("failed/#{queue}") %>"><%= h queue %></a></td>
         <td class='size'><%= Resque::Failure.count(queue) %></td>
       </tr>
       <% end %>

--- a/lib/resque/server/views/stats.erb
+++ b/lib/resque/server/views/stats.erb
@@ -11,7 +11,7 @@
   <% for key, value in resque.info.to_a.sort_by { |i| i[0].to_s } %>
     <tr>
       <th>
-        <%= key %>
+        <%= h key %>
       </th>
       <td>
         <%= h value %>
@@ -27,10 +27,10 @@
   <% for key, value in resque.redis.redis.info.to_a.sort_by { |i| i[0].to_s } %>
     <tr>
       <th>
-        <%= key %>
+        <%= h key %>
       </th>
       <td>
-        <%= value %>
+        <%= h value %>
       </td>
     </tr>
   <% end %>
@@ -39,7 +39,7 @@
 <% elsif params[:id] == 'keys' %>
 
   <h1>Keys owned by <%= h resque.redis_id %></h1>
-  <p class='sub'>(All keys are actually prefixed with "<%= Resque.redis.namespace %>:")</p>
+  <p class='sub'>(All keys are actually prefixed with "<%= h Resque.redis.namespace %>:")</p>
   <table class='stats'>
     <tr>
       <th>key</th>
@@ -49,7 +49,7 @@
   <% for key in resque.keys.sort %>
     <tr>
       <th>
-        <a href="<%=u "/stats/keys/#{key}" %>"><%= key %></a>
+        <a href="<%= h u("/stats/keys/#{key}") %>"><%= h key %></a>
       </th>
       <td><%= resque.redis.type key %></td>
       <td><%= redis_get_size key %></td>

--- a/lib/resque/server/views/workers.erb
+++ b/lib/resque/server/views/workers.erb
@@ -2,7 +2,7 @@
 
 <% if params[:id] && worker = Resque::Worker.find(params[:id]) %>
 
-  <h1>Worker <%= worker %></h1>
+  <h1>Worker <%= h worker %></h1>
   <table class='workers'>
     <tr>
       <th>&nbsp;</th>
@@ -16,14 +16,14 @@
       <th>Processing</th>
     </tr>
     <tr>
-      <td class='icon'><img src="<%=u state = worker.state %>.png" alt="<%= state %>" title="<%= state %>"></td>
+      <td class='icon'><img src="<%= h u(state = worker.state) %>.png" alt="<%= h state %>" title="<%= h state %>"></td>
 
       <% host, pid, queues = worker.to_s.split(':') %>
-      <td><%= host %></td>
-      <td><%= pid %></td>
-      <td><span class="time"><%= worker.started %></span></td>
-      <td><span class="time"><%= worker.heartbeat %></span></td>
-      <td class='queues'><%= queues.split(',').map { |q| '<a class="queue-tag" href="' + u("/queues/#{q}") + '">' + q + '</a>'}.join('') %></td>
+      <td><%= h host %></td>
+      <td><%= h pid %></td>
+      <td><span class="time"><%= h worker.started %></span></td>
+      <td><span class="time"><%= h worker.heartbeat %></span></td>
+      <td class='queues'><%= queues.split(',').map { |q| '<a class="queue-tag" href="' + h(u("/queues/#{q}")) + '">' + h(q) + '</a>'}.join('') %></td>
       <td><%= worker.processed %></td>
       <td><%= worker.failed %></td>
       <td class='process'>
@@ -60,11 +60,11 @@
     </tr>
     <% for worker in (workers = workers.sort_by { |w| w.to_s }) %>
     <tr class="<%=state = worker.state%>">
-      <td class='icon'><img src="<%=u state %>.png" alt="<%= state %>" title="<%= state %>"></td>
+      <td class='icon'><img src="<%= h u(state) %>.png" alt="<%= h state %>" title="<%= h state %>"></td>
 
       <% host, pid, queues = worker.to_s.split(':') %>
-      <td class='where'><a href="<%=u "workers/#{worker}"%>"><%= host %>:<%= pid %></a></td>
-      <td class='queues'><%= queues.split(',').map { |q| '<a class="queue-tag" href="' + u("/queues/#{q}") + '">' + q + '</a>'}.join('') %></td>
+      <td class='where'><a href="<%= h u("workers/#{worker}") %>"><%= h host %>:<%= h pid %></a></td>
+      <td class='queues'><%= queues.split(',').map { |q| '<a class="queue-tag" href="' + h(u("/queues/#{q}")) + '">' + h(q) + '</a>'}.join('') %></td>
 
       <td class='process'>
         <% data = worker.processing || {} %>
@@ -95,7 +95,7 @@
     </tr>
     <% for hostname, workers in worker_hosts.sort_by { |h,w| h } %>
     <tr>
-      <td class='queue'><a class="queue" href="<%= u "workers/#{hostname}" %>"><%= hostname %></a></td>
+      <td class='queue'><a class="queue" href="<%= h u("workers/#{hostname}") %>"><%= h hostname %></a></td>
       <td class='size'><%= workers.size %></td>
     </tr>
     <% end %>

--- a/lib/resque/server/views/working.erb
+++ b/lib/resque/server/views/working.erb
@@ -15,11 +15,11 @@
         <% host, pid, _ = current_worker.to_s.split(':') %>
         <td><a href="<%= h u("/workers/#{current_worker}") %>"><%= h host %>:<%= h pid %></a></td>
         <% queue = data['queue'] %>
-        <td><a class="queue" href="<%=u "/queues/#{queue}" %>"><%= queue %></a></td>
-        <td><span class="time"><%= data['run_at'] %></span></td>
+        <td><a class="queue" href="<%= h u("/queues/#{queue}") %>"><%= h queue %></a></td>
+        <td><span class="time"><%= h data['run_at'] %></span></td>
         <% payload = data.key?('payload') ? data['payload'] : {} %>
         <td>
-          <code><%= payload.key?('class') ? payload['class'] : "—" %></code>
+          <code><%= payload.key?('class') ? h(payload['class']) : "—" %></code>
         </td>
         <td><pre><%=h payload.key?('args') ? show_args(payload['args']) : "—" %></pre></td>
       </tr>
@@ -55,7 +55,7 @@
         <% host, pid, _queues = worker.to_s.split(':') %>
         <td class='where'><a href="<%= h u("/workers/#{worker}") %>"><%= h host %>:<%= h pid %></a></td>
         <td class='queues queue'>
-          <a class="queue-tag" href="<%=u "/queues/#{job['queue']}" %>"><%= job['queue'] %></a>
+          <a class="queue-tag" href="<%= h u("/queues/#{job['queue']}") %>"><%= h job['queue'] %></a>
         </td>
         <td class='process'>
           <% if job['queue'] %>

--- a/lib/resque/server/views/working.erb
+++ b/lib/resque/server/views/working.erb
@@ -1,5 +1,5 @@
 <% if params[:id] && (current_worker = Resque::Worker.find(params[:id])) && (data = current_worker.job) %>
-  <h1><%= current_worker %>'s job</h1>
+  <h1><%= h current_worker %>'s job</h1>
 
   <table>
     <tr>
@@ -13,7 +13,7 @@
       <tr>
         <td><img src="<%=u 'working.png' %>" alt="working" title="working"></td>
         <% host, pid, _ = current_worker.to_s.split(':') %>
-        <td><a href="<%=u "/workers/#{current_worker}" %>"><%= host %>:<%= pid %></a></td>
+        <td><a href="<%= h u("/workers/#{current_worker}") %>"><%= h host %>:<%= h pid %></a></td>
         <% queue = data['queue'] %>
         <td><a class="queue" href="<%=u "/queues/#{queue}" %>"><%= queue %></a></td>
         <td><span class="time"><%= data['run_at'] %></span></td>
@@ -51,9 +51,9 @@
 
     <% worker_jobs.sort_by { |_w, j| j['run_at'] ? j['run_at'].to_s() : '' }.each do |worker, job| %>
       <tr>
-        <td class='icon'><img src="<%=u state = worker.state %>.png" alt="<%= state %>" title="<%= state %>"></td>
+        <td class='icon'><img src="<%= h u(state = worker.state) %>.png" alt="<%= h state %>" title="<%= h state %>"></td>
         <% host, pid, _queues = worker.to_s.split(':') %>
-        <td class='where'><a href="<%=u "/workers/#{worker}" %>"><%= host %>:<%= pid %></a></td>
+        <td class='where'><a href="<%= h u("/workers/#{worker}") %>"><%= h host %>:<%= h pid %></a></td>
         <td class='queues queue'>
           <a class="queue-tag" href="<%=u "/queues/#{job['queue']}" %>"><%= job['queue'] %></a>
         </td>

--- a/lib/resque/server_helper.rb
+++ b/lib/resque/server_helper.rb
@@ -29,7 +29,7 @@ module Resque
     def tab(name)
       dname = name.to_s.downcase
       path = url_path(dname)
-      "<li #{class_if_current(path)}><a href='#{path.gsub(" ", "_")}'>#{name}</a></li>"
+      "<li #{class_if_current(path)}><a href='#{h path.gsub(" ", "_")}'>#{h name}</a></li>"
     end
 
     def tabs
@@ -112,7 +112,7 @@ module Resque
       if defined?(@polling) && @polling
         text = "Last Updated: #{Time.now.strftime("%H:%M:%S")}"
       else
-        text = "<a href='#{u(request.path_info)}.poll' rel='poll'>Live Poll!!</a>"
+        text = "<a href='#{h u(request.path_info)}.poll' rel='poll'>Live Poll!!</a>"
       end
       "<p class='poll'>#{text}</p>"
     end

--- a/test/resque-web_escaping_test.rb
+++ b/test/resque-web_escaping_test.rb
@@ -133,4 +133,37 @@ describe "Resque web escaping" do
       assert_escaped last_response.body
     end
   end
+
+  describe "Redis keys and values" do
+    before do
+      Resque.redis.set(PAYLOAD, PAYLOAD)
+      Resque.redis.rpush("list#{PAYLOAD}", PAYLOAD)
+    end
+
+    after do
+      Resque.redis.del(PAYLOAD)
+      Resque.redis.del("list#{PAYLOAD}")
+    end
+
+    it "escapes key names in the key listing" do
+      get "/stats/keys"
+
+      assert last_response.ok?, last_response.errors
+      assert_escaped last_response.body
+    end
+
+    it "escapes a string key's value" do
+      get "/stats/keys?key=#{Rack::Utils.escape(PAYLOAD)}"
+
+      assert last_response.ok?, last_response.errors
+      assert_escaped last_response.body
+    end
+
+    it "escapes a list key's values" do
+      get "/stats/keys?key=#{Rack::Utils.escape("list#{PAYLOAD}")}"
+
+      assert last_response.ok?, last_response.errors
+      assert_escaped last_response.body
+    end
+  end
 end

--- a/test/resque-web_escaping_test.rb
+++ b/test/resque-web_escaping_test.rb
@@ -56,4 +56,29 @@ describe "Resque web escaping" do
       assert_escaped last_response.body
     end
   end
+
+  describe "worker identifiers" do
+    before do
+      @worker = Resque::Worker.new(PAYLOAD)
+      @worker.hostname = PAYLOAD
+      @worker.to_s = "#{PAYLOAD}:1:#{PAYLOAD}"
+      Resque.data_store.register_worker(@worker)
+    end
+
+    after { Resque.data_store.unregister_worker(@worker) { } }
+
+    it "escapes them in the worker listing" do
+      get "/workers/all"
+
+      assert last_response.ok?, last_response.errors
+      assert_escaped last_response.body
+    end
+
+    it "escapes them on a worker's own page" do
+      get "/workers/#{Rack::Utils.escape_path(@worker.to_s)}"
+
+      assert last_response.ok?, last_response.errors
+      assert_escaped last_response.body
+    end
+  end
 end

--- a/test/resque-web_escaping_test.rb
+++ b/test/resque-web_escaping_test.rb
@@ -8,6 +8,13 @@ require 'resque/server'
 describe "Resque web escaping" do
   include Rack::Test::Methods
 
+  # Breaks out of both a double-quoted attribute and a text node.
+  PAYLOAD = %q{"><svg onload=alert(1)>}
+
+  # A literal apostrophe survives a URL path untouched by browsers, so it is
+  # what actually reaches PATH_INFO and breaks out of a single-quoted attribute.
+  PATH_PAYLOAD = "x'onmouseover='alert(1)"
+
   def app
     Resque::Server.new
   end
@@ -16,19 +23,37 @@ describe "Resque web escaping" do
     'localhost'
   end
 
-  # A literal apostrophe survives a URL path untouched by browsers, so it is
-  # what actually reaches PATH_INFO and breaks out of a single-quoted attribute.
-  PATH_PAYLOAD = "x'onmouseover='alert(1)"
+  # Rack 2 and Rack 3 spell some entities differently (&#x27; vs &#39;), so
+  # compare against whatever escape_html the app itself is running.
+  def assert_escaped(body, payload = PAYLOAD)
+    refute_includes body, payload
+    assert_includes body, Rack::Utils.escape_html(payload)
+  end
 
   describe "the request path reflected into links" do
     it "escapes the path in the live poll link" do
       get "/overview/#{PATH_PAYLOAD}"
 
       assert last_response.ok?, last_response.errors
-      refute_includes last_response.body, PATH_PAYLOAD
-      # Rack 2 and Rack 3 spell some entities differently (&#x27; vs &#39;), so
-      # compare against whatever escape_html the app itself is running.
-      assert_includes last_response.body, Rack::Utils.escape_html(PATH_PAYLOAD)
+      assert_escaped last_response.body, PATH_PAYLOAD
+    end
+  end
+
+  describe "queue names" do
+    it "escapes them in the queue listing" do
+      Resque.push(PAYLOAD, 'class' => 'SomeJob', 'args' => [])
+
+      get "/queues"
+
+      assert last_response.ok?, last_response.errors
+      assert_escaped last_response.body
+    end
+
+    it "escapes them on a queue's own page" do
+      get "/queues/#{Rack::Utils.escape_path(PAYLOAD)}"
+
+      assert last_response.ok?, last_response.errors
+      assert_escaped last_response.body
     end
   end
 end

--- a/test/resque-web_escaping_test.rb
+++ b/test/resque-web_escaping_test.rb
@@ -109,4 +109,28 @@ describe "Resque web escaping" do
       Resque.data_store.unregister_worker(worker) { }
     end
   end
+
+  describe "failed jobs" do
+    before do
+      worker = Resque::Worker.new(PAYLOAD)
+      worker.to_s = "#{PAYLOAD}:1:#{PAYLOAD}"
+      exception = begin
+        raise PAYLOAD
+      rescue => e
+        e
+      end
+      Resque::Failure.create(:payload => { 'class' => PAYLOAD, 'args' => [] },
+                             :exception => exception, :worker => worker,
+                             :queue => PAYLOAD)
+    end
+
+    after { Resque::Failure.clear }
+
+    it "escapes the worker, queue and exception on the failed list" do
+      get "/failed"
+
+      assert last_response.ok?, last_response.errors
+      assert_escaped last_response.body
+    end
+  end
 end

--- a/test/resque-web_escaping_test.rb
+++ b/test/resque-web_escaping_test.rb
@@ -81,4 +81,32 @@ describe "Resque web escaping" do
       assert_escaped last_response.body
     end
   end
+
+  describe "job payloads" do
+    it "escapes the job class in a queue listing" do
+      Resque.push('jobs', 'class' => PAYLOAD, 'args' => [])
+
+      get "/queues/jobs"
+
+      assert last_response.ok?, last_response.errors
+      assert_escaped last_response.body
+    end
+
+    it "escapes the job a worker is processing" do
+      worker = Resque::Worker.new('jobs')
+      Resque.data_store.register_worker(worker)
+      Resque.data_store.set_worker_payload(
+        worker,
+        Resque.encode('queue' => 'jobs', 'run_at' => PAYLOAD,
+                      'payload' => { 'class' => PAYLOAD, 'args' => [] })
+      )
+
+      get "/working"
+
+      assert last_response.ok?, last_response.errors
+      assert_escaped last_response.body
+    ensure
+      Resque.data_store.unregister_worker(worker) { }
+    end
+  end
 end

--- a/test/resque-web_escaping_test.rb
+++ b/test/resque-web_escaping_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+require 'rack/test'
+require 'resque/server'
+
+# Regression tests for HTML escaping in resque-web. Every value below is
+# attacker-controlled: either reflected straight off the request, or read back
+# out of Redis after being written by anyone able to enqueue a job.
+describe "Resque web escaping" do
+  include Rack::Test::Methods
+
+  def app
+    Resque::Server.new
+  end
+
+  def default_host
+    'localhost'
+  end
+
+  # A literal apostrophe survives a URL path untouched by browsers, so it is
+  # what actually reaches PATH_INFO and breaks out of a single-quoted attribute.
+  PATH_PAYLOAD = "x'onmouseover='alert(1)"
+
+  describe "the request path reflected into links" do
+    it "escapes the path in the live poll link" do
+      get "/overview/#{PATH_PAYLOAD}"
+
+      assert last_response.ok?, last_response.errors
+      refute_includes last_response.body, PATH_PAYLOAD
+      # Rack 2 and Rack 3 spell some entities differently (&#x27; vs &#39;), so
+      # compare against whatever escape_html the app itself is running.
+      assert_includes last_response.body, Rack::Utils.escape_html(PATH_PAYLOAD)
+    end
+  end
+end

--- a/test/resque-web_escaping_test.rb
+++ b/test/resque-web_escaping_test.rb
@@ -166,4 +166,16 @@ describe "Resque web escaping" do
       assert_escaped last_response.body
     end
   end
+
+  describe "the stats.txt metrics feed" do
+    it "is served as text/plain so queue names cannot execute" do
+      Resque.push(PAYLOAD, 'class' => 'SomeJob', 'args' => [])
+
+      get "/stats.txt"
+
+      assert last_response.ok?, last_response.errors
+      assert_includes last_response.headers['content-type'], 'text/plain'
+      refute_includes last_response.headers['content-type'], 'text/html'
+    end
+  end
 end


### PR DESCRIPTION
Escapes data throughout resque-web. Seven issues, one commit each so they map cleanly to advisories.

**One reflected:** the live-poll link interpolated the raw request path into a single-quoted `href`. Browsers leave `'` literal in a URL path, so `/overview/x'onmouseover='alert(1)` breaks out of the attribute. No prior state needed.

**Five stored:** queue names, worker IDs, job class names, failed-job details, and Redis keys/values all reached the templates unescaped, in both text nodes and `href` attributes. Anyone who can enqueue a job controls most of these. In most cases, this is the lowest of low concerns unless your app is doing something interesting with dynamic jobs, queues, etc using untrusted user input.

**One content-type:** `/stats.txt` built a plaintext metrics feed but declared `Content-Type: text/html`, so a queue name containing markup executed. Now served as `text/plain` since escaping would corrupt the values for scrapers and other consumers.

Root cause for the first six is that the ERB templates have no auto-escaping, so every `<%= %>` emitted raw HTML. Fixed by escaping at each interpolation rather than switching the app to auto-escaping ERB, which would break plugin-supplied views rendered through `Resque::Server`. That said, we will likely change this in later versions of resque.

Every commit carries a regression test confirmed failing before its fix. Full suite green on Rack 2 and Rack 3 and assertions compare against `Rack::Utils.escape_html` rather than hardcoded entities, since Rack 2 emits `&#x27;` where Rack 3 emits `&#39;`.
