### PR TITLE
Pass the browser url as an argv element instead of a shell string

### DIFF
--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -226,8 +226,8 @@ module Resque
 
     def launch!(specific_url = nil, path = nil)
       return if options[:skip_launch]
-      cmd = WINDOWS ? "start" : "open"
-      system "#{cmd} #{specific_url || url}#{path}"
+      target = "#{specific_url || url}#{path}"
+      WINDOWS ? system("cmd", "/c", "start", "", target) : system("open", target)
     end
 
     def kill!

--- a/lib/resque/web_runner.rb
+++ b/lib/resque/web_runner.rb
@@ -227,7 +227,7 @@ module Resque
     def launch!(specific_url = nil, path = nil)
       return if options[:skip_launch]
       target = "#{specific_url || url}#{path}"
-      WINDOWS ? system("cmd", "/c", "start", "", target) : system("open", target)
+      WINDOWS ? system("rundll32", "url.dll,FileProtocolHandler", target) : system("open", target)
     end
 
     def kill!

--- a/test/resque-web_runner_test.rb
+++ b/test/resque-web_runner_test.rb
@@ -146,7 +146,7 @@ describe 'Resque::WebRunner' do
 
     describe 'with a launch path specified as a proc' do
       it 'evaluates the proc in the context of the runner' do
-        Resque::WebRunner.any_instance.expects(:system).once.with {|s| s =~ /\?search\=blah$/ }
+        Resque::WebRunner.any_instance.expects(:system).once.with {|*argv| argv.last =~ /\?search\=blah$/ }
         web_runner("--debug", "blah", launch_path: Proc.new {|r| "?search=#{r.args.first}" })
         assert @runner.options[:launch_path].is_a?(Proc)
       end
@@ -154,9 +154,19 @@ describe 'Resque::WebRunner' do
 
     describe 'with a launch path specified as string' do
       it 'launches to the specific path' do
-        Resque::WebRunner.any_instance.expects(:system).once.with {|s| s =~ /\?search\=blah$/ }
+        Resque::WebRunner.any_instance.expects(:system).once.with {|*argv| argv.last =~ /\?search\=blah$/ }
         web_runner("--debug", "blah", launch_path: "?search=blah")
         assert_equal @runner.options[:launch_path], "?search=blah"
+      end
+    end
+
+    describe 'with a launch path containing shell metacharacters' do
+      it 'hands the url to the browser as its own argument' do
+        injection = "?search=; touch pwned"
+        Resque::WebRunner.any_instance.expects(:system).once.with do |*argv|
+          argv.length > 1 && argv.last.end_with?(injection)
+        end
+        web_runner("--debug", launch_path: injection)
       end
     end
 


### PR DESCRIPTION
`launch!` built its command as a single string, so `system` handed it to a shell. `launch_path` is caller-supplied (a string or a proc) and lands in that string unquoted, so anything the shell treats specially gets interpreted rather than passed through. CodeQL flags this as `rb/shell-command-constructed-from-input`.

As CodeRabbit pointed out though, the Windows side needed some love too. For this, Windows uses `rundll32` rather than `start`, because `start` is a cmd builtin and would need `cmd /c`, which puts the url back in front of a parser, so an unquoted `&` would still split the command. `rundll32.exe` is a real executable, so the url stays a single argument. Untested on Windows; CI doesn't cover it and I don't personally own a Windows machine to test with. If this breaks your Windows setup I'd love for you to open a PR.

The two existing `launch_path` tests matched on a single string argument and now match on the argv list. Added one test covering a path with shell metacharacters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved browser launching for URLs containing shell-special characters.
  - Prevented URL content from being interpreted as part of a shell command across supported platforms.

- **Tests**
  - Added coverage confirming that URLs with shell metacharacters are passed safely to the browser opener.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->