### PR TITLE
Build the relatized time markup with DOM APIs instead of HTML strings

### DIFF
--- a/lib/resque/server/public/ranger.js
+++ b/lib/resque/server/public/ranger.js
@@ -11,10 +11,9 @@ $(function() {
     } else {
       $(this)
         .text('')
-        .append( $('<a href="#" class="toggle_format" title="' + dt + '" />')
-        .append('<span class="date_time">' + dt +
-                '</span><span class="relatized_time">' +
-                relatized + '</span>') )
+        .append( $('<a href="#" class="toggle_format" />').attr('title', dt)
+        .append( $('<span class="date_time" />').text(dt) )
+        .append( $('<span class="relatized_time" />').text(relatized) ) )
     }
   };
 


### PR DESCRIPTION
`ranger.js` reads a `.time` element's text back out of the DOM and rebuilds it as an HTML string, which CodeQL flags as `js/xss-through-dom`. Everything that reaches those elements is a timestamp resque generates itself, so this is cleanup to make CodeQL happy and close the alert rather than a behavior fix.

Solution: Uses `.attr()` and `.text()` instead of concatenation, easy peasy.