### PR TITLE
Remove suggestion to update HISTORY.md when opening a PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,6 @@ The main way to contribute to Resque is to write some code! Here's how:
    branch
 5. That's it!
 
-An entry in the `HISTORY.md` is appropriate for changes that aren't of purely
-internal consequences. Please include a modification of HISTORY.md adding a
-bullet for your change in your pull request where relevant.
-
 Oh, and 80 character columns, please!
 
 Tests


### PR DESCRIPTION
Remove suggestion to update HISTORY.md when opening a PR so as to avoid merge conflicts when preparing a new release.