### PR TITLE
Drop Ruby 3.0 and 3.1 and add Ruby 4.0 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,10 @@ jobs:
           - 4.8
           - latest
         ruby-version:
-          - "3.0"
-          - 3.1
           - 3.2
           - 3.3
           - 3.4
+          - "4.0"
           - head
         rack-version:
           - 2
@@ -47,10 +46,10 @@ jobs:
           - 4.8
           - latest
         ruby-version:
-          - 3.1
           - 3.2
           - 3.3
           - 3.4
+          - "4.0"
           - head
         rails-version:
           - 7.2
@@ -61,9 +60,6 @@ jobs:
           - 2
           - 3
         exclude:
-          - { ruby-version: 3.1, rails-version: "8.0" }
-          - { ruby-version: 3.1, rails-version: 8.1 }
-          - { ruby-version: 3.1, rails-version: main }
           - { ruby-version: 3.2, rails-version: main }
     env:
       REDIS_VERSION: "${{ matrix.redis-version }}"
@@ -89,10 +85,10 @@ jobs:
           - 4.8
           - latest
         ruby-version:
-          - 3.1
           - 3.2
           - 3.3
           - 3.4
+          - "4.0"
           - head
         rails-version:
           - 7.2
@@ -110,9 +106,6 @@ jobs:
             rails-version: main
             continue-on-error: true
         exclude:
-          - { ruby-version: 3.1, rails-version: "8.0" }
-          - { ruby-version: 3.1, rails-version: 8.1 }
-          - { ruby-version: 3.1, rails-version: main }
           - { ruby-version: 3.2, rails-version: main }
     env:
       REDIS_VERSION: "${{ matrix.redis-version }}"

--- a/README.markdown
+++ b/README.markdown
@@ -39,13 +39,13 @@ The Resque frontend tells you what workers are doing, what workers are
 not doing, what queues you're using, what's in those queues, provides
 general usage stats, and helps you track failures.
 
-Resque 3.0 requires Ruby 3.0.0 or newer.
+Resque requires Ruby 3.2.0 or newer.
 
 **Version Support:**
-- Ruby: 3.0, 3.1, 3.2, 3.3, 3.4+
+- Ruby: 3.2, 3.3, 3.4, 4.0
 - Redis gem: 4.0+
 - Rack: 2.x or 3.x
-- Rails (for ActiveJob): 7.2+ (requires Ruby 3.1+ for Rails 8.0+)
+- Rails (for ActiveJob): 7.2+
 
 ### Resque 3.0
 

--- a/Rakefile
+++ b/Rakefile
@@ -44,11 +44,6 @@ task "env:aj_integration" do
 end
 
 Rake::TestTask.new('test:activejob:integration' => 'env:aj_integration') do |t|
-  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.1")
-    puts "Integration tests require Ruby 3.1 or later"
-    exit 0
-  end
-
   t.description = "Run integration tests for Resque::ActiveJob::Adapter"
   t.libs << "test"
   t.libs << "test/active_job"

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "LICENSE", "README.markdown" ]
   s.rdoc_options      = ["--charset=UTF-8"]
 
-  s.required_ruby_version = ">= 3.0.0"
+  s.required_ruby_version = ">= 3.2.0"
 
   s.add_dependency "base64", "~> 0.1"
   s.add_dependency "logger"


### PR DESCRIPTION
Ruby 3.0 and 3.1 are both past end of life. This sets the floor at 3.2 and adds 4.0 to the matrix.

It also fixes CI, which is currently red on 3.1 for reasons unrelated to any recent change. `multi_json` 1.21 — the first release that calls `JSON.parse` correctly for json 3.x — requires Ruby 3.2, so 3.1 resolves down to 1.19.1, whose adapter passes two positional arguments to `JSON.parse` and raises `ArgumentError: wrong number of arguments (given 2, expected 1)`. Not a whole lot we can do without pinning things, or adding glue code and frankly, it's not worth the effort considering 3.1 went EOL over a year ago.

Ruby 3.0 looked green only because the `test:activejob:integration` guard ran `exit 0` while the Rakefile was still being loaded, so `rake` exited before defining the default task and ran nothing at all. That guard goes away with 3.0.

Also drops the matrix excludes that existed only to keep Ruby 3.1 off Rails 8.0+.

I considered dropping 3.2 for this also, but technically it's still working and it only recently went EOL. These changes are slated for the Resque 3.1 release.