### PR TITLE
Probe ports with `URI(...).open` instead of `Kernel.open`

### DIFF
--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -156,8 +156,8 @@ module Resque
       end
     end
 
-    def uri_open(*args)
-      (RbConfig::CONFIG['ruby_version'] < '2.7') ? open(*args) : URI.open(*args)
+    def uri_open(url, *args)
+      URI.parse(url).open(*args)
     end
 
     def write_url


### PR DESCRIPTION
CodeQL flags both halves of this line under `rb/non-constant-kernel-open`.

The `Kernel.open` half is dead code because it is guarded by `RbConfig::CONFIG['ruby_version'] < '2.7'`, and the gemspec has required Ruby >= 3.0 since 3.0.0. Removed. The remaining call becomes `URI.parse(url).open`, which is the form that makes CodeQL happy.

One behavior change: a malformed URL now raises `URI::InvalidURIError` where it previously raised `Errno::ENOENT`. `port_open?` rescues neither, so nothing changes for callers. The only input is the URL resque-web writes to its own url file.

No test bc behavior for well-formed URLs is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web page opening behavior for greater consistency across supported Ruby versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->