### PR TITLE
Version 3.0.3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,12 @@
+## 3.0.3
+
+### Fixed
+
+* resque-web: Fix an off-by-one error in the failed jobs pagination end index (#1931)
+* resque-web: Pass the browser url as an argv element instead of a shell string, and launch it on Windows without going through `cmd.exe` (#1956)
+* resque-web: Probe ports with `URI(...).open` instead of `Kernel.open` (#1955)
+* resque-web: Build the relatized time markup with DOM APIs instead of HTML strings (#1957)
+
 ## 3.0.2
 
 ### Added

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  VERSION = '3.0.2'
+  VERSION = '3.0.3'
 end


### PR DESCRIPTION
- Changelog for 3.0.3
- Version 3.0.3

Patch release covering the failed jobs pagination off-by-one (#1931) and the resque-web CodeQL cleanups: the browser launch shell string (#1956), `Kernel.open` port probing (#1955), and the relatized time markup (#1957).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the failed-jobs pagination endpoint so the final item is displayed properly.
  - Improved browser launching on Windows.
  - Improved port availability checks.
  - Improved relative-time display rendering for greater reliability.

- **Release**
  - Updated the application version to 3.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->