### PR TITLE
Version 3.0.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,16 @@
+## 3.0.2
+
+### Added
+
+* resque-web: Support IPv6 hosts in the server URL (#1938)
+
+### Fixed
+
+* resque-web: Escape queue names, worker IDs, job classes, failed job details, Redis keys/values, and the reflected request path; serve `/stats.txt` as `text/plain` (#1946)
+* resque-web: Fix the class filter link URL on the failed jobs page (#1934)
+* Prefer `MultiJson.generate`/`parse` over the deprecated `dump`/`load` (#1944)
+* Add tests covering which hooks run in which process (#1932)
+
 ## 3.0.1
 
 ### Fixed

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  VERSION = '3.0.1'
+  VERSION = '3.0.2'
 end


### PR DESCRIPTION
- Changelog for 3.0.2
- Version 3.0.2

Patch release covering the XSS remediation across resque-web (#1946), the `multi_json` `dump`/`load` deprecation warning (#1944), the failed jobs class filter link (#1934), and IPv6 support in the web server URL (#1938).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added IPv6 host support in server URLs.
  - Added plain-text serving for `/stats.txt`.

- **Bug Fixes**
  - Improved escaping for queue names, worker IDs, job details, Redis data, and request paths.
  - Fixed class filter links on the failed jobs page.
  - Updated JSON handling to use current MultiJson methods.

- **Documentation**
  - Added release notes for version 3.0.2.

- **Tests**
  - Added coverage for process-specific hook execution.

- **Release**
  - Updated the application version to 3.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->